### PR TITLE
Small issue with CultureInfo

### DIFF
--- a/src/CsvHelper.Tests/CsvHelper.Tests.csproj
+++ b/src/CsvHelper.Tests/CsvHelper.Tests.csproj
@@ -65,6 +65,7 @@
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CsvWriterWriteRecordsTests.cs" />
     <Compile Include="CsvWriterWriteRecordsCultureTests.cs" />
     <Compile Include="CsvParserTests.cs" />
     <Compile Include="CsvReaderTests.cs" />

--- a/src/CsvHelper.Tests/CsvWriterWriteRecordsCultureTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterWriteRecordsCultureTests.cs
@@ -26,7 +26,7 @@ namespace CsvHelper.Tests
         }        
 
 		[TestMethod]        
-		public void WriteRecordsTest()
+		public void WriteRecordsWithSomeCultureSpecificValuesTest()
 		{            
 			var records = new List<TestRecordWithDecimal>
             {

--- a/src/CsvHelper.Tests/CsvWriterWriteRecordsTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterWriteRecordsTests.cs
@@ -1,0 +1,54 @@
+﻿#region License
+// Copyright 2009-2010 Josh Close
+// This file is a part of CsvHelper and is licensed under the MS-PL
+// See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html
+// http://csvhelper.com
+#endregion
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CsvHelper.Tests
+{
+	[TestClass]
+    public class CsvWriterWriteRecordsTests
+	{	    
+		[TestMethod]
+        [ExpectedException(typeof(CsvHelperException))]
+		public void WriteRecordsThatLeadsToEmptyRecordTest()
+		{            
+            // NOTE
+            // Because WriteRecords uses <T> to determine type of 
+            // entity to write, it's possible to fail with stupid NullReferenceException
+            // when for example passing List<object>. 
+            // I think this is OK not to support this case, but I believe that
+            // exception handling should be better. So now we will throw 
+            //  CsvHelperException with appropreate message.
+            //
+            // BTW, this is not the only situation when there is no fields to write
+            // For example single property with Ignore=true, or when property
+            // has type converter that does not support converting to string.
+
+			var records = new List<object>
+            {
+                new TestRecord
+                {                    
+                    Foo = "Hello"
+                }
+            };
+			
+			var writer = new StringWriter();
+			var csv = new CsvWriter( writer, new CsvWriterOptions{ HasHeaderRecord = true } );
+
+			csv.WriteRecords(records);
+
+            Assert.AreEqual("", writer.ToString().Trim());
+		}
+				
+		private class TestRecord
+		{            
+            public string Foo { get; set; }
+		}        
+	}
+}

--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -66,8 +66,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CsvFieldAttribute.cs" />
+    <Compile Include="CsvHelperException.cs" />
     <Compile Include="CsvParser.cs" />
     <Compile Include="CsvParserOptions.cs" />
+    <Compile Include="CsvPropertyInfo.cs" />
     <Compile Include="CsvPropertyInfoComparer.cs" />
     <Compile Include="CsvReader.cs" />
     <Compile Include="CsvReaderOptions.cs" />

--- a/src/CsvHelper/CsvHelperException.cs
+++ b/src/CsvHelper/CsvHelperException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace CsvHelper
+{
+    [Serializable]
+    public class CsvHelperException : Exception
+    {                
+        public CsvHelperException(string message) : base(message)
+        {
+        }
+
+        public CsvHelperException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        protected CsvHelperException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+    }    
+}

--- a/src/CsvHelper/CsvPropertyInfo.cs
+++ b/src/CsvHelper/CsvPropertyInfo.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reflection;
+
+namespace CsvHelper
+{
+    public class CsvPropertyInfo
+    {
+        private readonly PropertyInfo property;
+        private readonly CsvFieldAttribute csvAttribute;
+
+
+        public CsvPropertyInfo(PropertyInfo property)
+        {
+            if (property == null)
+            {
+                throw new ArgumentNullException("property");
+            }
+
+            this.property = property;
+            this.csvAttribute = ReflectionHelper.GetAttribute<CsvFieldAttribute>(property, false);
+        }
+
+        public bool Ignore
+        {
+            get
+            {
+                if (csvAttribute != null)
+                {
+                    return csvAttribute.Ignore;
+                }
+                return false;
+            }
+        }
+
+        public bool HasFieldIndex
+        {
+            get
+            {
+                if (csvAttribute != null)
+                {
+                    return csvAttribute.FieldIndex >= 0;
+                }
+                return false;
+            }            
+        }
+
+        public string Name
+        {
+            get
+            {
+                if (csvAttribute != null
+                    && !String.IsNullOrEmpty(csvAttribute.FieldName))
+                {
+                    return csvAttribute.FieldName;
+                }
+                return property.Name;
+            }            
+        }
+
+        public int FieldIndex
+        {
+            get
+            {
+                if (csvAttribute != null)                    
+                {
+                    return csvAttribute.FieldIndex;
+                }
+                return -1;
+            }
+        }
+
+        public PropertyInfo Property
+        {
+            get { return property; }
+        }
+
+        public bool HasAttribute
+        {
+            get { return csvAttribute != null; }
+        }
+
+        public TypeConverter FindTypeConverter()
+        {
+            TypeConverter typeConverter = null;
+            var typeConverterAttribute = ReflectionHelper.GetAttribute<TypeConverterAttribute>(property, false);
+            if (typeConverterAttribute != null)
+            {
+                var typeConverterType = Type.GetType(typeConverterAttribute.ConverterTypeName);
+                if (typeConverterType != null)
+                {
+                    typeConverter = Activator.CreateInstance(typeConverterType) as TypeConverter;
+                }
+            }
+            return typeConverter;
+        }
+    }
+}

--- a/src/CsvHelper/CsvPropertyInfoComparer.cs
+++ b/src/CsvHelper/CsvPropertyInfoComparer.cs
@@ -5,15 +5,14 @@
 // http://csvhelper.com
 #endregion
 using System;
-using System.Collections;
-using System.Reflection;
+using System.Collections.Generic;
 
 namespace CsvHelper
 {
 	/// <summary>
 	/// Used to compare properties by <see cref="CsvFieldAttribute" />.
 	/// </summary>
-	public class CsvPropertyInfoComparer : IComparer
+    public class CsvPropertyInfoComparer : IComparer<CsvPropertyInfo>
 	{
 		private readonly bool useFieldName;
 
@@ -25,75 +24,50 @@ namespace CsvHelper
 		{
 			this.useFieldName = useFieldName;
 		}
+		
+	    public int Compare(CsvPropertyInfo x, CsvPropertyInfo y)
+	    {            
+            if (x == null)
+            {
+                throw new ArgumentNullException("x");
+            }
+            if (y == null)
+            {
+                throw new ArgumentNullException("y");
+            }
+            
+            // Push properties without the attribute to the bottom.
+            if (!x.HasAttribute && !y.HasAttribute)
+            {
+                return 0;
+            }
+            if (!x.HasAttribute)
+            {
+                return 1;
+            }
+            if (!y.HasAttribute)
+            {
+                return -1;
+            }
 
-		/// <summary>
-		/// Compares two objects and returns a value indicating whether one is less than, equal to, or greater than the other.
-		/// </summary>
-		/// <returns>
-		/// Value 
-		///                     Condition 
-		///                     Less than zero 
-		///                 <paramref name="x"/> is less than <paramref name="y"/>. 
-		///                     Zero 
-		///                 <paramref name="x"/> equals <paramref name="y"/>. 
-		///                     Greater than zero 
-		///                 <paramref name="x"/> is greater than <paramref name="y"/>. 
-		/// </returns>
-		/// <param name="x">The first object to compare. 
-		///                 </param><param name="y">The second object to compare. 
-		///                 </param><exception cref="T:System.ArgumentException">Neither <paramref name="x"/> nor <paramref name="y"/> implements the <see cref="T:System.IComparable"/> interface.
-		///                     -or- 
-		///                 <paramref name="x"/> and <paramref name="y"/> are of different types and neither one can handle comparisons with the other. 
-		///                 </exception><filterpriority>2</filterpriority>
-		public int Compare( object x, object y )
-		{
-			var xProperty = x as PropertyInfo;
-			var yProperty = y as PropertyInfo;
+            if (!useFieldName)
+            {
+                // Treat non-set field indexes like nulls.
+                if (x.FieldIndex == -1 && y.FieldIndex == -1)
+                {
+                    return 0;
+                }
+                if (x.FieldIndex == -1)
+                {
+                    return 1;
+                }
+                if (y.FieldIndex == -1)
+                {
+                    return -1;
+                }
+            }
 
-			if( xProperty == null )
-			{
-				throw new ArgumentNullException( "x" );
-			}
-			if( yProperty == null )
-			{
-				throw new ArgumentNullException( "y" );
-			}
-
-			var xAttribute = ReflectionHelper.GetAttribute<CsvFieldAttribute>( xProperty, false );
-			var yAttribute = ReflectionHelper.GetAttribute<CsvFieldAttribute>( yProperty, false );
-
-			// Push properties without the attribute to the bottom.
-			if( xAttribute == null && yAttribute == null )
-			{
-				return 0;
-			}
-			if( xAttribute == null )
-			{
-				return 1;
-			}
-			if( yAttribute == null )
-			{
-				return -1;
-			}
-
-			if( !useFieldName )
-			{
-				// Treat non-set field indexes like nulls.
-				if( xAttribute.FieldIndex == -1 && yAttribute.FieldIndex == -1 )
-				{
-					return 0;
-				}
-				if( xAttribute.FieldIndex == -1 )
-				{
-					return 1;
-				}
-				if( yAttribute.FieldIndex == -1 )
-				{
-					return -1;
-				}
-			}
-
-			return useFieldName ? xAttribute.FieldName.CompareTo( yAttribute.FieldName ) : xAttribute.FieldIndex.CompareTo( yAttribute.FieldIndex );
-		}
+            return useFieldName ? x.Name.CompareTo(y.Name) : x.FieldIndex.CompareTo(y.FieldIndex);
+	    }
 	}
 }

--- a/src/CsvHelper/ReflectionHelper.cs
+++ b/src/CsvHelper/ReflectionHelper.cs
@@ -12,7 +12,7 @@ namespace CsvHelper
 	/// <summary>
 	/// Common reflection tasks.
 	/// </summary>
-	public static class ReflectionHelper
+	static class ReflectionHelper
 	{
 		/// <summary>
 		/// Gets the first attribute of type T on property.


### PR DESCRIPTION
In your code for value types you search for static method ToString that accepts value and format provider (Int32.ToString(string, IFormatProvider)), then you pass value as a first a value. Actually first value is format string. Anyway always this hit nothing (at least I do not know value object with static ToString) and uses just ToString, this means that code write values with CurrentCulture instead of CultureInvariant). 

I changed this to search for instance method ToString that accept only IFormatProvider, and of course twicked execution code to call it as instance method).

I have added test to the seprate test class, as CsvWriterTests became bit oveloaded with tests. Hope you can accept this.

In couple hours I will push another pull request, with more changes, they fix another issue when record write lead to none, however I decided to add more changes like introducing CsvPropertyInfo that abstracts writer from reflection stuff.
