### PR TITLE
Made RegisterClassMap overload that takes CsvClassMap instance public

### DIFF
--- a/src/CsvHelper.Tests/CsvConfigurationTests.cs
+++ b/src/CsvHelper.Tests/CsvConfigurationTests.cs
@@ -62,6 +62,15 @@ namespace CsvHelper.Tests
 			Assert.AreEqual( 2, config.Maps[typeof( TestClass )].PropertyMaps.Count );
 		}
 
+        [TestMethod]
+        public void AddingMappingsWithInstanceMethodTest()
+        {
+            var config = new CsvConfiguration();
+            config.RegisterClassMap(new TestClassMappings());
+
+            Assert.AreEqual(2, config.Maps[typeof(TestClass)].PropertyMaps.Count);
+        }
+
 		[TestMethod]
 		public void RegisterClassMapGenericTest()
 		{
@@ -81,6 +90,16 @@ namespace CsvHelper.Tests
 			config.RegisterClassMap( typeof( TestClassMappings ) );
 			Assert.IsNotNull( config.Maps[typeof( TestClass )] );
 		}
+
+        [TestMethod]
+        public void RegisterClassInstanceTest()
+        {
+            var config = new CsvConfiguration();
+
+            Assert.IsNull(config.Maps[typeof(TestClass)]);
+            config.RegisterClassMap(new TestClassMappings());
+            Assert.IsNotNull(config.Maps[typeof(TestClass)]);
+        }
 
 		[TestMethod]
 		public void UnregisterClassMapGenericTest()

--- a/src/CsvHelper.sln.DotSettings
+++ b/src/CsvHelper.sln.DotSettings
@@ -69,4 +69,6 @@ http://csvhelper.com&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/EventHandlerPatternLong/@EntryValue">$object$_On$event$</s:String>
-	<s:Boolean x:Key="/Default/Environment/SearchAndNavigation/NavigateByControlClick/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Environment/SearchAndNavigation/NavigateByControlClick/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
+	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String></wpf:ResourceDictionary>

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -347,7 +347,7 @@ namespace CsvHelper.Configuration
 		/// Registers the class map.
 		/// </summary>
 		/// <param name="map">The class map to register.</param>
-		protected virtual void RegisterClassMap( CsvClassMap map )
+		public virtual void RegisterClassMap( CsvClassMap map )
 		{
 			map.CreateMap();
 


### PR DESCRIPTION
The `RegisterClassMap` overload that takes a `CsvClassMap` instance was `protected`. This had the unfortunate effect that I could not control the creation of that instance myself, the creation was done inside the `CsvConfiguration` class. I need to be able to provide an instance myself to support dependency-injection in my code, as I want to be able to create a `CsvClassMap` instance in which fields are injected through an IoC container.

I have also added test methods that verify that the behavior is still correct.
