### PR TITLE
Trim headerRecords

### DIFF
--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -946,7 +946,7 @@ namespace CsvHelper
 
 			for( var i = 0; i < headerRecord.Length; i++ )
 			{
-				var name = headerRecord[i];
+				var name = headerRecord[i].Trim();
 				if( !Configuration.IsCaseSensitive )
 				{
 					name = name.ToLower();


### PR DESCRIPTION
Hi Josh, I've added a Trim when parsing the headerRecords. This caters for the following example: header1,   header2,  header3
