### PR TITLE
fix for issue #67 - don't double count the closing quote

### DIFF
--- a/src/CsvHelper.Tests/CsvParserTests.cs
+++ b/src/CsvHelper.Tests/CsvParserTests.cs
@@ -796,6 +796,31 @@ namespace CsvHelper.Tests
 			}
 		}
 
+        [Fact]
+		public void ByteCountTestWithQuotedFields()
+		{
+			using( var stream = new MemoryStream() )
+			using( var writer = new StreamWriter( stream ) )
+			using( var reader = new StreamReader( stream ) )
+			using( var parser = new CsvParser( reader ) )
+			{
+				parser.Configuration.CountBytes = true;
+				writer.Write( "1,\"2\"\r\n" );
+				writer.Write( "\"3\",4\r\n" );
+				writer.Flush();
+				stream.Position = 0;
+
+				parser.Read();
+				Assert.Equal( 6, parser.BytePosition );
+
+				parser.Read();
+				Assert.Equal( 13, parser.BytePosition );
+
+				parser.Read();
+				Assert.Equal( 14, parser.BytePosition );
+			}
+		}
+
 		[Fact]
 		public void ByteCountUsingCharWithMoreThanSingleByteTest()
 		{

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -251,6 +251,7 @@ namespace CsvHelper
 
 				if( c == configuration.Quote )
 				{
+				    bool quoteCounted = false;
 					if( !fieldIsEscaped && ( cPrev == configuration.Delimiter || cPrev == '\r' || cPrev == '\n' || cPrev == '\0' ) )
 					{
 						// The field is escaped only if the first char of
@@ -273,6 +274,7 @@ namespace CsvHelper
 						// Grab all the field chars before the
 						// quote if there are any.
 						AppendField( ref field, fieldStartPosition, readerBufferPosition - fieldStartPosition - 1 );
+					    quoteCounted = true;
 					}
 
 					if( cPrev != configuration.Quote || !inQuotes )
@@ -280,7 +282,7 @@ namespace CsvHelper
 						// Set the new field start position to
 						// the char after the quote.
 
-						if( configuration.CountBytes )
+						if( configuration.CountBytes && !quoteCounted )
 						{
 							BytePosition += configuration.Encoding.GetByteCount( new[] { c } );
 						}


### PR DESCRIPTION
There might be a more elegant way to fix this but this solution seems to work - this change avoid double counting the closing quote - it is already included when we increment BytePosition in AppendField when we create the string with length "readerBufferPosition - fieldStartPosition" and then again on line 285
