### PR TITLE
Fix CsvParser.Row when IgnoreBlank & SkipLines are false

### DIFF
--- a/src/CsvHelper.Tests/CsvParserTests.cs
+++ b/src/CsvHelper.Tests/CsvParserTests.cs
@@ -777,6 +777,45 @@ namespace CsvHelper.Tests
 		}
 
 		[TestMethod]
+		public void RowWithBlanksAndEmptyDontSkipBlankAndEmptyTest()
+		{
+			using( var stream = new MemoryStream() )
+			using( var writer = new StreamWriter( stream ) )
+			using( var reader = new StreamReader( stream ) )
+			using( var csvReader = new CsvReader( reader ) )
+			{
+				csvReader.Configuration.IgnoreBlankLines = false;
+				csvReader.Configuration.SkipEmptyRecords = false;
+				writer.WriteLine( "StringColumn,IntColumn" );
+				writer.WriteLine( "s,2" );
+				writer.WriteLine( "," );
+				writer.WriteLine( "s,4" );
+				writer.WriteLine();
+				writer.WriteLine( "s,6" );
+				writer.Flush();
+				stream.Position = 0;
+
+				csvReader.Read();
+				Assert.AreEqual( 2, csvReader.Row );
+				Assert.AreEqual( 2, csvReader.GetField<int>( 1 ) );
+
+				csvReader.Read();
+				Assert.AreEqual( 3, csvReader.Row );
+
+				csvReader.Read();
+				Assert.AreEqual( 4, csvReader.Row );
+				Assert.AreEqual( 4, csvReader.GetField<int>( 1 ) );
+
+				csvReader.Read();
+				Assert.AreEqual( 5, csvReader.Row );
+
+				csvReader.Read();
+				Assert.AreEqual( 6, csvReader.Row );
+				Assert.AreEqual( 6, csvReader.GetField<int>( 1 ) );
+			}
+		}
+
+		[TestMethod]
 		public void RowCommentLinesTest()
 		{
 			using( var stream = new MemoryStream() )

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -392,12 +392,13 @@ namespace CsvHelper
 
 						fieldStartPosition = readerBufferPosition;
 						inComment = false;
-						currentRow++;
 
 						if( !configuration.IgnoreBlankLines )
 						{
 							break;
 						}
+
+						currentRow++;
 
 						continue;
 					}


### PR DESCRIPTION
Add Test. Verified all tests are passing.

This may be related to #254.