### PR TITLE
Fixed so that value types can be read and written correctly

### DIFF
--- a/src/CsvHelper/Configuration/CsvClassMap`1.cs
+++ b/src/CsvHelper/Configuration/CsvClassMap`1.cs
@@ -12,7 +12,7 @@ namespace CsvHelper.Configuration
 	/// Maps class properties to CSV fields.
 	/// </summary>
 	/// <typeparam name="T">The <see cref="Type"/> of class to map.</typeparam>
-	public class CsvClassMap<T> : CsvClassMap where T : class
+	public class CsvClassMap<T> : CsvClassMap 
 	{
 		/// <summary>
 		/// Constructs the row object using the given expression.

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -720,7 +720,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The <see cref="Type"/> of the record.</typeparam>
 		/// <returns>The record converted to <see cref="Type"/> T.</returns>
-		public virtual T GetRecord<T>() where T : class
+		public virtual T GetRecord<T>() 
 		{
 			CheckDisposed();
 			CheckHasBeenRead();
@@ -768,7 +768,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The <see cref="Type"/> of the record.</typeparam>
 		/// <returns>An <see cref="IList{T}" /> of records.</returns>
-		public virtual IEnumerable<T> GetRecords<T>() where T : class
+		public virtual IEnumerable<T> GetRecords<T>() 
 		{
 			CheckDisposed();
 			// Don't need to check if it's been read
@@ -852,7 +852,7 @@ namespace CsvHelper
 		/// changes, <see cref="ICsvReaderRow.ClearRecordCache{T}"/> needs to be called to update the
 		/// record cache.
 		/// </summary>
-		public virtual void ClearRecordCache<T>() where T : class
+		public virtual void ClearRecordCache<T>() 
 		{
 			ClearRecordCache( typeof( T ) );
 		}
@@ -1070,7 +1070,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The type of record to create.</typeparam>
 		/// <returns>The created record.</returns>
-		protected virtual T CreateRecord<T>() where T : class
+		protected virtual T CreateRecord<T>() 
 		{
 #if !NET_3_5 && !WINDOWS_PHONE_7
 			// If the type is an object, a dynamic
@@ -1114,7 +1114,7 @@ namespace CsvHelper
 		/// <typeparam name="T">The <see cref="Type"/> of object that is created
 		/// and populated.</typeparam>
 		/// <returns>The function delegate.</returns>
-		protected virtual Func<T> GetReadRecordFunc<T>() where T : class
+		protected virtual Func<T> GetReadRecordFunc<T>() 
 		{
 			var recordType = typeof( T );
 			CreateReadRecordFunc( recordType );

--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -224,7 +224,7 @@ namespace CsvHelper
 		/// Writes the header record from the given properties.
 		/// </summary>
 		/// <typeparam name="T">The type of the record.</typeparam>
-		public virtual void WriteHeader<T>() where T : class
+		public virtual void WriteHeader<T>()
 		{
 			WriteHeader( typeof( T ) );
 		}
@@ -281,7 +281,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The type of the record.</typeparam>
 		/// <param name="record">The record to write.</param>
-		public virtual void WriteRecord<T>( T record ) where T : class
+		public virtual void WriteRecord<T>( T record )
 		{
 			CheckDisposed();
 
@@ -329,7 +329,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The type of the record.</typeparam>
 		/// <param name="records">The list of records to write.</param>
-		public virtual void WriteRecords<T>( IEnumerable<T> records ) where T : class
+		public virtual void WriteRecords<T>( IEnumerable<T> records )
 		{
 			CheckDisposed();
 
@@ -390,7 +390,7 @@ namespace CsvHelper
 		/// record cache.
 		/// </summary>
 		/// <typeparam name="T">The record type.</typeparam>
-		public virtual void ClearRecordCache<T>() where T : class
+		public virtual void ClearRecordCache<T>()
 		{
 			ClearRecordCache( typeof( T ) );
 		}
@@ -522,7 +522,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The type of the custom class being written.</typeparam>
 		/// <returns>The action delegate.</returns>
-		protected virtual Action<T> GetWriteRecordAction<T>() where T : class
+		protected virtual Action<T> GetWriteRecordAction<T>()
 		{
 			var type = typeof( T );
 			CreateWriteRecordAction( type );
@@ -599,8 +599,11 @@ namespace CsvHelper
 				fieldExpression = Expression.Convert( fieldExpression, typeof( object ) );
 				fieldExpression = Expression.Call( typeConverterExpression, method, typeConverterOptions, fieldExpression );
 
-				var areEqualExpression = Expression.Equal( recordParameter, Expression.Constant( null ) );
-				fieldExpression = Expression.Condition( areEqualExpression, Expression.Constant( string.Empty ), fieldExpression );
+                if (type.IsClass)
+                {
+                    var areEqualExpression = Expression.Equal(recordParameter, Expression.Constant(null));
+                    fieldExpression = Expression.Condition(areEqualExpression, Expression.Constant(string.Empty), fieldExpression);
+                }
 
 				var writeFieldMethodCall = Expression.Call( Expression.Constant( this ), "WriteField", new[] { typeof( string ) }, fieldExpression );
 

--- a/src/CsvHelper/ICsvReaderRow.cs
+++ b/src/CsvHelper/ICsvReaderRow.cs
@@ -271,7 +271,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The <see cref="Type"/> of the record.</typeparam>
 		/// <returns>The record converted to <see cref="Type"/> T.</returns>
-		T GetRecord<T>() where T : class;
+		T GetRecord<T>() ;
 
 		/// <summary>
 		/// Gets the record.
@@ -287,7 +287,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The <see cref="Type"/> of the record.</typeparam>
 		/// <returns>An <see cref="IList{T}" /> of records.</returns>
-		IEnumerable<T> GetRecords<T>() where T : class;
+		IEnumerable<T> GetRecords<T>() ;
 
 		/// <summary>
 		/// Gets all the records in the CSV file and
@@ -305,7 +305,7 @@ namespace CsvHelper
 		/// changes, <see cref="ClearRecordCache{T}"/> needs to be called to update the
 		/// record cache.
 		/// </summary>
-		void ClearRecordCache<T>() where T : class;
+		void ClearRecordCache<T>() ;
 
 		/// <summary>
 		/// Clears the record cache for the given type. After <see cref="ICsvReader.GetRecord{T}"/> is called the

--- a/src/CsvHelper/ICsvWriter.cs
+++ b/src/CsvHelper/ICsvWriter.cs
@@ -89,7 +89,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The type of the record.</typeparam>
 		/// <param name="record">The record to write.</param>
-		void WriteRecord<T>( T record ) where T : class;
+		void WriteRecord<T>( T record );
 
 		/// <summary>
 		/// Writes the record to the CSV file.
@@ -103,7 +103,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The type of the record.</typeparam>
 		/// <param name="records">The list of records to write.</param>
-		void WriteRecords<T>( IEnumerable<T> records ) where T : class;
+        void WriteRecords<T>(IEnumerable<T> records);
 
 		/// <summary>
 		/// Writes the list of records to the CSV file.
@@ -120,7 +120,7 @@ namespace CsvHelper
 		/// record cache.
 		/// </summary>
 		/// <typeparam name="T">The record type.</typeparam>
-		void ClearRecordCache<T>() where T : class;
+		void ClearRecordCache<T>();
 
 		/// <summary>
 		/// Clears the record cache for the given type. After <see cref="WriteRecord{T}"/> is called the


### PR DESCRIPTION
Since value types can never be null, the conditional that checks to see if a type converted value is null only needs to be added to the delegate if the type is a class. Also removed the where T: class constraints from everywhere.
