### PR TITLE
Added Row property to ICsvReader

### DIFF
--- a/src/CsvHelper.Tests/CsvReaderTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderTests.cs
@@ -950,6 +950,25 @@ namespace CsvHelper.Tests
 			Assert.AreEqual( 1, reader.GetField<int>( 0 ) );
 		}
 
+        [TestMethod]
+        public void RowTest()
+        {
+            var queue = new Queue<string[]>();
+            queue.Enqueue(new[] { "1", "one" });
+            queue.Enqueue(new[] { "2", "two" });
+
+            var parserMock = new ParserMock(queue);
+            parserMock.Configuration.HasHeaderRecord = false;
+
+            var csv = new CsvReader(parserMock);
+            
+            csv.Read();
+            Assert.AreEqual(1, csv.Row);
+
+            csv.Read();
+            Assert.AreEqual(2, csv.Row);
+        }
+
 #if !NET_3_5 && !WINDOWS_PHONE_7
 		[TestMethod]
 		public void ReaderDynamicHasHeaderTest()

--- a/src/CsvHelper.Tests/Mocks/ParserMock.cs
+++ b/src/CsvHelper.Tests/Mocks/ParserMock.cs
@@ -30,6 +30,7 @@ namespace CsvHelper.Tests.Mocks
 
 		public string[] Read()
 		{
+		    ++Row;
 			return rows.Dequeue();
 		}
 	}

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -88,7 +88,21 @@ namespace CsvHelper
 			}
 		}
 
-		/// <summary>
+        /// <summary>
+        /// Gets the current row.
+        /// </summary>
+	    public int Row
+	    {
+	        get
+	        {
+                CheckDisposed();
+                CheckHasBeenRead();
+
+	            return parser.Row;
+	        }
+	    }
+
+	    /// <summary>
 		/// Creates a new CSV reader using the given <see cref="TextReader"/> and
 		/// <see cref="CsvParser"/> as the default parser.
 		/// </summary>

--- a/src/CsvHelper/ICsvReaderRow.cs
+++ b/src/CsvHelper/ICsvReaderRow.cs
@@ -19,7 +19,12 @@ namespace CsvHelper
 		/// <summary>
 		/// Get the current record;
 		/// </summary>
-		string[] CurrentRecord { get; }
+        string[] CurrentRecord { get; }
+
+        /// <summary>
+        /// Gets the current row.
+        /// </summary>
+        int Row { get; }
 
 		/// <summary>
 		/// Gets the raw field at position (column) index.


### PR DESCRIPTION
The Row property was not available from the `ICsvReader` interface. This fixes issue #172 
