### PR TITLE
Fix issue #349

### DIFF
--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -428,9 +428,10 @@ namespace CsvHelper
 
 			// Write the header. If records is a List<dynamic>, the header won't be written.
 			// This is because typeof( T ) = Object.
-			if( records.GetType().IsGenericType )
+			var genericEnumerable = records.GetType().GetInterfaces().FirstOrDefault( t => t.GetGenericTypeDefinition() == typeof( IEnumerable<> ) );
+			if( genericEnumerable != null )
 			{
-				var type = records.GetType().GetGenericArguments().First();
+				var type = genericEnumerable.GetGenericArguments().Single();
 				if( configuration.HasHeaderRecord && !hasHeaderBeenWritten && !type.IsPrimitive )
 				{
 					WriteHeader( type );

--- a/src/CsvHelper35.Tests/CsvWriterTests.cs
+++ b/src/CsvHelper35.Tests/CsvWriterTests.cs
@@ -42,6 +42,30 @@ namespace CsvHelper35.Tests
 			}
 		}
 
+		[TestMethod]
+		public void WriteSelectIteratorTest()
+		{
+			string csv;
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var csvWriter = new CsvWriter(writer))
+			{
+				var array = new[] { new { a = "a", b = "b" } };
+
+				csvWriter.Configuration.HasHeaderRecord = true;
+				csvWriter.WriteRecords(array.Select(a => new { x = a.a, y = a.b, z = a.a + a.b }));
+
+				writer.Flush();
+				stream.Position = 0;
+
+				csv = reader.ReadToEnd();
+			}
+
+			const string expected = "x,y,z\r\na,b,ab\r\n";
+			Assert.AreEqual(expected, csv);
+		}
+
 		private class Test
 		{
 			public int Id { get; set; }


### PR DESCRIPTION
I've fixed the issue #349. Main idea is to use not the _real_ enumerable type (it can even be any nongeneric type implementing the `IEnumerable<T>`) but to extract the generic type we really care about - `IEnumerable<T>` and use its single generic argument we know of.

Please check my usage of generics and types - I am not sure whether such usage of `IEnumerable<T>` is supported by all platforms supported by CsvHelper itself.