### PR TITLE
Add alternative names for header configuration

### DIFF
--- a/src/CsvHelper.Example/Program.cs
+++ b/src/CsvHelper.Example/Program.cs
@@ -107,7 +107,7 @@ namespace CsvHelper.Example
 		{
 			Console.WriteLine( "Records with attributes:" );
 
-            using (var reader = new CsvReader(new StreamReader(GetDataStream(true, true)), new CsvConfiguration { UseAlternativeNames = true}))
+            using (var reader = new CsvReader(new StreamReader(GetDataStream(true, true)), new CsvConfiguration()))
 			{
 				while( reader.Read() )
 				{
@@ -431,7 +431,7 @@ namespace CsvHelper.Example
 			[CsvField( Ignore = true )]
 			public string IgnoredColumn { get; set; }
 
-            [CsvField(Name = "AltColumn,Alt Column")]
+            [CsvField(Name = "AltColumn", AlternativeNames = new[] { "Alt Column" })]
 			public string AltNamesColumn { get; set; }
 
 			public override string ToString()

--- a/src/CsvHelper.Tests/CsvClassMappingTests.cs
+++ b/src/CsvHelper.Tests/CsvClassMappingTests.cs
@@ -43,7 +43,11 @@ namespace CsvHelper.Tests
 			Assert.Equal( "Guid Column", map.PropertyMaps[0].NameValue );
 			Assert.Equal( "Int Column", map.PropertyMaps[1].NameValue );
 			Assert.Equal( "String Column", map.PropertyMaps[2].NameValue );
-            Assert.Equal("String Alt Column,StringAltColumn", map.PropertyMaps[3].NameValue);
+            Assert.Equal("String Alt Column", map.PropertyMaps[3].NameValue);
+            Assert.Equal(2, map.PropertyMaps[3].AlternativeNamesValue.Length);
+
+            Assert.Equal("StringAltColumn", map.PropertyMaps[3].AlternativeNamesValue[0]);
+            Assert.Equal("String AltColumn", map.PropertyMaps[3].AlternativeNamesValue[1]);
 		}
 
 		[Fact]
@@ -108,7 +112,7 @@ namespace CsvHelper.Tests
 				Map( m => m.GuidColumn ).Name( "Guid Column" );
 				Map( m => m.IntColumn ).Name( "Int Column" );
 				Map( m => m.StringColumn ).Name( "String Column" );
-                Map(m => m.AltStringColumn).Name("String Alt Column,StringAltColumn");
+                Map( m => m.AltStringColumn ).Name( "String Alt Column" ).AlternativeNames( "StringAltColumn", "String AltColumn" );
 			}
 		}
 

--- a/src/CsvHelper.Tests/CsvReaderTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderTests.cs
@@ -281,7 +281,7 @@ namespace CsvHelper.Tests
 			var isHeaderRecord = true;
 			var mockFactory = new MockRepository( MockBehavior.Default );
 			var csvParserMock = mockFactory.Create<ICsvParser>();
-            csvParserMock.Setup(m => m.Configuration).Returns(new CsvConfiguration {UseAlternativeNames = true});
+            csvParserMock.Setup(m => m.Configuration).Returns(new CsvConfiguration());
 			csvParserMock.Setup( m => m.Read() ).Returns( () =>
 			{
 				if( isHeaderRecord )
@@ -687,10 +687,36 @@ namespace CsvHelper.Tests
 				csv.Read();
 
 				Assert.Equal( "1", csv.GetField( "one" ) );
-				Assert.Equal( "2", csv.GetField( "TWO" ) );
+				Assert.Equal( "2", csv.GetField( "TwO" ) );
 				Assert.Equal( "3", csv.GetField( "ThreE" ) );
 			}
 		}
