### PR TITLE
Custom exceptions to give more information about error

### DIFF
--- a/src/CsvHelper.Tests/CsvHelper.Tests.csproj
+++ b/src/CsvHelper.Tests/CsvHelper.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="TypeConversion\DateTimeConverterTests.cs" />
     <Compile Include="TypeConversion\EnumerableConverterTests.cs" />
     <Compile Include="TypeConversion\TimeSpanConverterTests.cs" />
+    <Compile Include="TypeConversion\TypeConverterExceptionTests.cs" />
     <Compile Include="TypeConversion\TypeConverterFactoryTests.cs" />
     <Compile Include="TypeConversion\TypeConverterOptionsFactoryTests.cs" />
     <Compile Include="TypeConversion\TypeConverterTests.cs" />

--- a/src/CsvHelper.Tests/CsvReaderErrorMessageTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderErrorMessageTests.cs
@@ -193,7 +193,7 @@ namespace CsvHelper.Tests
 					csvReader.Configuration.RegisterClassMap<Test3Map>();
 					var records = csvReader.GetRecords<Test3>().ToList();
 				}
-				catch( CsvReaderException )
+				catch (CsvTypeConverterException)
 				{
 					// Should throw this exception.
 				}

--- a/src/CsvHelper.Tests/TypeConversion/DateTimeConverterTests.cs
+++ b/src/CsvHelper.Tests/TypeConversion/DateTimeConverterTests.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Globalization;
 using CsvHelper.TypeConversion;
+
+using Microsoft.SqlServer.Server;
 #if WINRT_4_5
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 #else
@@ -59,6 +61,52 @@ namespace CsvHelper.Tests.TypeConversion
 			}
 			catch( CsvTypeConverterException )
 			{
+			}
+		}
+
+		[TestMethod]
+		public void ShouldThrowTypeConversionExceptionThatContainsData()
+		{
+			var converter = new DateTimeConverter();
+			var typeConverterOptions = new TypeConverterOptions();
+			typeConverterOptions.CultureInfo = new CultureInfo("en-US");
+
+			try
+			{
+				converter.ConvertFromString(typeConverterOptions, "18-12-2014");
+				Assert.Fail();
+			}
+			catch (CsvTypeConverterException exception)
+			{
+				Assert.AreEqual("Exception while parsing value [18-12-2014] to a date. Using Culture [en-US].", exception.Message);
+				Assert.IsInstanceOfType(exception.InnerException, typeof(FormatException));
+			}
+			catch (Exception)
+			{
+				Assert.Fail();
+			}
+		}
+
+		[TestMethod]
+		public void ShouldThrowTypeConversionExceptionThatContainsDataWithFormatOptions()
+		{
+			var converter = new DateTimeConverter();
+			var typeConverterOptions = new TypeConverterOptions();
+			typeConverterOptions.CultureInfo = new CultureInfo("en-US");
+			typeConverterOptions.Format = "yyyyddMM";
+			try
+			{
+				converter.ConvertFromString(typeConverterOptions, "18-12-2014");
+				Assert.Fail();
+			}
+			catch (CsvTypeConverterException exception)
+			{
+				Assert.AreEqual("Exception while parsing value [18-12-2014] to a date. Using Culture [en-US]. Using option format [yyyyddMM]", exception.Message);
+				Assert.IsInstanceOfType(exception.InnerException, typeof(FormatException));
+			}
+			catch (Exception)
+			{
+				Assert.Fail();
 			}
 		}
 

--- a/src/CsvHelper.Tests/TypeConversion/DateTimeConverterTests.cs
+++ b/src/CsvHelper.Tests/TypeConversion/DateTimeConverterTests.cs
@@ -153,7 +153,7 @@ namespace CsvHelper.Tests.TypeConversion
 			{
 				converter.ConvertFromString( typeConverterOptions, "blah" );
 			}
-			catch( FormatException ){}
+			catch (CsvTypeConverterException) { }
 		}
 #endif
 	}

--- a/src/CsvHelper.Tests/TypeConversion/TypeConverterExceptionTests.cs
+++ b/src/CsvHelper.Tests/TypeConversion/TypeConverterExceptionTests.cs
@@ -1,0 +1,34 @@
+﻿using System.Globalization;
+
+using CsvHelper.TypeConversion;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CsvHelper.Tests.TypeConversion
+{
+	[TestClass]
+	public class TypeConverterExceptionTests
+	{
+		[TestMethod]
+		public void ConvertToStringTest()
+		{
+			var converter = new Int16Converter();
+			var typeConverterOptions = new TypeConverterOptions
+			{
+				CultureInfo = new CultureInfo("en-US")
+			};
+
+			try
+			{
+				converter.ConvertFromString(typeConverterOptions, "not an int");
+				Assert.Fail();
+			}
+			catch (CsvTypeConverterException csvTypeConverterException)
+			{
+				Assert.AreEqual("The conversion of value [not an int] using converter [CsvHelper.TypeConversion.Int16Converter] cannot be performed. Using CultureInfo [en-US]", csvTypeConverterException.Message);
+			}
+			
+		}
+
+	}
+}

