### PR TITLE
Fixed bug with multiculture support

### DIFF
--- a/src/CsvHelper.Tests/CsvReaderErrorMessageTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderErrorMessageTests.cs
@@ -11,6 +11,7 @@ using CsvHelper.TypeConversion;
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 #else
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Globalization;
 #endif
 
 namespace CsvHelper.Tests
@@ -181,7 +182,7 @@ namespace CsvHelper.Tests
 			using( var stream = new MemoryStream() )
 			using( var writer = new StreamWriter( stream ) )
 			using( var reader = new StreamReader( stream ) )
-			using( var csvReader = new CsvReader( reader ) )
+			using( var csvReader = new CsvReader( reader, new CsvConfiguration { CultureInfo = CultureInfo.InvariantCulture } ) )
 			{
 				writer.WriteLine("1,9/24/2012");
 				writer.Flush();

--- a/src/CsvHelper.Tests/CsvReaderErrorMessageTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderErrorMessageTests.cs
@@ -5,13 +5,13 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Globalization;
 using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
 #if WINRT_4_5
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 #else
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Globalization;
 #endif
 
 namespace CsvHelper.Tests

--- a/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
+++ b/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
@@ -58,6 +58,57 @@ namespace CsvHelper.Tests.TypeConversion
 			}
 		}
 