+
+        [Fact]
+        public void CaseInsensitiveAltNamesHeaderMatching()
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new StreamWriter(stream))
+            using (var reader = new StreamReader(stream))
+            using (var csv = new CsvReader(reader))
+            {
+                writer.WriteLine("One,Two,Three");
+                writer.WriteLine("1,2,3");
+                writer.Flush();
+                stream.Position = 0;
+
+                csv.Configuration.IsCaseSensitive = false;
+                csv.Configuration.IsStrictMode = true;
+                csv.Configuration.ClassMapping<TestNullableMap>();
+
+                csv.Read();
+                var record = csv.GetRecord<TestNullable>();
+
+                Assert.NotNull(record);
+                Assert.Equal("1", record.StringColumn);
+                Assert.Equal(2, record.IntColumn);
+            }
+        }
 
 		private class TestNullable
 		{
@@ -699,37 +725,39 @@ namespace CsvHelper.Tests
 			public Guid? GuidColumn { get; set; }
 		}
 
-		[DebuggerDisplay( "IntColumn = {IntColumn}, StringColumn = {StringColumn}, IgnoredColumn = {IgnoredColumn}, TypeConvertedColumn = {TypeConvertedColumn}, FirstColumn = {FirstColumn}" )]
-		private class TestRecord
-		{
-			[TypeConverter( typeof( Int32Converter ) )]
-			public int IntColumn { get; set; }
+	    [DebuggerDisplay(
+	        "IntColumn = {IntColumn}, StringColumn = {StringColumn}, IgnoredColumn = {IgnoredColumn}, TypeConvertedColumn = {TypeConvertedColumn}, FirstColumn = {FirstColumn}"
+	        )]
+	    private class TestRecord
+	    {
+	        [TypeConverter(typeof (Int32Converter))]
+	        public int IntColumn { get; set; }
 
-			[CsvField( Name = "String Column" )]
-			public string StringColumn { get; set; }
+	        [CsvField(Name = "String Column")]
+	        public string StringColumn { get; set; }
 
-			[CsvField( Ignore = true )]
-			public string IgnoredColumn { get; set; }
+	        [CsvField(Ignore = true)]
+	        public string IgnoredColumn { get; set; }
 
-			[CsvField( Index = 1 )]
-			[TypeConverter( typeof( TestTypeConverter ) )]
-			public string TypeConvertedColumn { get; set; }
+	        [CsvField(Index = 1)]
+	        [TypeConverter(typeof (TestTypeConverter))]
+	        public string TypeConvertedColumn { get; set; }
 
-			[CsvField( Index = 0 )]
-			public int FirstColumn { get; set; }
+	        [CsvField(Index = 0)]
+	        public int FirstColumn { get; set; }
 
-			public Guid GuidColumn { get; set; }
+	        public Guid GuidColumn { get; set; }
 
-			public int NoMatchingFields { get; set; }
+	        public int NoMatchingFields { get; set; }
 
-            [CsvField(Name = "AltName,Alt Name")]
-			public string AltName { get; set; }
-            
-            [CsvField(Name = "NoAltName,No Alt Name")]
-			public string NoAltName { get; set; }
-		}
+	        [CsvField(Name = "AltName", AlternativeNames = new[] {"Alt Name Column", "Alt Name"})]
+	        public string AltName { get; set; }
 
-		private class TestRecordNoAttributes
+	        [CsvField(Name = "NoAltName")]
+	        public string NoAltName { get; set; }
+	    }
+
+	    private class TestRecordNoAttributes
 		{
 			public int IntColumn { get; set; }
 
@@ -772,5 +800,14 @@ namespace CsvHelper.Tests
 				return sourceType == typeof( string );
 			}
 		}
+
+	    private sealed class TestNullableMap : CsvClassMap<TestNullable>
+	    {
+	        public TestNullableMap()
+	        {
+	            Map(_ => _.StringColumn).Name("one").AlternativeNames("One");
+	            Map(_ => _.IntColumn).Name("2").AlternativeNames("tWo");
+	        }
+	    }
 	}
 }

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -25,7 +25,6 @@ namespace CsvHelper.Configuration
 		private char comment = '#';
 		private int bufferSize = 2048;
 		private bool isCaseSensitive = true;
-        private string _alternativeNameDelimiter = ",";
 
 	    /// <summary>
 		/// Gets the property mappings.
@@ -187,41 +186,21 @@ namespace CsvHelper.Configuration
 		/// </summary>
 		public virtual int FieldCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating if use alternative names
