### PR TITLE
Added CsvConfiguration.IsIgnoreSpaceInHeader

### DIFF
--- a/src/CsvHelper.Tests/CsvReaderTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderTests.cs
@@ -165,6 +165,29 @@ namespace CsvHelper.Tests
 			Assert.AreEqual( Convert.ToInt32( data2[1] ), reader.GetField<int>( "One", 1 ) );
 		}
 
+        [TestMethod]
+        public void GetSpacedFieldByNameTest()
+        {
+            var data1 = new[] { "One", "Two Is Multiple", "three", "four is FUNKy" };
+            var data2 = new[] { "1", "2", "3", "4" };
+
+            var queue = new Queue<string[]>();
+            queue.Enqueue(data1);
+            queue.Enqueue(data2);
+
+            var parseMock = new ParserMock(queue);
+
+            var reader = new CsvReader(parseMock);
+            reader.Configuration.IsCaseSensitive = false;
+            reader.Configuration.IsIgnoreSpaceInHeader = true;
+            reader.Read();
+
+            Assert.AreEqual(Convert.ToInt32(data2[0]), reader.GetField<int>("one"));
+            Assert.AreEqual(Convert.ToInt32(data2[1]), reader.GetField<int>("twoismultiple"));
+            Assert.AreEqual(Convert.ToInt32(data2[2]), reader.GetField<int>("three"));
+            Assert.AreEqual(Convert.ToInt32(data2[3]), reader.GetField<int>("fourisfunky"));
+        }
+
 		[TestMethod]
 		public void GetMissingFieldByNameTest()
 		{

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -41,6 +41,7 @@ namespace CsvHelper.Configuration
 		private Encoding encoding = Encoding.UTF8;
 		private bool quoteAllFields = false;
 		private bool quoteNoFields = false;
+        private bool isIgnoreSpacesInHeader = false;
 
 #if !NET_2_0
 		/// <summary>
@@ -258,6 +259,18 @@ namespace CsvHelper.Configuration
 				}
 			}
 		}
+
+        /// <summary>
+        /// Gets or sets a value indicating whether matching header
+		/// column names should ignore spaces. True for ignoring space
+		/// matching, otherwise false.
+        /// </summary>
+
+        public virtual bool IsIgnoreSpaceInHeader
+        {
+            get { return isIgnoreSpacesInHeader; }
+            set { isIgnoreSpacesInHeader = value; }
+        }
 
 		/// <summary>
 		/// Gets or sets a value indicating whether the number of bytes should

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -954,6 +954,11 @@ namespace CsvHelper
 					name = name.ToLower();
 				}
 
+                if (Configuration.IsIgnoreSpaceInHeader)
+                {
+                    name = name.Replace(" ", "");
+                }
+
 				if( namedIndexes.ContainsKey( name ) )
 				{
 					namedIndexes[name].Add( i );


### PR DESCRIPTION
Configuration to say whether spaces in header records should be ignored. So a header record of "Multi Word" is read the same as "MultiWord". Default for the configuration is false.

Added the following:
- Property to configuration (CsvConfiguration.cs)
- Check when reading header (CsvReader.cs)
- Unit test (CsvReaderTest.cs)
