### PR TITLE
Fix typo and remove unused namespaces

### DIFF
--- a/src/CsvHelper.SpeedTests/Program.cs
+++ b/src/CsvHelper.SpeedTests/Program.cs
@@ -3,7 +3,6 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // http://csvhelper.com
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;

--- a/src/CsvHelper.Tests/AutoMappingTests.cs
+++ b/src/CsvHelper.Tests/AutoMappingTests.cs
@@ -2,7 +2,6 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // http://csvhelper.com
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/CsvHelper/Configuration/CsvClassMap.cs
+++ b/src/CsvHelper/Configuration/CsvClassMap.cs
@@ -7,7 +7,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using CsvHelper.TypeConversion;
 
 namespace CsvHelper.Configuration
@@ -140,7 +139,7 @@ namespace CsvHelper.Configuration
 			var type = map.GetType().BaseType.GetGenericArguments()[0];
 			if( typeof( IEnumerable ).IsAssignableFrom( type ) )
 			{
-				throw new CsvConfigurationException( "Types that inhererit IEnumerable cannot be auto mapped. " +
+				throw new CsvConfigurationException( "Types that inherit IEnumerable cannot be auto mapped. " +
 													 "Did you accidentally call GetRecord or WriteRecord which " +
 													 "acts on a single record instead of calling GetRecords or " +
 													 "WriteRecords which acts on a list of records?" );

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -3,7 +3,6 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // http://csvhelper.com
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 #if !NET_2_0

--- a/src/CsvHelper/Configuration/CsvPropertyMapCollection.cs
+++ b/src/CsvHelper/Configuration/CsvPropertyMapCollection.cs
@@ -5,7 +5,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace CsvHelper.Configuration
 {

--- a/src/CsvHelper/Configuration/CsvPropertyMapComparer.cs
+++ b/src/CsvHelper/Configuration/CsvPropertyMapComparer.cs
@@ -3,7 +3,6 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // http://csvhelper.com
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace CsvHelper.Configuration

--- a/src/CsvHelper/Configuration/CsvPropertyMapData.cs
+++ b/src/CsvHelper/Configuration/CsvPropertyMapData.cs
@@ -3,7 +3,6 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // http://csvhelper.com
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using CsvHelper.TypeConversion;

--- a/src/CsvHelper/ICsvParser.cs
+++ b/src/CsvHelper/ICsvParser.cs
@@ -3,7 +3,6 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // http://csvhelper.com
 using System;
-using System.Collections.Generic;
 using CsvHelper.Configuration;
 
 namespace CsvHelper

--- a/src/CsvHelper/ICsvReader.cs
+++ b/src/CsvHelper/ICsvReader.cs
@@ -3,10 +3,7 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // http://csvhelper.com
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using CsvHelper.Configuration;
-using CsvHelper.TypeConversion;
 
 namespace CsvHelper
 {

--- a/src/CsvHelper/ICsvReaderRow.cs
+++ b/src/CsvHelper/ICsvReaderRow.cs
@@ -4,7 +4,6 @@
 // http://csvhelper.com
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
 

--- a/src/CsvHelper/ICsvWriter.cs
+++ b/src/CsvHelper/ICsvWriter.cs
@@ -4,7 +4,6 @@
 // http://csvhelper.com
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
 


### PR DESCRIPTION
"that inhererit IEnumerable cannot be auto mapped.". Inherit spelt incorrectly.