### PR TITLE
Add CsvClassAttribute

### DIFF
--- a/src/CsvHelper.Tests/CsvClassMappingAutoMapTests.cs
+++ b/src/CsvHelper.Tests/CsvClassMappingAutoMapTests.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 using CsvHelper.Configuration;
+using CsvHelper.Attributes;
 
 namespace CsvHelper.Tests
 {
@@ -27,6 +28,33 @@ namespace CsvHelper.Tests
 
 			Assert.AreEqual( 1, aMap.ReferenceMaps.Count );
 		}
+
+
+        [TestMethod]
+        public void TestCsvClass()
+        {
+            var aMap = new CMap();
+
+            Assert.AreEqual(3, aMap.PropertyMaps.Count);
+            Assert.AreEqual(0, aMap.PropertyMaps[0].Data.Index);
+            Assert.AreEqual(1, aMap.PropertyMaps[1].Data.Index);
+            Assert.AreEqual("IntColumnInCsv", aMap.PropertyMaps[1].Data.Names);
+            Assert.AreEqual(2, aMap.PropertyMaps[2].Data.Index);
+            Assert.AreEqual("GuidColumnInCsv", aMap.PropertyMaps[2].Data.Names);
+        }
+        
+        [TestMethod]
+        public void TestCsvProperty()
+        {
+            var aMap = new DMap();
+
+            Assert.AreEqual(3, aMap.PropertyMaps.Count);
+            Assert.AreEqual(0, aMap.PropertyMaps[0].Data.Index);
+            Assert.AreEqual(1, aMap.PropertyMaps[1].Data.Index);
+            Assert.AreEqual("IntColumnInCsv", aMap.PropertyMaps[1].Data.Names);
+            Assert.AreEqual(2, aMap.PropertyMaps[2].Data.Index);
+            Assert.AreEqual("GuidColumnInCsv", aMap.PropertyMaps[2].Data.Names);
+        }
 
 		private class A
 		{
@@ -60,5 +88,56 @@ namespace CsvHelper.Tests
 		private sealed class BMap : CsvClassMap<B>
 		{
 		}
+
+        [CsvClass]
+        private class C
+        {
+            [CsvProperty]
+            public string StringColumn { get; set; }
+
+            [CsvProperty("IntColumnInCsv")]
+            public int IntColumn { get; set; }
+
+            [CsvProperty("GuidColumnInCsv")]
+            public Guid GuidColumn { get; set; }
+
+            public string NotUsedColumn
+            {
+                get;
+                set;
+            }
+
+            private sealed class CMap : CsvClassMap<C>
+            {
+                public CMap()
+                {
+                    AutoMap();
+                }
+            }
+
+            private class D
+            {
+                public string NotUsedColumn1 { get; set; }
+
+                [CsvProperty]
+                public string StringColumn { get; set; }
+
+                [CsvProperty("IntColumnInCsv")]
+                public int IntColumn { get; set; }
+
+                [CsvProperty("GuidColumnInCsv")]
+                public Guid GuidColumn { get; set; }
+
+                public string NotUsedColumn2 { get; set; }
+            }
+
+            private sealed class DMap : CsvClassMap<D>
+            {
+                public DMap()
+                {
+                    AutoMap();
+                }
+            }
+        }
 	}
 }

