### PR TITLE
Added configuration locking for parallel runs

### DIFF
--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -1318,18 +1318,21 @@ namespace CsvHelper
 				return;
 			}
 
-			if( configuration.Maps[recordType] == null )
+			lock( configuration )
 			{
-				configuration.Maps.Add( configuration.AutoMap( recordType ) );
-			}
+				if( configuration.Maps[recordType] == null )
+				{
+					configuration.Maps.Add( configuration.AutoMap( recordType ) );
+				}
 
-			if( recordType.IsPrimitive )
-			{
-				CreateFuncForPrimitive( recordType );
-			}
-			else
-			{
-				CreateFuncForObject( recordType );
+				if( recordType.IsPrimitive )
+				{
+					CreateFuncForPrimitive( recordType );
+				}
+				else
+				{
+					CreateFuncForObject( recordType );
+				}
 			}
 		}
 


### PR DESCRIPTION
When running CsvHelper's CsvReader.GetRecords<T> with .NET's Parallel.For when sharing the cofiguration between the different tasks, I encountered what seemed to be an erratic synchronization bug.

Adding the lock() on the configuration object seems to have fixed the issue for me...