### PR TITLE
Feature - Reference prefixes when mapping #270

### DIFF
--- a/src/CsvHelper.Tests/CsvHelper.Tests.csproj
+++ b/src/CsvHelper.Tests/CsvHelper.Tests.csproj
@@ -56,6 +56,8 @@
     <Compile Include="ClassMapOrderingTests.cs" />
     <Compile Include="CsvClassMappingAutoMapTests.cs" />
     <Compile Include="CsvParserDelimiterTests.cs" />
+    <Compile Include="CsvReaderReferenceMappingPrefixTests.cs" />
+    <Compile Include="CsvWriterReferenceMappingPrefixTests.cs" />
     <Compile Include="DynamicProxyTests.cs" />
     <Compile Include="ExcelCompatibleTests.cs" />
     <Compile Include="CsvParserRawRecordTests.cs" />

--- a/src/CsvHelper.Tests/CsvReaderReferenceMappingPrefixTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderReferenceMappingPrefixTests.cs
@@ -1,0 +1,98 @@
+﻿// Copyright 2009-2014 Josh Close and Contributors
+// This file is a part of CsvHelper and is licensed under the MS-PL
+// See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html
+// http://csvhelper.com
+using System.IO;
+using System.Linq;
+#if WINRT_4_5
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+using CsvHelper.Configuration;
+
+namespace CsvHelper.Tests
+{
+	[TestClass]
+	public class CsvReaderReferenceMappingPrefixTests
+	{
+		[TestMethod]
+		public void ReferencesWithPrefixTest()
+		{
+			using( var stream = new MemoryStream() )
+			using( var reader = new StreamReader( stream ) )
+			using( var writer = new StreamWriter( stream ) )
+			using( var csv = new CsvReader( reader ) )
+			{
+				csv.Configuration.RegisterClassMap<AMap>();
+
+                writer.WriteLine("Id,BPrefix.Id,CPrefix_CId");
+				writer.WriteLine( "a1,b1,c1" );
+				writer.WriteLine( "a2,b2,c2" );
+				writer.WriteLine( "a3,b3,c3" );
+				writer.WriteLine( "a4,b4,c4" );
+				writer.Flush();
+				stream.Position = 0;
+
+				var list = csv.GetRecords<A>().ToList();
+
+				Assert.IsNotNull( list );
+				Assert.AreEqual( 4, list.Count );
+
+				for( var i = 0; i < 4; i++ )
+				{
+					var rowId = i + 1;
+					var row = list[i];
+					Assert.AreEqual( "a" + rowId, row.Id );
+					Assert.AreEqual( "b" + rowId, row.B.Id );
+					Assert.AreEqual( "c" + rowId, row.B.C.Id );
+				}
+			}
+		}
+
+		private class A
+		{
+			public string Id { get; set; }
+
+			public B B { get; set; }
+		}
+
+		private class B
+		{
+			public string Id { get; set; }
+
+			public C C { get; set; }
+		}
+
+		private class C
+		{
+			public string Id { get; set; }
+		}
+
+		private sealed class AMap : CsvClassMap<A>
+		{
+			public AMap()
+			{
+				Map( m => m.Id );
+                References<BMap>(m => m.B).Prefix("BPrefix.");
+			}
+		}
+
+		private sealed class BMap : CsvClassMap<B>
+		{
+			public BMap()
+			{
+			    Map( m => m.Id );
+                References<CMap>(m => m.C).Prefix("CPrefix_");
+			}
+		}
+
+		private sealed class CMap : CsvClassMap<C>
+		{
+			public CMap()
+			{
+				Map( m => m.Id ).Name( "CId" );
+			}
+		}
+	}
+}