--- a/src/CsvHelper.Tests/CsvClassMappingAutoMapTests.cs
+++ b/src/CsvHelper.Tests/CsvClassMappingAutoMapTests.cs
@@ -12,22 +12,22 @@ using CsvHelper.Attributes;
 
 namespace CsvHelper.Tests
 {
-	[TestClass]
-	public class CsvClassMappingAutoMapTests
-	{
-		[TestMethod]
-		public void Test()
-		{
-			var aMap = new AMap();
+    [TestClass]
+    public class CsvClassMappingAutoMapTests
+    {
+        [TestMethod]
+        public void Test()
+        {
+            var aMap = new AMap();
 
-			Assert.AreEqual( 3, aMap.PropertyMaps.Count );
-			Assert.AreEqual( 0, aMap.PropertyMaps[0].Data.Index );
-			Assert.AreEqual( 1, aMap.PropertyMaps[1].Data.Index );
-			Assert.AreEqual( 2, aMap.PropertyMaps[2].Data.Index );
-			Assert.AreEqual( true, aMap.PropertyMaps[2].Data.Ignore );
+            Assert.AreEqual(3, aMap.PropertyMaps.Count);
+            Assert.AreEqual(0, aMap.PropertyMaps[0].Data.Index);
+            Assert.AreEqual(1, aMap.PropertyMaps[1].Data.Index);
+            Assert.AreEqual(2, aMap.PropertyMaps[2].Data.Index);
+            Assert.AreEqual(true, aMap.PropertyMaps[2].Data.Ignore);
 
-			Assert.AreEqual( 1, aMap.ReferenceMaps.Count );
-		}
+            Assert.AreEqual(1, aMap.ReferenceMaps.Count);
+        }
 
 
         [TestMethod]
@@ -42,7 +42,7 @@ namespace CsvHelper.Tests
             Assert.AreEqual(2, aMap.PropertyMaps[2].Data.Index);
             Assert.AreEqual("GuidColumnInCsv", aMap.PropertyMaps[2].Data.Names);
         }
-        
+
         [TestMethod]
         public void TestCsvProperty()
         {
@@ -56,38 +56,38 @@ namespace CsvHelper.Tests
             Assert.AreEqual("GuidColumnInCsv", aMap.PropertyMaps[2].Data.Names);
         }
 
-		private class A
-		{
-			public int One { get; set; }
+        private class A
+        {
+            public int One { get; set; }
 
-			public int Two { get; set; }
+            public int Two { get; set; }
 
-			public int Three { get; set; }
+            public int Three { get; set; }
 
-			public B B { get; set; }
-		}
+            public B B { get; set; }
+        }
 
-		private class B
-		{
-			public int Four { get; set; }
+        private class B
+        {
+            public int Four { get; set; }
 
-			public int Five { get; set; }
+            public int Five { get; set; }
 
-			public int Six { get; set; }
-		}
+            public int Six { get; set; }
+        }
 
-		private sealed class AMap : CsvClassMap<A>
-		{
-			public AMap()
-			{
-				AutoMap();
-				Map( m => m.Three ).Ignore();
-			}
-		}
+        private sealed class AMap : CsvClassMap<A>
+        {
+            public AMap()
+            {
+                AutoMap();
+                Map(m => m.Three).Ignore();
+            }
+        }
 
-		private sealed class BMap : CsvClassMap<B>
-		{
-		}
+        private sealed class BMap : CsvClassMap<B>
+        {
+        }
 
         [CsvClass]
         private class C
@@ -106,38 +106,37 @@ namespace CsvHelper.Tests
                 get;
                 set;
             }
-
-            private sealed class CMap : CsvClassMap<C>
+        }
+        private sealed class CMap : CsvClassMap<C>
+        {
+            public CMap()
             {
-                public CMap()
-                {
-                    AutoMap();
-                }
-            }
-
-            private class D
-            {
-                public string NotUsedColumn1 { get; set; }
-
-                [CsvProperty]
-                public string StringColumn { get; set; }
-
-                [CsvProperty("IntColumnInCsv")]
-                public int IntColumn { get; set; }
-
-                [CsvProperty("GuidColumnInCsv")]
-                public Guid GuidColumn { get; set; }
-
-                public string NotUsedColumn2 { get; set; }
-            }
-
-            private sealed class DMap : CsvClassMap<D>
-            {
-                public DMap()
-                {
-                    AutoMap();
-                }
+                AutoMap();
             }
         }
-	}
+
+        private class D
+        {
+            public string NotUsedColumn1 { get; set; }
+
+            [CsvProperty]
+            public string StringColumn { get; set; }
+
+            [CsvProperty("IntColumnInCsv")]
+            public int IntColumn { get; set; }
+
+            [CsvProperty("GuidColumnInCsv")]
+            public Guid GuidColumn { get; set; }
+
+            public string NotUsedColumn2 { get; set; }
+        }
+
+        private sealed class DMap : CsvClassMap<D>
+        {
+            public DMap()
+            {
+                AutoMap();
+            }
+        }
+    }
 }

--- a/src/CsvHelper.Tests/CsvClassMappingTests.cs
+++ b/src/CsvHelper.Tests/CsvClassMappingTests.cs
@@ -185,7 +185,7 @@ namespace CsvHelper.Tests
 				StringColumn = stringColumn;
 			}
 		}
-		
+
 		private sealed class TestMappingConstructorClass : CsvClassMap<TestClass>
 		{
 			public TestMappingConstructorClass()

--- a/src/CsvHelper/Attributes/CsvClassAttribute.cs
+++ b/src/CsvHelper/Attributes/CsvClassAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace CsvHelper.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class CsvClassAttribute : System.Attribute
+    {
+    }
+}

--- a/src/CsvHelper/Attributes/CsvPropertyAttribute.cs
+++ b/src/CsvHelper/Attributes/CsvPropertyAttribute.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace CsvHelper.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class CsvPropertyAttribute : System.Attribute
+    {
+        public readonly string[] ColumnToMapNames;
+
+        public bool HasDifferentNames
+        {
+            get
+            {
+                return ColumnToMapNames != null;
+            }
+        }
+
+        public CsvPropertyAttribute()
+        {
+        }
+
+        public CsvPropertyAttribute(string columnToMapName)
+        {
+            ColumnToMapNames = new string[] { columnToMapName };
+        }
+
+        public CsvPropertyAttribute(string[] columnToMapNames)
+        {
+            ColumnToMapNames = columnToMapNames;
+        }
+    }
+}