--- a/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
+++ b/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
@@ -17,6 +17,8 @@ namespace CsvHelper.Tests.TypeConversion
 	[TestClass]
 	public class TypeConverterOptionsFactoryTests
 	{
+		private static CultureInfo _englishUsCultureInfo = new CultureInfo("en-US");
+
 		[TestMethod]
 		public void AddGetRemoveTest()
 		{
@@ -39,7 +41,7 @@ namespace CsvHelper.Tests.TypeConversion
 		[TestMethod]
 		public void GetFieldTest()
 		{
-			var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
+			var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands, CultureInfo = _englishUsCultureInfo };
 			TypeConverterOptionsFactory.AddOptions<int>( options );
 
 			using( var stream = new MemoryStream() )
@@ -61,7 +63,7 @@ namespace CsvHelper.Tests.TypeConversion
 		[TestMethod]
 		public void GetRecordsTest()
 		{
-			var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
+			var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands, CultureInfo = _englishUsCultureInfo };
 			TypeConverterOptionsFactory.AddOptions<int>( options );
 
 			using( var stream = new MemoryStream() )
@@ -72,7 +74,8 @@ namespace CsvHelper.Tests.TypeConversion
 				writer.WriteLine( "\"1,234\",\"5,678\"" );
 				writer.Flush();
 				stream.Position = 0;
-
+				
+				csvReader.Configuration.CultureInfo = _englishUsCultureInfo;
 				csvReader.Configuration.HasHeaderRecord = false;
 				csvReader.GetRecords<Test>().ToList();
 			}
@@ -94,6 +97,7 @@ namespace CsvHelper.Tests.TypeConversion
 				stream.Position = 0;
 
 				csvReader.Configuration.HasHeaderRecord = false;
+				csvReader.Configuration.CultureInfo = _englishUsCultureInfo;
 				csvReader.Configuration.RegisterClassMap<TestMap>();
 				csvReader.GetRecords<Test>().ToList();
 			}
@@ -102,7 +106,7 @@ namespace CsvHelper.Tests.TypeConversion
 		[TestMethod]
 		public void WriteFieldTest()
 		{
-			var options = new TypeConverterOptions { Format = "c" };
+			var options = new TypeConverterOptions { Format = "c", CultureInfo = _englishUsCultureInfo };
 			TypeConverterOptionsFactory.AddOptions<int>( options );
 
 			using( var stream = new MemoryStream() )
@@ -123,7 +127,7 @@ namespace CsvHelper.Tests.TypeConversion
 		[TestMethod]
 		public void WriteRecordsTest()
 		{
-			var options = new TypeConverterOptions { Format = "c" };
+			var options = new TypeConverterOptions { Format = "c", CultureInfo = _englishUsCultureInfo };
 			TypeConverterOptionsFactory.AddOptions<int>( options );
 
 			using( var stream = new MemoryStream() )
@@ -135,6 +139,7 @@ namespace CsvHelper.Tests.TypeConversion
 				{
 					new Test { Number = 1234, NumberOverridenInMap = 5678 },
 				};
+				csvWriter.Configuration.CultureInfo = _englishUsCultureInfo;
 				csvWriter.Configuration.HasHeaderRecord = false;
 				csvWriter.WriteRecords( list );
 				writer.Flush();
@@ -148,7 +153,7 @@ namespace CsvHelper.Tests.TypeConversion
 		[TestMethod]
 		public void WriteRecordsAppliedWhenMappedTest()
 		{
-			var options = new TypeConverterOptions { Format = "c" };
+			var options = new TypeConverterOptions { Format = "c", CultureInfo = _englishUsCultureInfo };
 			TypeConverterOptionsFactory.AddOptions<int>( options );
 
 			using( var stream = new MemoryStream() )
@@ -160,6 +165,7 @@ namespace CsvHelper.Tests.TypeConversion
 				{
 					new Test { Number = 1234, NumberOverridenInMap = 5678 },
 				};
+				csvWriter.Configuration.CultureInfo = _englishUsCultureInfo;
 				csvWriter.Configuration.HasHeaderRecord = false;
 				csvWriter.Configuration.RegisterClassMap<TestMap>();
 				csvWriter.WriteRecords( list );

--- a/src/CsvHelper/TypeConversion/DateTimeConverter.cs
+++ b/src/CsvHelper/TypeConversion/DateTimeConverter.cs
@@ -20,6 +20,8 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object ConvertFromString( TypeConverterOptions options, string text )
 		{
+			try
+			{
 			if( text == null )
 			{
 				return base.ConvertFromString( options, null );
@@ -36,6 +38,17 @@ namespace CsvHelper.TypeConversion
 			return string.IsNullOrEmpty( options.Format )
 				? DateTime.Parse( text, formatProvider, dateTimeStyle )
 				: DateTime.ParseExact( text, options.Format, formatProvider, dateTimeStyle );
+			}
+			catch (Exception exception)
+			{
+				string errormessage = string.Format("Exception while parsing value [{0}] to a date. Using Culture [{1}].", text, options.CultureInfo);
+				if (!string.IsNullOrEmpty(options.Format))
+				{
+					errormessage += string.Format(" Using option format [{0}]", options.Format);
+				}
+
+				throw new CsvTypeConverterException(errormessage, exception);
+			}
 		}
 
 		/// <summary>

--- a/src/CsvHelper/TypeConversion/DefaultTypeConverter.cs
+++ b/src/CsvHelper/TypeConversion/DefaultTypeConverter.cs
@@ -42,7 +42,7 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public virtual object ConvertFromString( TypeConverterOptions options, string text )
 		{
-			throw new CsvTypeConverterException( "The conversion cannot be performed." );
+			throw new CsvTypeConverterException( string.Format("The conversion of value [{0}] using converter [{1}] cannot be performed. Using CultureInfo [{2}]", text, this, options.CultureInfo) );
 		}
 
 		/// <summary>


### PR DESCRIPTION
Catch exception when parsing date, store the parsed value and culture in
exception before rethrowing.

I'm aware that this breaks some existing test, but before implementing this on all typeconverters and fixing all the tests i'm wondering how you feel about using this solution in you codebase.

I started this because i got an error about parsing a datetime on our buildserver, which did not occure local, and gave me little information about what was going on.