### PR TITLE
config option to write a final delimiter after last field

### DIFF
--- a/src/CsvHelper.Tests/CsvWriterTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterTests.cs
@@ -75,6 +75,33 @@ namespace CsvHelper.Tests
 
 			Assert.AreEqual( expected, csvFile );
 		}
+        
+        [TestMethod]
+		public void WriteRecordWithDelimiterAfterLastFieldTestTest()
+		{
+			var record = new TestRecord
+			{
+				IntColumn = 1,
+				StringColumn = "string column",
+				IgnoredColumn = "ignored column",
+				FirstColumn = "first column",
+			};
+
+			var stream = new MemoryStream();
+			var writer = new StreamWriter( stream ) { AutoFlush = true };
+			var csv = new CsvWriter( writer );
+            csv.Configuration.DelimiterAfterLastField = true;
+			csv.Configuration.RegisterClassMap<TestRecordMap>();
+
+			csv.WriteRecord( record );
+
+			stream.Position = 0;
+			var reader = new StreamReader( stream );
+			var csvFile = reader.ReadToEnd();
+			var expected = "first column,1,string column,test,\r\n";
+
+			Assert.AreEqual( expected, csvFile );
+		}
 
 		[TestMethod]
 		public void WriteRecordNoIndexesTest()

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -308,6 +308,8 @@ namespace CsvHelper.Configuration
 		/// </summary>
 		public virtual bool IgnorePrivateAccessor { get; set; }
 
+        public virtual bool DelimiterAfterLastField { get; set; }
+
 #if !NET_2_0
 		/// <summary>
 		/// Gets or sets a value indicating whether

--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -220,6 +220,8 @@ namespace CsvHelper
 			CheckDisposed();
 
 			var record = string.Join( configuration.Delimiter, currentRecord.ToArray() );
+		    if( configuration.DelimiterAfterLastField )
+		        record += configuration.Delimiter;
 			writer.WriteLine( record );
 			currentRecord.Clear();
 		}


### PR DESCRIPTION
Hey,

I needed an option to add one final delimiter after the last field in the record (or header). I thought somebody else might find it useful so I created a pull request.
Any chance of pulling it?

Thanks in advance!
