### PR TITLE
Fixing minor regression to certain IEnumerables

### DIFF
--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -428,7 +428,7 @@ namespace CsvHelper
 
 			// Write the header. If records is a List<dynamic>, the header won't be written.
 			// This is because typeof( T ) = Object.
-			var genericEnumerable = records.GetType().GetInterfaces().FirstOrDefault( t => t.GetGenericTypeDefinition() == typeof( IEnumerable<> ) );
+			var genericEnumerable = records.GetType().GetInterfaces().FirstOrDefault( t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof( IEnumerable<> ) );
 			if( genericEnumerable != null )
 			{
 				var type = genericEnumerable.GetGenericArguments().Single();


### PR DESCRIPTION
For Certain types of IEnumerables, in my case a PLINQ double join, this code blows up saying that GetGenericTypeDefinition() cannot be called on a non-generic type, thus I am adding this small check to keep it from throwing that exception.