### PR TITLE
Issue #90 - update count for all closing quotes

### DIFF
--- a/src/CsvHelper.Tests/CsvParserTests.cs
+++ b/src/CsvHelper.Tests/CsvParserTests.cs
@@ -853,6 +853,91 @@ namespace CsvHelper.Tests
 			}
 		}
 
+        [TestMethod]
+        public void ByteCountTestWithQuotedFieldsEmptyQuotedField()
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new StreamWriter(stream))
+            using (var reader = new StreamReader(stream))
+            using (var parser = new CsvParser(reader))
+            {
+                parser.Configuration.CountBytes = true;
+                writer.Write("1,\"\",2\r\n");
+                writer.Write("\"3\",4,\"5\"\r\n");
+                writer.Flush();
+                stream.Position = 0;
+
+                parser.Read();
+                Assert.AreEqual(7, parser.BytePosition);
+
+                parser.Read();
+                Assert.AreEqual(18, parser.BytePosition);
+
+                parser.Read();
+                Assert.AreEqual(19, parser.BytePosition);
+            }
+        }
+
+        [TestMethod]
+        public void ByteCountTestWithQuotedFieldsClosingQuoteAtStartOfBuffer()
+        {
+            var config = new Configuration.CsvConfiguration()
+            {
+                CountBytes = true,
+                BufferSize = 4
+            };
+
+            using (var stream = new MemoryStream())
+            using (var writer = new StreamWriter(stream))
+            using (var reader = new StreamReader(stream))
+            using (var parser = new CsvParser(reader, config))
+            {
+                writer.Write("1,\"2\",3\r\n");
+                writer.Write("\"4\",5,\"6\"\r\n");
+                writer.Flush();
+                stream.Position = 0;
+
+                parser.Read();
+                Assert.AreEqual(8, parser.BytePosition);
+
+                parser.Read();
+                Assert.AreEqual(19, parser.BytePosition);
+
+                parser.Read();
+                Assert.AreEqual(20, parser.BytePosition);
+            }
+        }
+
+        [TestMethod]
+        public void ByteCountTestWithQuotedFieldsEscapedQuoteAtStartOfBuffer()
+        {
+            var config = new Configuration.CsvConfiguration()
+            {
+                CountBytes = true,
+                BufferSize = 4
+            };
+
+            using (var stream = new MemoryStream())
+            using (var writer = new StreamWriter(stream))
+            using (var reader = new StreamReader(stream))
+            using (var parser = new CsvParser(reader, config))
+            {
+                writer.Write("1,\"2a\",3\r\n");
+                writer.Write("\"\"\"4\"\"\",5,\"6\"\r\n");
+                writer.Flush();
+                stream.Position = 0;
+
+                var r1 = parser.Read();
+                Assert.AreEqual(9, parser.BytePosition);
+
+                var r2 = parser.Read();
+                Assert.AreEqual(24, parser.BytePosition);
+
+                parser.Read();
+                Assert.AreEqual(25, parser.BytePosition);
+            }
+        }
+
 		[TestMethod]
 		public void ByteCountUsingCharWithMoreThanSingleByteTest()
 		{

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -312,13 +312,14 @@ namespace CsvHelper
 						// Include the quote in the byte count.
 						UpdateBytePosition( fieldStartPosition, readerBufferPosition - fieldStartPosition );
 					}
-
 					if( cPrev != configuration.Quote || !inQuotes )
 					{
-						if( inQuotes )
+						if( inQuotes || cPrev == configuration.Quote || readerBufferPosition == 1)
 						{
-							// If this is the first quote, it will not 
-							// have been counted yet so we need to count it.
+							// The quote will be uncounted and needs to be catered for if:
+                            // 1. It's the opening quote
+                            // 2. It's the closing quote on an empty field ("")
+                            // 3. It's the closing quote and has appeared as the first character in the buffer
 							UpdateBytePosition( fieldStartPosition, readerBufferPosition - fieldStartPosition );
 						}
 


### PR DESCRIPTION
See the [issue description](https://github.com/JoshClose/CsvHelper/issues/90) for details of what this fixes. All other tests pass, i put in one test for each of the mentioned cases, and an additional case where the buffer boundary occurs halfway through an escaped double-quote.

Let me know if there's anything you're not happy with.
