### PR TITLE
Allow preservation of numeric strings for Excel

### DIFF
--- a/src/CsvHelper.Tests/ExcelCompatibleTests.cs
+++ b/src/CsvHelper.Tests/ExcelCompatibleTests.cs
@@ -303,11 +303,49 @@ namespace CsvHelper.Tests
 			}
 		}
 
+        [TestMethod]
+        public void WriteNumericPrefixTest()
+        {
+            using( var stream = new MemoryStream() )
+			using( var reader = new StreamReader( stream ) )
+            using (var writer = new StreamWriter(stream))
+            using (var csv = new CsvWriter(writer))
+            {
+                csv.Configuration.UseExcelNumericPrefix = true;
+
+                var record = new SimpleWithPostal
+                {
+                    Id = 1,
+                    Name = "one",
+                    Postal = "09010"
+                };
+
+                csv.Configuration.Delimiter = ";";
+                csv.Configuration.HasExcelSeparator = true;
+                csv.WriteExcelSeparator();
+                csv.WriteHeader<SimpleWithPostal>();
+                csv.WriteRecord(record);
+
+                writer.Flush();
+                stream.Position = 0;
+
+                var text = reader.ReadToEnd();
+                Assert.IsTrue(true);
+            }
+        }
+
 		private class Simple
 		{
 			public int Id { get; set; }
 
 			public string Name { get; set; }
 		}
+
+        private class SimpleWithPostal
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Postal { get; set; }
+        }
 	}
 }

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -36,6 +36,7 @@ namespace CsvHelper.Configuration
 		private bool quoteAllFields;
 		private bool quoteNoFields;
 		private bool ignoreBlankLines = true;
+        private bool useExcelNumericPrefix = false;
 #if !NET_2_0
 		private readonly CsvClassMapCollection maps = new CsvClassMapCollection();
 #endif
@@ -373,6 +374,17 @@ namespace CsvHelper.Configuration
 			get { return ignoreBlankLines; }
 			set { ignoreBlankLines = value; }
 		}
+
+        /// <summary>
+        /// Gets or sets a value indicating if an Excel-specific
+        /// prefix (=) should be used when writing fields containing
+        /// numeric values only (e.g. 00001)
+        /// </summary>
+        public virtual bool UseExcelNumericPrefix
+        {
+            get { return useExcelNumericPrefix; }
+            set { useExcelNumericPrefix = value; }
+        }
 
 		/// <summary>
 		/// Gets or sets a value indicating if headers of reference

--- a/src/CsvHelper/CsvSerializer.cs
+++ b/src/CsvHelper/CsvSerializer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using CsvHelper.Configuration;
+using System.Text.RegularExpressions;
 
 namespace CsvHelper
 {
@@ -60,6 +61,17 @@ namespace CsvHelper
 		public void Write( string[] record )
 		{
 			CheckDisposed();
+
+            if (configuration.UseExcelNumericPrefix)
+            {
+                for (var i = 0; i < record.Length; i++ )
+                {
+                    if (Regex.IsMatch(record[i], "^[0-9]+$"))
+                    {
+                        record[i] = string.Format("=\"{0}\"", record[i]);
+                    }
+                }
+            }
 
 			var recordString = string.Join( configuration.Delimiter, record );
 			writer.WriteLine( recordString );


### PR DESCRIPTION
When exporting a file strictly for use in Excel, it is sometimes desirable to use a special prefix on numeric strings to preserve leading zeros (e.g. for postal codes '00501'). This pull request supports that feature as a configuration parameter.