-        /// for named columns in caption record
-        /// <example>'LastName' or 'Last Name'</example>
-        /// </summary>
-	    public virtual bool UseAlternativeNames { get; set; }
-
-        /// <summary>
-        /// Gets or sets delimiter used to split alternative names in CsvFieldAttribute.Name.
-        /// </summary>
-	    public virtual string AlternativeNameDelimiter
-	    {
-	        get {
-	            return _alternativeNameDelimiter;
-	        }
-	        set {
-	            _alternativeNameDelimiter = value;
-	        }
-	    }
-
 	    /// <summary>
 		/// Maps a property of a class to a CSV field.
 		/// </summary>
 		/// <param name="expression">The property to map.</param>
-		public virtual CsvPropertyMap PropertyMap<T>( Expression<Func<T, object>> expression )
+		public virtual CsvPropertyMap GetPropertyMap<T>( Expression<Func<T, object>> expression )
 		{
 			var property = ReflectionHelper.GetProperty( expression );
-			return PropertyMap( property );
+			return GetPropertyMap( property );
 		}
 
 		/// <summary>
 		/// Maps a property of a class to a CSV field.
 		/// </summary>
 		/// <param name="property">The property to map.</param>
-		public virtual CsvPropertyMap PropertyMap( PropertyInfo property )
+		public virtual CsvPropertyMap GetPropertyMap( PropertyInfo property )
 		{
 			return new CsvPropertyMap( property );
 		}
@@ -231,7 +210,7 @@ namespace CsvHelper.Configuration
 		/// </summary>
 		/// <param name="expression">The expression.</param>
 		/// <returns></returns>
