### PR TITLE
Fix bad link to Register Class Map

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@ foreach( var item in list )
 	<h3 id="mapping-fluent-class-mapping">Fluent Class Mapping</h3>
 
 	<p>If your CSV file doesn't match up exactly with your custom class, you can use a fluent class map to set options
-	for how the class maps to the file. You need to <a href="#register-class-map">register your class map</a> in
+	for how the class maps to the file. You need to <a href="#configuration-register-class-map">register your class map</a> in
 	configuration.</p>
 
 	<p><textarea>


### PR DESCRIPTION
The class mapping documentation has a link to the configuration documentation to demonstrate registering the mapping.  However, the anchor used in the link doesn't match.