+        [TestMethod]
+        public void GetFieldFromTwoOrMoreDifferentStreamsUsingTwoOrMoreCulturesTest() {
+            var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
+            TypeConverterOptionsFactory.AddOptions<int>(options);
+            // en-GB culture
+            var britishCI = System.Globalization.CultureInfo.GetCultureInfo("en-GB");
+            var frenchCI = System.Globalization.CultureInfo.GetCultureInfo("fr-FR");
+            var greekCI = System.Globalization.CultureInfo.GetCultureInfo("el-GR");
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            using (var csvReader = new CsvReader(reader, new CsvConfiguration { CultureInfo = britishCI, Delimiter = ","  })) {
+                writer.WriteLine("\"1,234.32\",\"5,678.44\"");
+                writer.Flush();
+                stream.Position = 0;
+
+                csvReader.Configuration.HasHeaderRecord = false;
+                csvReader.Read();
+                Assert.AreEqual(1234.32M, csvReader.GetField<decimal>(0));
+                Assert.AreEqual(5678.44M, csvReader.GetField(typeof(decimal), 1));
+            }
+            // fr-FR culture
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            using (var csvReader = new CsvReader(reader, new CsvConfiguration { CultureInfo = frenchCI, Delimiter = ";" })) {
+                writer.WriteLine("\"1 234,32\";\"5678,44\"");
+                writer.Flush();
+                stream.Position = 0;
+
+                csvReader.Configuration.HasHeaderRecord = false;
+                csvReader.Read();
+                Assert.AreEqual(1234.32M, csvReader.GetField<decimal>(0));
+                Assert.AreEqual(5678.44M, csvReader.GetField(typeof(decimal), 1));
+            }
+            // el-GR culture
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            using (var csvReader = new CsvReader(reader, new CsvConfiguration { CultureInfo = greekCI, Delimiter = ";" })) {
+                writer.WriteLine("\"1.234,32\";\"5678,44\"");
+                writer.Flush();
+                stream.Position = 0;
+
+                csvReader.Configuration.HasHeaderRecord = false;
+                csvReader.Read();
+                Assert.AreEqual(1234.32M, csvReader.GetField<decimal>(0));
+                Assert.AreEqual(5678.44M, csvReader.GetField(typeof(decimal), 1));
+            }
+        }
+
 		[TestMethod]
 		public void GetRecordsTest()
 		{

--- a/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
+++ b/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
@@ -10,95 +10,78 @@ using CsvHelper.TypeConversion;
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 #else
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
 #endif
 
 namespace CsvHelper.Tests.TypeConversion
 {
-	[TestClass]
-	public class TypeConverterOptionsFactoryTests
-	{
-		[TestMethod]
-		public void AddGetRemoveTest()
-		{
-			var customOptions = new TypeConverterOptions
-			{
-				Format = "custom",
-			};
-			TypeConverterOptionsFactory.AddOptions<string>( customOptions );
-			var options = TypeConverterOptionsFactory.GetOptions<string>();
+    [TestClass]
+    public class TypeConverterOptionsFactoryTests
+    {
+        [TestMethod]
+        public void AddGetRemoveTest() {
+            var customOptions = new TypeConverterOptions {
+                Format = "custom",
+            };
+            TypeConverterOptionsFactory.AddOptions<string>(customOptions);
+            var options = TypeConverterOptionsFactory.GetOptions<string>();
 
-			Assert.AreEqual( customOptions.Format, options.Format );
+            Assert.AreEqual(customOptions.Format, options.Format);
 
-			TypeConverterOptionsFactory.RemoveOptions<string>();
+            TypeConverterOptionsFactory.RemoveOptions<string>();
 
-			options = TypeConverterOptionsFactory.GetOptions<string>();
+            options = TypeConverterOptionsFactory.GetOptions<string>();
 
-			Assert.AreNotEqual( customOptions.Format, options.Format );
-		}
-
-		[TestMethod]
-		public void GetFieldTest()
-		{
-			var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
-			TypeConverterOptionsFactory.AddOptions<int>( options );
-
-			using( var stream = new MemoryStream() )
-			using( var reader = new StreamReader( stream ) )
-			using( var writer = new StreamWriter( stream ) )
-			using( var csvReader = new CsvReader( reader, new CsvConfiguration { CultureInfo = CultureInfo.InvariantCulture }  ) )
-			{
-				writer.WriteLine( "\"1,234\",\"5,678\"" );
-				writer.Flush();
-				stream.Position = 0;
-
-				csvReader.Configuration.HasHeaderRecord = false;
-				csvReader.Read();
-				Assert.AreEqual( 1234, csvReader.GetField<int>( 0 ) );
-				Assert.AreEqual( 5678, csvReader.GetField( typeof( int ),  1 ) );
-			}
-		}
+            Assert.AreNotEqual(customOptions.Format, options.Format);
+        }
 
         [TestMethod]
-        public void GetFieldFromTwoOrMoreDifferentStreamsUsingTwoOrMoreCulturesTest() {
+        public void GetFieldTest() {
             var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
             TypeConverterOptionsFactory.AddOptions<int>(options);
-            // en-GB culture
-            var britishCI = System.Globalization.CultureInfo.GetCultureInfo("en-GB");
-            var frenchCI = System.Globalization.CultureInfo.GetCultureInfo("fr-FR");
-            var greekCI = System.Globalization.CultureInfo.GetCultureInfo("el-GR");
+
             using (var stream = new MemoryStream())
             using (var reader = new StreamReader(stream))
             using (var writer = new StreamWriter(stream))
-            using (var csvReader = new CsvReader(reader, new CsvConfiguration { CultureInfo = britishCI, Delimiter = ","  })) {
-                writer.WriteLine("\"1,234.32\",\"5,678.44\"");
+            using (var csvReader = new CsvReader(reader, new CsvConfiguration { CultureInfo = CultureInfo.InvariantCulture })) {
+                writer.WriteLine("\"1,234\",\"5,678\"");
                 writer.Flush();
                 stream.Position = 0;
 
                 csvReader.Configuration.HasHeaderRecord = false;
                 csvReader.Read();
-                Assert.AreEqual(1234.32M, csvReader.GetField<decimal>(0));
-                Assert.AreEqual(5678.44M, csvReader.GetField(typeof(decimal), 1));
+                Assert.AreEqual(1234, csvReader.GetField<int>(0));
+                Assert.AreEqual(5678, csvReader.GetField(typeof(int), 1));
             }
-            // fr-FR culture
-            using (var stream = new MemoryStream())
-            using (var reader = new StreamReader(stream))
-            using (var writer = new StreamWriter(stream))
-            using (var csvReader = new CsvReader(reader, new CsvConfiguration { CultureInfo = frenchCI, Delimiter = ";" })) {
-                writer.WriteLine("\"1 234,32\";\"5678,44\"");
-                writer.Flush();
-                stream.Position = 0;
+        }
 
-                csvReader.Configuration.HasHeaderRecord = false;
-                csvReader.Read();
-                Assert.AreEqual(1234.32M, csvReader.GetField<decimal>(0));
-                Assert.AreEqual(5678.44M, csvReader.GetField(typeof(decimal), 1));
-            }
-            // el-GR culture
+        [TestMethod]
+        public void GetFieldSwitchCulturesThreadSaftyTest() {
+            var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
+            TypeConverterOptionsFactory.AddOptions<int>(options);
+            var actions = new Action[] {
+                () => GetFieldForCultureTest("\"1,234.32\",\"5,678.44\"", "en-GB"),
+                () => GetFieldForCultureTest("\"1 234,32\",\"5678,44\"", "fr-FR"),
+                () => GetFieldForCultureTest("\"1.234,32\",\"5678,44\"", "el-GR")
+            };
+            Parallel.ForEach(actions, new ParallelOptions { MaxDegreeOfParallelism = 3 }, action => action()); 
+        }
+
+        [TestMethod]
+        public void GetFieldSwitchCulturesTest() {
+            var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
+            TypeConverterOptionsFactory.AddOptions<int>(options);
+            GetFieldForCultureTest("\"1,234.32\",\"5,678.44\"", "en-GB");
+            GetFieldForCultureTest("\"1 234,32\",\"5678,44\"", "fr-FR");
+            GetFieldForCultureTest("\"1.234,32\",\"5678,44\"", "el-GR");
+        }
+
+        private void GetFieldForCultureTest(string csvtext, string culture) {
             using (var stream = new MemoryStream())
             using (var reader = new StreamReader(stream))
             using (var writer = new StreamWriter(stream))
-            using (var csvReader = new CsvReader(reader, new CsvConfiguration { CultureInfo = greekCI, Delimiter = ";" })) {
-                writer.WriteLine("\"1.234,32\";\"5678,44\"");
+            using (var csvReader = new CsvReader(reader, new CsvConfiguration { CultureInfo = CultureInfo.GetCultureInfo(culture) })) {
+                writer.WriteLine(csvtext);
                 writer.Flush();
                 stream.Position = 0;
 
@@ -109,136 +92,125 @@ namespace CsvHelper.Tests.TypeConversion
             }
         }
 
-		[TestMethod]
-		public void GetRecordsTest()
-		{
-			var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
-			TypeConverterOptionsFactory.AddOptions<int>( options );
+        [TestMethod]
+        public void GetRecordsTest() {
+            var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
+            TypeConverterOptionsFactory.AddOptions<int>(options);
 
-			using( var stream = new MemoryStream() )
-			using( var reader = new StreamReader( stream ) )
-			using( var writer = new StreamWriter( stream ) )
-			using( var csvReader = new CsvReader( reader, new CsvConfiguration { CultureInfo = CultureInfo.InvariantCulture } ) )
-			{
-				writer.WriteLine( "\"1,234\",\"5,678\"" );
-				writer.Flush();
-				stream.Position = 0;
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            using (var csvReader = new CsvReader(reader, new CsvConfiguration { CultureInfo = CultureInfo.InvariantCulture })) {
+                writer.WriteLine("\"1,234\",\"5,678\"");
+                writer.Flush();
+                stream.Position = 0;
 
-				csvReader.Configuration.HasHeaderRecord = false;
-				csvReader.GetRecords<Test>().ToList();
-			}
-		}
+                csvReader.Configuration.HasHeaderRecord = false;
+                csvReader.GetRecords<Test>().ToList();
+            }
+        }
 
-		[TestMethod]
-		public void GetRecordsAppliedWhenMappedTest()
-		{
-			var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
-			TypeConverterOptionsFactory.AddOptions<int>( options );
+        [TestMethod]
+        public void GetRecordsAppliedWhenMappedTest() {
+            var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
+            TypeConverterOptionsFactory.AddOptions<int>(options);
             var config = new CsvConfiguration { CultureInfo = CultureInfo.GetCultureInfo("en-US") };
 
-			using( var stream = new MemoryStream() )
-			using( var reader = new StreamReader( stream ) )
-			using( var writer = new StreamWriter( stream ) )
-			using( var csvReader = new CsvReader( reader, config ) )
-			{
-				writer.WriteLine( "\"1,234\",\"$5,678\"" );
-				writer.Flush();
-				stream.Position = 0;
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            using (var csvReader = new CsvReader(reader, config)) {
+                writer.WriteLine("\"1,234\",\"$5,678\"");
+                writer.Flush();
+                stream.Position = 0;
 
-				csvReader.Configuration.HasHeaderRecord = false;
-				csvReader.Configuration.RegisterClassMap<TestMap>();
-				csvReader.GetRecords<Test>().ToList();
-			}
-		}
+                csvReader.Configuration.HasHeaderRecord = false;
+                csvReader.Configuration.RegisterClassMap<TestMap>();
+                csvReader.GetRecords<Test>().ToList();
+            }
+        }
 
-		[TestMethod]
-		public void WriteFieldTest()
-		{
-			var options = new TypeConverterOptions { Format = "c" };
-			TypeConverterOptionsFactory.AddOptions<int>( options );
+        [TestMethod]
+        public void WriteFieldTest() {
+            var options = new TypeConverterOptions { Format = "c" };
+            TypeConverterOptionsFactory.AddOptions<int>(options);
             var config = new CsvConfiguration { CultureInfo = CultureInfo.GetCultureInfo("en-US") };
 
-			using( var stream = new MemoryStream() )
-			using( var reader = new StreamReader( stream ) )
-			using( var writer = new StreamWriter( stream ) )
-			using( var csvWriter = new CsvWriter( writer, config ) )
-			{
-				csvWriter.WriteField( 1234 );
-				csvWriter.NextRecord();
-				writer.Flush();
-				stream.Position = 0;
-				var record = reader.ReadToEnd();
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            using (var csvWriter = new CsvWriter(writer, config)) {
+                csvWriter.WriteField(1234);
+                csvWriter.NextRecord();
+                writer.Flush();
+                stream.Position = 0;
+                var record = reader.ReadToEnd();
 
-				Assert.AreEqual( "\"$1,234.00\"\r\n", record );
-			}
-		}
+                Assert.AreEqual("\"$1,234.00\"\r\n", record);
+            }
+        }
 
-		[TestMethod]
-		public void WriteRecordsTest()
-		{
-			var options = new TypeConverterOptions { Format = "c" };
-			TypeConverterOptionsFactory.AddOptions<int>( options );
+        [TestMethod]
+        public void WriteRecordsTest() {
+            var options = new TypeConverterOptions { Format = "c" };
+            TypeConverterOptionsFactory.AddOptions<int>(options);
             var config = new CsvConfiguration { CultureInfo = CultureInfo.GetCultureInfo("en-US") };
-			using( var stream = new MemoryStream() )
-			using( var reader = new StreamReader( stream ) )
-			using( var writer = new StreamWriter( stream ) )
-            using( var csvWriter = new CsvWriter( writer, config ) )
-			{
-				var list = new List<Test>
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            using (var csvWriter = new CsvWriter(writer, config)) {
+                var list = new List<Test>
 				{
 					new Test { Number = 1234, NumberOverridenInMap = 5678 },
 				};
-				csvWriter.Configuration.HasHeaderRecord = false;
-				csvWriter.WriteRecords( list );
-				writer.Flush();
-				stream.Position = 0;
-				var record = reader.ReadToEnd();
+                csvWriter.Configuration.HasHeaderRecord = false;
+                csvWriter.WriteRecords(list);
+                writer.Flush();
+                stream.Position = 0;
+                var record = reader.ReadToEnd();
 
-				Assert.AreEqual( "\"$1,234.00\",\"$5,678.00\"\r\n", record );
-			}
-		}
+                Assert.AreEqual("\"$1,234.00\",\"$5,678.00\"\r\n", record);
+            }
+        }
 
-		[TestMethod]
-		public void WriteRecordsAppliedWhenMappedTest()
-		{
-			var options = new TypeConverterOptions { Format = "c" };
-			TypeConverterOptionsFactory.AddOptions<int>( options );
+        [TestMethod]
+        public void WriteRecordsAppliedWhenMappedTest() {
+            var options = new TypeConverterOptions { Format = "c" };
+            TypeConverterOptionsFactory.AddOptions<int>(options);
             var config = new CsvConfiguration { CultureInfo = CultureInfo.GetCultureInfo("en-US") };
 
-			using( var stream = new MemoryStream() )
-			using( var reader = new StreamReader( stream ) )
-			using( var writer = new StreamWriter( stream ) )
-			using( var csvWriter = new CsvWriter( writer, config ) )
-			{
-				var list = new List<Test>
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            using (var csvWriter = new CsvWriter(writer, config)) {
+                var list = new List<Test>
 				{
 					new Test { Number = 1234, NumberOverridenInMap = 5678 },
 				};
-				csvWriter.Configuration.HasHeaderRecord = false;
-				csvWriter.Configuration.RegisterClassMap<TestMap>();
-				csvWriter.WriteRecords( list );
-				writer.Flush();
-				stream.Position = 0;
-				var record = reader.ReadToEnd();
+                csvWriter.Configuration.HasHeaderRecord = false;
+                csvWriter.Configuration.RegisterClassMap<TestMap>();
+                csvWriter.WriteRecords(list);
+                writer.Flush();
+                stream.Position = 0;
+                var record = reader.ReadToEnd();
 
-				Assert.AreEqual( "\"$1,234.00\",\"5,678.00\"\r\n", record );
-			}
-		}
+                Assert.AreEqual("\"$1,234.00\",\"5,678.00\"\r\n", record);
+            }
+        }
 
-		private class Test
-		{
-			public int Number { get; set; }
+        private class Test
+        {
+            public int Number { get; set; }
 
-			public int NumberOverridenInMap { get; set; }
-		}
+            public int NumberOverridenInMap { get; set; }
+        }
 
-		private class TestMap : CsvClassMap<Test>
-		{
-			public TestMap()
-			{
-				Map( m => m.Number );
-				Map( m => m.NumberOverridenInMap ).TypeConverterOption( NumberStyles.AllowThousands | NumberStyles.AllowCurrencySymbol ).TypeConverterOption( "N" );
-			}
-		}
-	}
+        private class TestMap : CsvClassMap<Test>
+        {
+            public TestMap() {
+                Map(m => m.Number);
+                Map(m => m.NumberOverridenInMap).TypeConverterOption(NumberStyles.AllowThousands | NumberStyles.AllowCurrencySymbol).TypeConverterOption("N");
+            }
+        }
+    }
 }

--- a/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
+++ b/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
@@ -45,7 +45,7 @@ namespace CsvHelper.Tests.TypeConversion
 			using( var stream = new MemoryStream() )
 			using( var reader = new StreamReader( stream ) )
 			using( var writer = new StreamWriter( stream ) )
-			using( var csvReader = new CsvReader( reader ) )
+			using( var csvReader = new CsvReader( reader, new CsvConfiguration { CultureInfo = CultureInfo.InvariantCulture }  ) )
 			{
 				writer.WriteLine( "\"1,234\",\"5,678\"" );
 				writer.Flush();
@@ -67,7 +67,7 @@ namespace CsvHelper.Tests.TypeConversion
 			using( var stream = new MemoryStream() )
 			using( var reader = new StreamReader( stream ) )
 			using( var writer = new StreamWriter( stream ) )
-			using( var csvReader = new CsvReader( reader ) )
+			using( var csvReader = new CsvReader( reader, new CsvConfiguration { CultureInfo = CultureInfo.InvariantCulture } ) )
 			{
 				writer.WriteLine( "\"1,234\",\"5,678\"" );
 				writer.Flush();
@@ -83,11 +83,12 @@ namespace CsvHelper.Tests.TypeConversion
 		{
 			var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };
 			TypeConverterOptionsFactory.AddOptions<int>( options );
+            var config = new CsvConfiguration { CultureInfo = CultureInfo.GetCultureInfo("en-US") };
 
 			using( var stream = new MemoryStream() )
 			using( var reader = new StreamReader( stream ) )
 			using( var writer = new StreamWriter( stream ) )
-			using( var csvReader = new CsvReader( reader ) )
+			using( var csvReader = new CsvReader( reader, config ) )
 			{
 				writer.WriteLine( "\"1,234\",\"$5,678\"" );
 				writer.Flush();
@@ -104,11 +105,12 @@ namespace CsvHelper.Tests.TypeConversion
 		{
 			var options = new TypeConverterOptions { Format = "c" };
 			TypeConverterOptionsFactory.AddOptions<int>( options );
+            var config = new CsvConfiguration { CultureInfo = CultureInfo.GetCultureInfo("en-US") };
 
 			using( var stream = new MemoryStream() )
 			using( var reader = new StreamReader( stream ) )
 			using( var writer = new StreamWriter( stream ) )
-			using( var csvWriter = new CsvWriter( writer ) )
+			using( var csvWriter = new CsvWriter( writer, config ) )
 			{
 				csvWriter.WriteField( 1234 );
 				csvWriter.NextRecord();
@@ -125,11 +127,11 @@ namespace CsvHelper.Tests.TypeConversion
 		{
 			var options = new TypeConverterOptions { Format = "c" };
 			TypeConverterOptionsFactory.AddOptions<int>( options );
-
+            var config = new CsvConfiguration { CultureInfo = CultureInfo.GetCultureInfo("en-US") };
 			using( var stream = new MemoryStream() )
 			using( var reader = new StreamReader( stream ) )
 			using( var writer = new StreamWriter( stream ) )
-			using( var csvWriter = new CsvWriter( writer ) )
+            using( var csvWriter = new CsvWriter( writer, config ) )
 			{
 				var list = new List<Test>
 				{
@@ -150,11 +152,12 @@ namespace CsvHelper.Tests.TypeConversion
 		{
 			var options = new TypeConverterOptions { Format = "c" };
 			TypeConverterOptionsFactory.AddOptions<int>( options );
+            var config = new CsvConfiguration { CultureInfo = CultureInfo.GetCultureInfo("en-US") };
 
 			using( var stream = new MemoryStream() )
 			using( var reader = new StreamReader( stream ) )
 			using( var writer = new StreamWriter( stream ) )
-			using( var csvWriter = new CsvWriter( writer ) )
+			using( var csvWriter = new CsvWriter( writer, config ) )
 			{
 				var list = new List<Test>
 				{

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -435,7 +435,7 @@ namespace CsvHelper
 			CheckHasBeenRead();
 
 			var typeConverterOptions = TypeConverterOptionsFactory.GetOptions( type );
-			if( typeConverterOptions.CultureInfo == null )
+            if ( typeConverterOptions.CultureInfo != configuration.CultureInfo )
 			{
 				typeConverterOptions.CultureInfo = configuration.CultureInfo;
 			}
@@ -1350,7 +1350,7 @@ namespace CsvHelper
 
 			var typeConverter = TypeConverterFactory.GetConverter( recordType );
 			var typeConverterOptions = TypeConverterOptionsFactory.GetOptions( recordType );
-			if( typeConverterOptions.CultureInfo == null )
+			if( typeConverterOptions.CultureInfo != configuration.CultureInfo )
 			{
 				typeConverterOptions.CultureInfo = configuration.CultureInfo;
 			}
@@ -1458,7 +1458,7 @@ namespace CsvHelper
 
 				// Convert the field.
 				var typeConverterExpression = Expression.Constant( propertyMap.Data.TypeConverter );
-				if( propertyMap.Data.TypeConverterOptions.CultureInfo == null )
+				if( propertyMap.Data.TypeConverterOptions.CultureInfo != configuration.CultureInfo )
 				{
 					propertyMap.Data.TypeConverterOptions.CultureInfo = configuration.CultureInfo;
 				}

--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -200,7 +200,7 @@ namespace CsvHelper
 			CheckDisposed();
 
 			var typeConverterOptions = TypeConverterOptionsFactory.GetOptions<T>();
-			if( typeConverterOptions.CultureInfo == null )
+			if( typeConverterOptions.CultureInfo != configuration.CultureInfo )
 			{
 				typeConverterOptions.CultureInfo = configuration.CultureInfo;
 			}
@@ -627,7 +627,7 @@ namespace CsvHelper
 				var fieldExpression = CreatePropertyExpression( recordParameter, configuration.Maps[type], propertyMap );
 
 				var typeConverterExpression = Expression.Constant( propertyMap.Data.TypeConverter );
-				if( propertyMap.Data.TypeConverterOptions.CultureInfo == null )
+				if( propertyMap.Data.TypeConverterOptions.CultureInfo != configuration.CultureInfo)
 				{
 					propertyMap.Data.TypeConverterOptions.CultureInfo = configuration.CultureInfo;
 				}
@@ -669,7 +669,7 @@ namespace CsvHelper
 			var method = typeConverter.GetType().GetMethod( "ConvertToString" );
 
 			var typeConverterOptions = TypeConverterOptionsFactory.GetOptions( type );
-			if( typeConverterOptions.CultureInfo == null )
+			if( typeConverterOptions.CultureInfo != configuration.CultureInfo )
 			{
 				typeConverterOptions.CultureInfo = configuration.CultureInfo;
 			}

--- a/src/CsvHelper/TypeConversion/DecimalConverter.cs
+++ b/src/CsvHelper/TypeConversion/DecimalConverter.cs
@@ -19,7 +19,7 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object ConvertFromString( TypeConverterOptions options, string text )
 		{
-			var numberStyle = options.NumberStyle ?? NumberStyles.Float;
+			var numberStyle = options.NumberStyle ??  ( NumberStyles.Float | NumberStyles.AllowThousands );
 
 			decimal d;
 			if( decimal.TryParse( text, numberStyle, options.CultureInfo, out d ) )

--- a/src/CsvHelper/TypeConversion/DoubleConverter.cs
+++ b/src/CsvHelper/TypeConversion/DoubleConverter.cs
@@ -21,7 +21,7 @@ namespace CsvHelper.TypeConversion
 		/// </returns>
 		public override object ConvertFromString( TypeConverterOptions options, string text )
 		{
-			var numberStyle = options.NumberStyle ?? NumberStyles.Float;
+			var numberStyle = options.NumberStyle ?? ( NumberStyles.Float | NumberStyles.AllowThousands );
 
 			double d;
 			if( double.TryParse( text, numberStyle, options.CultureInfo, out d ) )

--- a/src/CsvHelper/TypeConversion/Int16Converter.cs
+++ b/src/CsvHelper/TypeConversion/Int16Converter.cs
@@ -19,7 +19,7 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object ConvertFromString( TypeConverterOptions options, string text )
 		{
-			var numberStyle = options.NumberStyle ?? NumberStyles.Integer;
+			var numberStyle = options.NumberStyle ?? ( NumberStyles.Integer | NumberStyles.AllowThousands );
 
 			short s;
 			if( short.TryParse( text, numberStyle, options.CultureInfo, out s ) )

--- a/src/CsvHelper/TypeConversion/Int32Converter.cs
+++ b/src/CsvHelper/TypeConversion/Int32Converter.cs
@@ -19,7 +19,7 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object ConvertFromString( TypeConverterOptions options, string text )
 		{
-			var numberStyle = options.NumberStyle ?? NumberStyles.Integer;
+			var numberStyle = options.NumberStyle ?? ( NumberStyles.Integer | NumberStyles.AllowThousands );
 
 			int i;
 			if( int.TryParse( text, numberStyle, options.CultureInfo, out i ) )

--- a/src/CsvHelper/TypeConversion/Int64Converter.cs
+++ b/src/CsvHelper/TypeConversion/Int64Converter.cs
@@ -19,7 +19,7 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object ConvertFromString( TypeConverterOptions options, string text )
 		{
-			var numberStyle = options.NumberStyle ?? NumberStyles.Integer;
+			var numberStyle = options.NumberStyle ?? ( NumberStyles.Integer | NumberStyles.AllowThousands );
 
 			long l;
 			if( long.TryParse( text, numberStyle, options.CultureInfo, out l ) )

--- a/src/CsvHelper/TypeConversion/TypeConverterOptionsFactory.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterOptionsFactory.cs
@@ -96,7 +96,7 @@ namespace CsvHelper.TypeConversion
 					typeConverterOptions.Add( type, options );
 				}
 
-				return options;
+                return TypeConverterOptions.Merge( options );
 			}
 		}
 

--- a/src/CsvHelper/TypeConversion/UInt16Converter.cs
+++ b/src/CsvHelper/TypeConversion/UInt16Converter.cs
@@ -19,7 +19,7 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object ConvertFromString( TypeConverterOptions options, string text )
 		{
-			var numberStyle = options.NumberStyle ?? NumberStyles.Integer;
+			var numberStyle = options.NumberStyle ?? ( NumberStyles.Integer | NumberStyles.AllowThousands );
 
 			ushort us;
 			if( ushort.TryParse( text, numberStyle, options.CultureInfo, out us ) )

--- a/src/CsvHelper/TypeConversion/UInt32Converter.cs
+++ b/src/CsvHelper/TypeConversion/UInt32Converter.cs
@@ -19,7 +19,7 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object ConvertFromString( TypeConverterOptions options, string text )
 		{
-			var numberStyle = options.NumberStyle ?? NumberStyles.Integer;
+			var numberStyle = options.NumberStyle ?? ( NumberStyles.Integer | NumberStyles.AllowThousands );
 
 			uint ui;
 			if( uint.TryParse( text, numberStyle, options.CultureInfo, out ui ) )

--- a/src/CsvHelper/TypeConversion/UInt64Converter.cs
+++ b/src/CsvHelper/TypeConversion/UInt64Converter.cs
@@ -19,7 +19,7 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object ConvertFromString( TypeConverterOptions options, string text )
 		{
-			var numberStyle = options.NumberStyle ?? NumberStyles.Integer;
+			var numberStyle = options.NumberStyle ?? ( NumberStyles.Integer | NumberStyles.AllowThousands );
 
 			ulong ul;
 			if( ulong.TryParse( text, numberStyle, options.CultureInfo, out ul ) )


### PR DESCRIPTION
When using csv reader with different cultures TypeConverterOptions are initialized once in the application lifecycle. As a result when using different instantces of the CsvReader class with different configurations regarding the CultureInfo setting the config setting was ignored.

Also resolves issue https://github.com/JoshClose/CsvHelper/issues/290 