-		public virtual CsvPropertyReferenceMap ReferenceMap<T>( Expression<Func<T, object>> expression )
+		public virtual CsvPropertyReferenceMap GetReferenceMap<T>( Expression<Func<T, object>> expression )
 		{
 			var property = ReflectionHelper.GetProperty( expression );
 			return new CsvPropertyReferenceMap( property );
@@ -242,7 +221,7 @@ namespace CsvHelper.Configuration
 		/// </summary>
 		/// <param name="property">The property.</param>
 		/// <returns></returns>
-		public virtual CsvPropertyReferenceMap ReferenceMap( PropertyInfo property )
+		public virtual CsvPropertyReferenceMap GetReferenceMap( PropertyInfo property )
 		{
 			return new CsvPropertyReferenceMap( property );
 		}
@@ -303,9 +282,10 @@ namespace CsvHelper.Configuration
 					CsvPropertyMap map;
 					if( csvFieldAttribute != null )
 					{
-						map = PropertyMap( property )
+						map = GetPropertyMap( property )
 							.Ignore( csvFieldAttribute.Ignore )
-							.Index( csvFieldAttribute.Index );
+                            .Index(csvFieldAttribute.Index)
+                            .AlternativeNames(csvFieldAttribute.AlternativeNames);
 						if( csvFieldAttribute.Name != null )
 						{
 							map.Name( csvFieldAttribute.Name );
@@ -314,7 +294,7 @@ namespace CsvHelper.Configuration
 					else
 					{
 						// Use defaults.
-						map = PropertyMap( property );
+						map = GetPropertyMap( property );
 					}
 					var typeConverter = ReflectionHelper.GetTypeConverterFromAttribute( property );
 					if( typeConverter != null )
@@ -326,7 +306,7 @@ namespace CsvHelper.Configuration
 				else
 				{
 					// This is a reference mapping.
-					var refMap = ReferenceMap( property );
+					var refMap = GetReferenceMap( property );
 					references.Add( refMap );
 					var refProps = property.PropertyType.GetProperties( PropertyBindingFlags );
 					foreach( var refProp in refProps )
@@ -336,7 +316,7 @@ namespace CsvHelper.Configuration
 						CsvPropertyMap map;
 						if( refCsvFieldAttribute != null )
 						{
-							map = PropertyMap( refProp )
+							map = GetPropertyMap( refProp )
 								.Ignore( refCsvFieldAttribute.Ignore )
 								.Index( refCsvFieldAttribute.Index );
 							if( refCsvFieldAttribute.Name != null )
@@ -347,7 +327,7 @@ namespace CsvHelper.Configuration
 						else
 						{
 							// Use defaults.
-							map = PropertyMap( refProp );
+							map = GetPropertyMap( refProp );
 						}
 						var typeConverter = ReflectionHelper.GetTypeConverterFromAttribute( refProp );
 						if( typeConverter != null )

--- a/src/CsvHelper/Configuration/CsvFieldAttribute.cs
+++ b/src/CsvHelper/Configuration/CsvFieldAttribute.cs
@@ -11,7 +11,7 @@ namespace CsvHelper.Configuration
 	/// Used to set behavior of a field when
 	/// reading a writing a CSV file.
 	/// </summary>
-	[DebuggerDisplay( "Index = {Index}, Name = {Name}, Ignore = {Ignore}, ReferenceKey = {ReferenceKey}" )]
+    [DebuggerDisplay("Index = {Index}, Name = {Name}, Ignore = {Ignore}, ReferenceKey = {ReferenceKey}, AlternativeNames = {AlternativeNames}")]
 	[AttributeUsage( AttributeTargets.Property, AllowMultiple = true )]
 	public class CsvFieldAttribute : Attribute
 	{
@@ -51,5 +51,11 @@ namespace CsvHelper.Configuration
 		/// The key.
 		/// </value>
 		public virtual string ReferenceKey { get; set; }
+
+        /// <summary>
+        /// When reading, is used as alternative names to get the field
+        /// at the index of the name if there was a header specified.
+        /// </summary>
+	    public virtual string[] AlternativeNames { get; set; }
 	}
 }

--- a/src/CsvHelper/Configuration/CsvPropertyMap.cs
+++ b/src/CsvHelper/Configuration/CsvPropertyMap.cs
@@ -12,7 +12,7 @@ namespace CsvHelper.Configuration
 	/// <summary>
 	/// Mapping info for a property to a CSV field.
 	/// </summary>
-	[DebuggerDisplay( "Name = {NameValue}, Index = {IndexValue}, Ignore = {IgnoreValue}, Property = {PropertyValue}, TypeConverter = {TypeConverterValue}" )]
+    [DebuggerDisplay("Name = {NameValue}, Index = {IndexValue}, Ignore = {IgnoreValue}, Property = {PropertyValue}, TypeConverter = {TypeConverterValue}, AlternativeNames = {AlternativeNamesValue}")]
 	public class CsvPropertyMap
 	{
 		private readonly PropertyInfo property;
@@ -20,8 +20,10 @@ namespace CsvHelper.Configuration
 		private int index = -1;
 		private TypeConverter typeConverter;
 		private bool ignore;
+	    private string[] alternativeNames;
 
-		/// <summary>
+	    
+	    /// <summary>
 		/// Gets the property value.
 		/// </summary>
 		public virtual PropertyInfo PropertyValue { get { return property; } }
@@ -45,6 +47,14 @@ namespace CsvHelper.Configuration
 		/// Gets a value indicating whether the field should be ignored.
 		/// </summary>
 		public virtual bool IgnoreValue { get { return ignore; } }
+
+        /// <summary>
+        /// Gets a value of alternative names for column
+        /// </summary>
+        public string[] AlternativeNamesValue
+        {
+            get { return alternativeNames; }
+        }
 
 		/// <summary>
 		/// Creates a new <see cref="CsvPropertyMap"/> instance using the specified property.
@@ -129,5 +139,15 @@ namespace CsvHelper.Configuration
 			TypeConverter( Activator.CreateInstance<T>() );
 			return this;
 		}
+
+        /// <summary>
+        /// Specify alternative names for column used in reading.
+        /// </summary>
+        /// <param name="alternativeNames">Array of alternative names for CSV column.</param>
+	    public virtual CsvPropertyMap AlternativeNames(params string[] alternativeNames)
+	    {
+	        this.alternativeNames = alternativeNames;
+	        return this;
+	    }
 	}
 }


### PR DESCRIPTION
Hi, Josh
I've added configuration and implementation for using alternative names for headers.

Like in the next example

``` csharp
public class TestClass
{
 [CsvField(Name = "AltName", AlternativeNames = new [] {"Alt Name", "Different Alt Name"})]
 public string AltColumn {get; set;}
}
```

So, we can provide csv file with alternative field names.
What do you think?

Thx, Slava