--- a/src/CsvHelper/Configuration/CsvClassMap.cs
+++ b/src/CsvHelper/Configuration/CsvClassMap.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using CsvHelper.TypeConversion;
+using CsvHelper.Attributes;
 
 namespace CsvHelper.Configuration
 {
@@ -135,6 +136,8 @@ namespace CsvHelper.Configuration
 		internal static void AutoMapInternal( CsvClassMap map, bool ignoreReferences, bool prefixReferenceHeaders, LinkedList<Type> mapParents, int indexStart = 0 )
 		{
 			var type = map.GetType().BaseType.GetGenericArguments()[0];
+            var attributes = type.GetCustomAttributes(true);
+            var isCsvClassMappedWithAttributes = attributes.Any(attr => attr is CsvClassAttribute);
 			if( typeof( IEnumerable ).IsAssignableFrom( type ) )
 			{
 				throw new CsvConfigurationException( "Types that inhererit IEnumerable cannot be auto mapped. " +
@@ -148,6 +151,27 @@ namespace CsvHelper.Configuration
 			{
 				var isDefaultConverter = TypeConverterFactory.GetConverter( property.PropertyType ).GetType() == typeof( DefaultTypeConverter );
 				var hasDefaultConstructor = property.PropertyType.GetConstructor( new Type[0] ) != null;
+
+                var csvPropertyAttribute = GetForCsvPropertyAttribute(property);
+
+                if (csvPropertyAttribute != null)
+                {
+                    if (!isCsvClassMappedWithAttributes)
+                    {
+                        //Turn Csv attributes mode on 
+                        isCsvClassMappedWithAttributes = true;
+                        map.ReferenceMaps.Clear();
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+                else if (isCsvClassMappedWithAttributes)
+                {
+                    continue;
+                }
+
 				if( isDefaultConverter && hasDefaultConstructor )
 				{
 					if( ignoreReferences )
@@ -166,6 +190,7 @@ namespace CsvHelper.Configuration
 					mapParents.AddLast( type );
 					var refMapType = typeof( DefaultCsvClassMap<> ).MakeGenericType( property.PropertyType );
 					var refMap = (CsvClassMap)ReflectionHelper.CreateInstance( refMapType );
+
 					AutoMapInternal( refMap, false, prefixReferenceHeaders, mapParents, map.GetMaxIndex() + 1 );
 
 					if( prefixReferenceHeaders )
@@ -188,6 +213,12 @@ namespace CsvHelper.Configuration
 				{
 					var propertyMap = new CsvPropertyMap( property );
 					propertyMap.Data.Index = map.GetMaxIndex() + 1;
+
+                    if (csvPropertyAttribute != null && csvPropertyAttribute.HasDifferentNames)
+                    {
+                        propertyMap.Name(csvPropertyAttribute.ColumnToMapNames);
+                    }
+
 					if( propertyMap.Data.TypeConverter.CanConvertFrom( typeof( string ) ) ||
 						propertyMap.Data.TypeConverter.CanConvertTo( typeof( string ) ) && !isDefaultConverter )
 					{
@@ -201,6 +232,16 @@ namespace CsvHelper.Configuration
 
 			map.ReIndex( indexStart );
 		}
+
+        /// <summary>
+        /// Get CsvPropertyAttribute data for current property
+        /// </summary>
+        /// <param name="type">Type of property to check the attribute</param>
+        /// <returns>CsvPropertyAttribute object if it's found, or null if attribute wasn't set.</returns>
+        private static CsvPropertyAttribute GetForCsvPropertyAttribute(PropertyInfo property)
+        {
+            return property.PropertyType.GetCustomAttributes(true).FirstOrDefault(attr => attr is CsvPropertyAttribute) as CsvPropertyAttribute;
+        }
 
 		/// <summary>
 		/// Checks for circular references.

--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -69,6 +69,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\CsvClassAttribute.cs" />
+    <Compile Include="Attributes\CsvPropertyAttribute.cs" />
     <Compile Include="Configuration\DefaultCsvClassMap`1.cs" />
     <Compile Include="Configuration\CsvClassMap`1.cs" />
     <Compile Include="Configuration\CsvConfigurationException.cs" />
@@ -148,6 +150,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Using this wonderful lib, I've got an idea of marking the class properties not only with maps, but with attributes (see example in CsvClassMappingAutoMapTests.cs). I think, it will make lib even easier to use - you can map different titles even without using Mapping class.

The logic of attribute is same as abstract keyword in C#:
- if class is marked as CsvClass, only properties with CsvProperty attribute are mapped
- if class has a CsvProperty attribute, it's counted as if it was a CsvClass

I've wrote UnitTest for it, but I couldn't run it :( (I don't know why, VS simply says that I have no unit tests in app).

I think, that attribute can be extended even more (supporting ignore and other commands)