### PR TITLE
Multimap properties

### DIFF
--- a/src/CsvHelper.Tests/CsvClassMappingTests.cs
+++ b/src/CsvHelper.Tests/CsvClassMappingTests.cs
@@ -145,6 +145,22 @@ namespace CsvHelper.Tests
 			Assert.AreEqual( true, config.Maps[typeof( A )].PropertyMaps[0].Data.Ignore );
 		}
 
+	    [TestMethod]
+	    public void DuplicatePropertyMapTest()
+	    {
+	        var map = new TestMappingDuplicateProperties();
+
+            Assert.AreEqual(2, map.PropertyMaps.Count);
+
+            Assert.AreEqual( 1, map.PropertyMaps[0].Data.Names.Count );
+            Assert.AreEqual( "First", map.PropertyMaps[0].Data.Names[0] );
+            Assert.AreEqual( 0, map.PropertyMaps[0].MapIndex );
+
+            Assert.AreEqual( 1, map.PropertyMaps[1].Data.Names.Count );
+            Assert.AreEqual( "Second", map.PropertyMaps[1].Data.Names[0] );
+            Assert.AreEqual( 1, map.PropertyMaps[1].MapIndex );
+	    }
+
 		private class A
 		{
 			public int AId { get; set; }
@@ -253,5 +269,14 @@ namespace CsvHelper.Tests
 				Map( m => m.StringColumn ).Name( "string1", "string2", "string3" );
 			}
 		}
+
+	    private sealed class TestMappingDuplicateProperties : CsvClassMap<TestClass>
+	    {
+	        public TestMappingDuplicateProperties()
+	        {
+	            Map( m => m.StringColumn, 0 ).Name( "First" );
+                Map( m => m.StringColumn, 1 ).Name( "Second" );
+	        }
+	    }
 	}
 }

--- a/src/CsvHelper.Tests/CsvWriterTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterTests.cs
@@ -865,11 +865,11 @@ namespace CsvHelper.Tests
         {
             public TestRecordMap()
             {
-                Map(m => m.IntColumn).Name("Int Column").Index(1).TypeConverter<Int32Converter>();
-                Map(m => m.StringColumn);
-                Map(m => m.FirstColumn).Index(0);
-                Map(m => m.TypeConvertedColumn).TypeConverter<TestTypeConverter>();
-                Map(m => m.InternalColumn);
+                Map( m => m.IntColumn ).Name( "Int Column" ).Index( 1 ).TypeConverter<Int32Converter>();
+                Map( m => m.StringColumn );
+                Map( m => m.FirstColumn ).Index( 0 );
+                Map( m => m.TypeConvertedColumn ).TypeConverter<TestTypeConverter>();
+                Map( m => m.InternalColumn );
             }
         }
 
@@ -877,8 +877,8 @@ namespace CsvHelper.Tests
         {
             public TestRecordMultiMap()
             {
-                Map(m => m.StringColumn).Name("First");
-                Map(m => m.StringColumn, ignoreExistingMap: true).Name("Second");
+                Map( m => m.StringColumn, 0 ).Name( "First" );
+                Map( m => m.StringColumn, 1 ).Name( "Second" );
             }
         }
 

--- a/src/CsvHelper/Configuration/CsvClassMap`1.cs
+++ b/src/CsvHelper/Configuration/CsvClassMap`1.cs
@@ -26,20 +26,21 @@ namespace CsvHelper.Configuration
 			Constructor = ReflectionHelper.GetConstructor( expression );
 		}
 
