### PR TITLE
Quick fix.

### DIFF
--- a/src/CsvHelper.Tests/CsvParserTests.cs
+++ b/src/CsvHelper.Tests/CsvParserTests.cs
@@ -449,5 +449,27 @@ namespace CsvHelper.Tests
 			Assert.AreEqual( "two", record[1] );
 			Assert.AreEqual( "three", record[2] );
 		}
+
+		[TestMethod]
+		public void ReadFinalRecordWithNoEndOfLineTest()
+		{
+			var stream = new MemoryStream();
+			var writer = new StreamWriter(stream);
+			writer.WriteLine("one,two,three,");
+			writer.Write("four,five,six,");
+			writer.Flush();
+			stream.Position = 0;
+			var reader = new StreamReader(stream);
+
+			var parser = new CsvParser(reader);
+
+			var count = 0;
+			while (parser.Read() != null)
+			{
+				count++;
+			}
+
+			Assert.AreEqual(2, count);
+		}
 	}
 }

--- a/src/CsvHelper.Tests/CsvReaderTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderTests.cs
@@ -18,7 +18,7 @@ namespace CsvHelper.Tests
 	public class CsvReaderTests
 	{
 		[TestMethod]
-		[ExpectedException( typeof( InvalidOperationException ) )]
+		[ExpectedException( typeof( CsvReaderException ) )]
 		public void HasHeaderRecordNotReadExceptionTest()
 		{
 			var mockFactory = new MockFactory( MockBehavior.Default );
@@ -178,7 +178,7 @@ namespace CsvHelper.Tests
 		}
 
 		[TestMethod]
-		[ExpectedException( typeof( MissingFieldException ) )]
+		[ExpectedException( typeof( CsvMissingFieldException ) )]
 		public void GetMissingFieldByNameStrictTest()
 		{
 			var isHeaderRecord = true;
@@ -203,7 +203,7 @@ namespace CsvHelper.Tests
 		}
 
 		[TestMethod]
-		[ExpectedException( typeof( InvalidOperationException ) )]
+		[ExpectedException( typeof( CsvReaderException ) )]
 		public void GetFieldByNameNoHeaderExceptionTest()
 		{
 			var data = new [] { "1", "2" };

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace CsvHelper
 {
@@ -195,7 +196,7 @@ namespace CsvHelper
 					{
 						// The end of the stream has been reached.
 
-						if( !string.IsNullOrEmpty( field ) )
+						if( record.Any( v => !string.IsNullOrEmpty( v ) ) )
 						{
 							AddFieldToRecord( ref recordPosition, field, hasQuotes );
 							return record;


### PR DESCRIPTION
I made a small fix so that final record is returned if there is a trailing delimiter. Basically, it was causing the CsvParser to think the last row was empty, cause it was only checking the current value. Instead I modified it so that it checks if there are any non-null values in the row.
