### PR TITLE
Fixed issue with PropertyInfo compare and interfaces.

### DIFF
--- a/src/CsvHelper.Tests/CsvClassMappingAutoMapTests.cs
+++ b/src/CsvHelper.Tests/CsvClassMappingAutoMapTests.cs
@@ -15,7 +15,7 @@ namespace CsvHelper.Tests
 	public class CsvClassMappingAutoMapTests
 	{
 		[TestMethod]
-		public void Test()
+		public void DirectPropertiesTest()
 		{
 			var aMap = new AMap();
 
@@ -26,6 +26,20 @@ namespace CsvHelper.Tests
 			Assert.AreEqual( true, aMap.PropertyMaps[2].Data.Ignore );
 
 			Assert.AreEqual( 1, aMap.ReferenceMaps.Count );
+		}
+
+		[TestMethod]
+		public void InterfacePropertiesTest()
+		{
+			var cMap = new CMap<C>();
+
+			Assert.AreEqual( 3, cMap.PropertyMaps.Count );
+			Assert.AreEqual( 0, cMap.PropertyMaps[0].Data.Index );
+			Assert.AreEqual( 1, cMap.PropertyMaps[1].Data.Index );
+			Assert.AreEqual( 2, cMap.PropertyMaps[2].Data.Index );
+			Assert.AreEqual( true, cMap.PropertyMaps[1].Data.Ignore );
+
+			Assert.AreEqual( 0, cMap.ReferenceMaps.Count );
 		}
 
 		private class A
@@ -48,6 +62,20 @@ namespace CsvHelper.Tests
 			public int Six { get; set; }
 		}
 
+		private interface IC
+		{
+			int Eight { get; set; }
+		}
+
+		private class C : IC
+		{
+			public int Seven { get; set; }
+
+			public int Eight { get; set; }
+
+			public int Nine { get; set; }
+		}
+
 		private sealed class AMap : CsvClassMap<A>
 		{
 			public AMap()
@@ -59,6 +87,15 @@ namespace CsvHelper.Tests
 
 		private sealed class BMap : CsvClassMap<B>
 		{
+		}
+
+		private sealed class CMap<T> : CsvClassMap<T> where T : IC
+		{
+			public CMap()
+			{
+				AutoMap();
+				Map( m => m.Eight ).Ignore();
+			}
 		}
 	}
 }

--- a/src/CsvHelper.Tests/ReflectionHelperTests.cs
+++ b/src/CsvHelper.Tests/ReflectionHelperTests.cs
@@ -26,6 +26,34 @@ namespace CsvHelper.Tests
 			Assert.AreEqual( "name", test.Name );
 		}
 
+		[TestMethod]
+		public void PropertyInfoAreEqualTests()
+		{
+			var implType = typeof( Implementer );
+			var ifaceType = typeof( IFace );
+
+			var implProp1 = implType.GetProperty( "Prop1" );
+			var ifaceProp1 = ifaceType.GetProperty( "Prop1" );
+			Assert.IsTrue( ReflectionHelper.PropertyInfoAreEqual( implProp1, implProp1 ) );
+			Assert.IsTrue( ReflectionHelper.PropertyInfoAreEqual( implProp1, ifaceProp1 ) );
+			Assert.IsTrue( ReflectionHelper.PropertyInfoAreEqual( ifaceProp1, implProp1 ) );
+
+			var implProp2 = implType.GetProperty( "Prop2" );
+			var ifaceProp2 = ifaceType.GetProperty( "Prop2" );
+			Assert.IsTrue( ReflectionHelper.PropertyInfoAreEqual( implProp2, ifaceProp2 ) );
+			Assert.IsTrue( ReflectionHelper.PropertyInfoAreEqual( ifaceProp2, implProp2 ) );
+			Assert.IsFalse( ReflectionHelper.PropertyInfoAreEqual( implProp1, ifaceProp2 ) );
+			Assert.IsFalse( ReflectionHelper.PropertyInfoAreEqual( implProp2, ifaceProp1 ) );
+
+			var implProp3 = implType.GetProperty( "Prop3" );
+			var ifaceProp3 = ifaceType.GetProperty( "Prop3" );
+			Assert.IsTrue( ReflectionHelper.PropertyInfoAreEqual( implProp3, ifaceProp3 ) );
+
+			var implProp4 = implType.GetProperty( "Prop4" );
+			Assert.IsFalse( ReflectionHelper.PropertyInfoAreEqual( implProp4, ifaceProp1 ) );
+			Assert.IsFalse( ReflectionHelper.PropertyInfoAreEqual( ifaceProp1, implProp4 ) );
+		}
+
 		private class Test
 		{
 			public string Name
@@ -33,5 +61,25 @@ namespace CsvHelper.Tests
 				get { return "name"; }
 			}
 		}
+	}
+
+	interface IFace
+	{
+		int Prop1 { get; set; }
+		int Prop2 { get; }
+		int Prop3 { set; }
+		int Method1();
+		int Method2( int arg );
+	}
+
+	class Implementer : IFace
+	{
+		public int Prop1 { get; set; }
+		public int Prop2 { get; set; }
+		public int Prop3 { get; set; }
+		public int Prop4 { get; set; }
+		public int Method1() { return 0; }
+		public int Method2( int arg ) { return arg; }
+		public int Method3( int arg ) { return arg; }
 	}
 }

--- a/src/CsvHelper/Configuration/CsvClassMap`1.cs
+++ b/src/CsvHelper/Configuration/CsvClassMap`1.cs
@@ -35,7 +35,7 @@ namespace CsvHelper.Configuration
 		{
 			var property = ReflectionHelper.GetProperty( expression );
 	
-			var existingMap = PropertyMaps.SingleOrDefault( m => m.Data.Property == property );
+			var existingMap = PropertyMaps.SingleOrDefault( m => ReflectionHelper.PropertyInfoAreEqual( m.Data.Property, property ) );
 			if( existingMap != null )
 			{
 				return existingMap;


### PR DESCRIPTION
CsvPropertyMap uses PropertyInfo operator== to identify any existing properties matching the fluent expression provided. This equality comparison does not succeed for interface implementations or inherited types. This fix is for interface implementations.
