### PR TITLE
Fixed differing Configurations between a parser and a reader

### DIFF
--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -55,13 +55,13 @@ namespace CsvHelper
 		/// the default parser.
 		/// </summary>
 		/// <param name="reader"></param>
-		public CsvReader( TextReader reader ) : this( new CsvParser( reader ) ) {}
+		public CsvReader( TextReader reader ) : this( new CsvParser( reader ) , null) {}
 
 		/// <summary>
 		/// Creates a new CSV reader using the given <see cref="ICsvParser" />.
 		/// </summary>
 		/// <param name="parser">The <see cref="ICsvParser" /> used to parse the CSV file.</param>
-		public CsvReader( ICsvParser parser ) : this( parser, new CsvConfiguration() ) {}
+		public CsvReader( ICsvParser parser ) : this( parser, null ) {}
 
 		/// <summary>
 		/// Creates a new CSV reader using the given <see cref="ICsvParser"/> and <see cref="CsvConfiguration"/>.
@@ -71,7 +71,8 @@ namespace CsvHelper
 		public CsvReader( ICsvParser parser, CsvConfiguration configuration )
 		{
 			this.parser = parser;
-			this.configuration = configuration;
+			this.configuration = configuration ?? parser.Configuration;
+			this.parser.Configuration = this.configuration;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Without it, Helper becomes useless for files with properties different from default configuration values, since Parser always creates its own. This patch fixes it. Perhaps, Writer needs the same change. I just didn't need it.

Thanks.