--- a/src/CsvHelper.Tests/CsvWriterReferenceMappingPrefixTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterReferenceMappingPrefixTests.cs
@@ -1,0 +1,111 @@
+﻿// Copyright 2009-2014 Josh Close and Contributors
+// This file is a part of CsvHelper and is licensed under the MS-PL
+// See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html
+// http://csvhelper.com
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using CsvHelper.Configuration;
+#if WINRT_4_5
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+
+namespace CsvHelper.Tests
+{
+	[TestClass]
+	public class CsvWriterReferenceMappingPrefixTests
+	{
+		[TestMethod]
+		public void ReferencesWithPrefixTest()
+		{
+			using( var stream = new MemoryStream() )
+			using( var reader = new StreamReader( stream ) )
+			using( var writer = new StreamWriter( stream ) )
+			using( var csv = new CsvWriter( writer ) )
+			{
+				csv.Configuration.RegisterClassMap<AMap>();
+
+				var list = new List<A>();
+				for( var i = 0; i < 4; i++ )
+				{
+					var row = i + 1;
+					list.Add(
+					         new A
+					         {
+						         Id = "a" + row,
+						         B = new B
+						         {
+							         Id = "b" + row,
+							         C = new C
+							         {
+								         Id = "c" + row
+							         }
+						         }
+					         } );
+				};
+
+				csv.WriteRecords( list );
+				writer.Flush();
+				stream.Position = 0;
+
+				var data = reader.ReadToEnd();
+
+				var expected = new StringBuilder();
+				expected.AppendLine( "Id,BPrefix.Id,CPrefix_CId" );
+				expected.AppendLine( "a1,b1,c1" );
+				expected.AppendLine( "a2,b2,c2" );
+				expected.AppendLine( "a3,b3,c3" );
+				expected.AppendLine( "a4,b4,c4" );
+				Assert.AreEqual( expected.ToString(), data );
+			}
+		}
+
+		private class A
+		{
+			public string Id { get; set; }
+
+			public B B { get; set; }
+		}
+
+		private class B
+		{
+			public string Id { get; set; }
+
+			public C C { get; set; }
+		}
+
+		private class C
+		{
+			public string Id { get; set; }
+		}
+
+		private sealed class AMap : CsvClassMap<A>
+		{
+			public AMap()
+			{
+				Map( m => m.Id );
+				References<BMap>( m => m.B ).Prefix("BPrefix.");
+			}
+		}
+
+		private sealed class BMap : CsvClassMap<B>
+		{
+			public BMap()
+			{
+			    Map( m => m.Id );
+				References<CMap>( m => m.C ).Prefix("CPrefix_");
+			}
+		}
+
+		private sealed class CMap : CsvClassMap<C>
+		{
+			public CMap()
+			{
+                Map(m => m.Id).Name("CId");
+			}
+		}
+	}
+}

--- a/src/CsvHelper/Configuration/CsvPropertyReferenceMap.cs
+++ b/src/CsvHelper/Configuration/CsvPropertyReferenceMap.cs
@@ -27,6 +27,11 @@ namespace CsvHelper.Configuration
 		/// </summary>
 		public CsvClassMap Mapping { get; protected set; }
 
+        /// <summary>
+        /// Gets the prefix for the reference property
+        /// </summary>
+        public string FieldPrefix { get; protected set; }
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="CsvPropertyReferenceMap"/> class.
 		/// </summary>
@@ -42,6 +47,36 @@ namespace CsvHelper.Configuration
 			this.property = property;
 			Mapping = mapping;
 		}
+
+        /// <summary>
+        /// Appends a prefix to the header of each field of the reference property
+        /// </summary>
+        /// <param name="prefix">The prefix to be prepended to headers of each reference property</param>
+        /// <returns>The current <see cref="CsvPropertyReferenceMap" /></returns>
+        public CsvPropertyReferenceMap Prefix(string prefix)
+        {
+            if (String.IsNullOrEmpty(prefix))
+            {
+                throw new ArgumentNullException("prefix");
+            }
+
+            if (!String.IsNullOrEmpty(FieldPrefix))
+            {
+                throw new InvalidOperationException(String.Format("Prefix has already been set to {0}. You can only set the prefix once.", FieldPrefix));
+            }
+
+            FieldPrefix = prefix;
+
+            foreach (var propertyMap in Mapping.PropertyMaps)
+            {
+                for (var i = 0; i < propertyMap.Data.Names.Count; i++)
+                {
+                    propertyMap.Data.Names[i] = string.Format("{0}{1}", prefix, propertyMap.Data.Names[i]);
+                }
+            }
+
+            return this;
+        }
 
 		/// <summary>
 		/// Get the largest index for the


### PR DESCRIPTION
Added .Prefix() method to CsvPropertyReferenceMap so that reference
properties could have their fields prefixed if needed.

Note: Initially I used the same style as for PrefixReferenceHeaders in
CsvConfiguration, using the format [Prefix].[FieldName]. However, I
removed the '.' separator as this made it less flexible than simply
allowing the user to determine their own prefix scheme