-		/// <summary>
-		/// Maps a property to a CSV field.
-		/// </summary>
-		/// <param name="expression">The property to map.</param>
-		/// <returns>The property mapping.</returns>
-		protected virtual CsvPropertyMap Map( Expression<Func<T, object>> expression )
+	    /// <summary>
+	    /// Maps a property to a CSV field.
+	    /// </summary>
+	    /// <param name="expression">The property to map.</param>
+	    /// <param name="ignoreExistingMap">If true then a new map will be created, even if the property has already been mapped.</param>
+	    /// <returns>The property mapping.</returns>
+	    protected virtual CsvPropertyMap Map( Expression<Func<T, object>> expression, bool ignoreExistingMap = false )
 		{
 			var property = ReflectionHelper.GetProperty( expression );
 
-			var existingMap = PropertyMaps.SingleOrDefault( m =>
+			var existingMap = PropertyMaps.FirstOrDefault( m =>
 				m.Data.Property == property
 				|| m.Data.Property.Name == property.Name
 				&& ( m.Data.Property.DeclaringType.IsAssignableFrom( property.DeclaringType ) || property.DeclaringType.IsAssignableFrom( m.Data.Property.DeclaringType ) ) );
-			if( existingMap != null )
+			if( existingMap != null && !ignoreExistingMap )
 			{
 				return existingMap;
 			}

--- a/src/CsvHelper/Configuration/CsvClassMap`1.cs
+++ b/src/CsvHelper/Configuration/CsvClassMap`1.cs
@@ -30,22 +30,26 @@ namespace CsvHelper.Configuration
 	    /// Maps a property to a CSV field.
 	    /// </summary>
 	    /// <param name="expression">The property to map.</param>
-	    /// <param name="ignoreExistingMap">If true then a new map will be created, even if the property has already been mapped.</param>
+	    /// <param name="mapIndex">
+	    /// When specifying multiple maps on the same property, you can specify an index, which will stop the preceding map(s) being overwritten and allow you to retrieve specific maps by index.
+	    /// When reading, only the map at index 0 will be used.
+	    /// </param>
 	    /// <returns>The property mapping.</returns>
-	    protected virtual CsvPropertyMap Map( Expression<Func<T, object>> expression, bool ignoreExistingMap = false )
+	    protected virtual CsvPropertyMap Map( Expression<Func<T, object>> expression, int mapIndex = 0 )
 		{
 			var property = ReflectionHelper.GetProperty( expression );
 
-			var existingMap = PropertyMaps.FirstOrDefault( m =>
-				m.Data.Property == property
-				|| m.Data.Property.Name == property.Name
+			var existingMap = PropertyMaps.SingleOrDefault( m =>
+				(m.Data.Property == property
+				|| m.Data.Property.Name == property.Name)
+                && m.MapIndex == mapIndex
 				&& ( m.Data.Property.DeclaringType.IsAssignableFrom( property.DeclaringType ) || property.DeclaringType.IsAssignableFrom( m.Data.Property.DeclaringType ) ) );
-			if( existingMap != null && !ignoreExistingMap )
+			if( existingMap != null )
 			{
 				return existingMap;
 			}
 
-			var propertyMap = new CsvPropertyMap( property );
+			var propertyMap = new CsvPropertyMap( property ) { MapIndex = mapIndex };
 			propertyMap.Data.Index = GetMaxIndex() + 1;
 			PropertyMaps.Add( propertyMap );
 

--- a/src/CsvHelper/Configuration/CsvPropertyMap.cs
+++ b/src/CsvHelper/Configuration/CsvPropertyMap.cs
@@ -42,6 +42,8 @@ namespace CsvHelper.Configuration
 			data.Names.Add( property.Name );
 		}
 
+        internal int MapIndex { get; set; }
+
 		/// <summary>
 		/// When reading, is used to get the field
 		/// at the index of the name if there was a

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -1412,7 +1412,7 @@ namespace CsvHelper
 		/// <param name="bindings">The bindings that will be added to from the properties.</param>
 		protected virtual void AddPropertyBindings( CsvPropertyMapCollection properties, List<MemberBinding> bindings )
 		{
-			foreach( var propertyMap in properties )
+			foreach( var propertyMap in properties.Where( m =>  m.MapIndex == 0 ) )
 			{
 				if( propertyMap.Data.ConvertExpression != null )
 				{


### PR DESCRIPTION
I had a requirement to be able to map the same property multiple times, to allow data to be exported in different formats. I'm aware that imports can be handled using the ConvertUsing method.
For example;
```
Map(m => m.Date).Name("Year").Index(0).TypeConverter<DateTimeYearTypeConverter>();
Map(m => m.Date, ignoreExistingMap: true).Name("Month").Index(1).TypeConverter<DateTimeMonthTypeConverter>();
```

Obviously this is a contrived example, and there may be better ways to get that specific effect.