### PR TITLE
A new PCL project that targets .NET 2.0

### DIFF
--- a/src/CsvHelper.nuspec
+++ b/src/CsvHelper.nuspec
@@ -18,6 +18,7 @@
 		<file src="CsvHelper\bin\Release\CsvHelper.*" target="lib\net40-client\" />
 		<file src="CsvHelper20\bin\Release\CsvHelper.*" target="lib\net20\" />
 		<file src="CsvHelper35\bin\Release\CsvHelper.*" target="lib\net35-client\" />
-		<file src="CsvHelperPcl\bin\Release\CsvHelper.*" target="lib\portable-sl4+wp71+windows8+net40\" />
+		<file src="CsvHelperPcl\bin\Release\CsvHelper.*" target="lib\portable-sl4+wp71+windows8+net40+wpa81+monoandroid\" />
+		<file src="CsvHelperXamarinPcl\bin\Release\CsvHelper.*" target="lib\portable-sl4+wp71+windows8+net40+wpa81+monoandroid+monotouch+xamarinios\" />
 	</files>
 </package>

--- a/src/CsvHelper.sln
+++ b/src/CsvHelper.sln
@@ -34,6 +34,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsvHelperPcl", "CsvHelperPc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsvHelperPcl.Tests", "CsvHelperPcl.Tests\CsvHelperPcl.Tests.csproj", "{4850CA2E-B00C-42E8-B9F9-97F614048A67}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsvHelperXamarinPcl", "CsvHelperXamarinPcl\CsvHelperXamarinPcl.csproj", "{865C2EAE-7A31-4015-ADD8-DD32027342CF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -188,6 +190,20 @@ Global
 		{4850CA2E-B00C-42E8-B9F9-97F614048A67}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{4850CA2E-B00C-42E8-B9F9-97F614048A67}.Release|x64.ActiveCfg = Release|Any CPU
 		{4850CA2E-B00C-42E8-B9F9-97F614048A67}.Release|x86.ActiveCfg = Release|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Release|ARM.ActiveCfg = Release|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Release|x64.ActiveCfg = Release|Any CPU
+		{865C2EAE-7A31-4015-ADD8-DD32027342CF}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -6,10 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using CsvHelper.Configuration;
-#if NET_2_0
+#if NET_2_0 && !PCL
 using CsvHelper.MissingFrom20;
-#endif
-#if !NET_2_0
+#else
 using System.Linq;
 #endif
 

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -9,10 +9,9 @@ using System.IO;
 using System.Text.RegularExpressions;
 using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
-#if NET_2_0
+#if NET_2_0 && !PCL
 using CsvHelper.MissingFrom20;
-#endif
-#if !NET_2_0
+#else
 using System.Linq;
 using System.Linq.Expressions;
 #endif

--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using System.Linq.Expressions;
 #endif
 
-#if NET_2_0
+#if NET_2_0 && !PCL
 using CsvHelper.MissingFrom20;
 #endif
 

--- a/src/CsvHelper/TypeConversion/TypeConverterOptions.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterOptions.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-#if NET_2_0
+#if NET_2_0 && !PCL
 using CsvHelper.MissingFrom20;
 #else
 using System.Linq;

--- a/src/CsvHelperXamarinPcl/CsvHelperXamarinPcl.csproj
+++ b/src/CsvHelperXamarinPcl/CsvHelperXamarinPcl.csproj
@@ -1,0 +1,200 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{865C2EAE-7A31-4015-ADD8-DD32027342CF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CsvHelper</RootNamespace>
+    <AssemblyName>CsvHelper</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\CsvHelper\CsvHelper.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>4.0</OldToolsVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;PCL;NET_2_0</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;PCL;NET_2_0</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\CsvHelper.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\CsvHelperPcl\MissingFromPcl\EnumerableExtensions.cs">
+      <Link>MissingFromPcl\EnumerableExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\Configuration\CsvConfiguration.cs">
+      <Link>Configuration\CsvConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\Configuration\CsvConfigurationException.cs">
+      <Link>Configuration\CsvConfigurationException.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\CsvBadDataException.cs">
+      <Link>CsvBadDataException.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\CsvHelperException.cs">
+      <Link>CsvHelperException.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\CsvMissingFieldException.cs">
+      <Link>CsvMissingFieldException.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\CsvParser.cs">
+      <Link>CsvParser.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\CsvParserException.cs">
+      <Link>CsvParserException.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\CsvReader.cs">
+      <Link>CsvReader.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\CsvReaderException.cs">
+      <Link>CsvReaderException.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\CsvSerializer.cs">
+      <Link>CsvSerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\CsvWriter.cs">
+      <Link>CsvWriter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\CsvWriterException.cs">
+      <Link>CsvWriterException.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\ExceptionHelper.cs">
+      <Link>ExceptionHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\ICsvParser.cs">
+      <Link>ICsvParser.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\ICsvReader.cs">
+      <Link>ICsvReader.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\ICsvReaderRow.cs">
+      <Link>ICsvReaderRow.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\ICsvSerializer.cs">
+      <Link>ICsvSerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\ICsvWriter.cs">
+      <Link>ICsvWriter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\ReflectionHelper.cs">
+      <Link>ReflectionHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\StringHelper.cs">
+      <Link>StringHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\BooleanConverter.cs">
+      <Link>TypeConversion\BooleanConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\ByteConverter.cs">
+      <Link>TypeConversion\ByteConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\CharConverter.cs">
+      <Link>TypeConversion\CharConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\CsvTypeConverterException.cs">
+      <Link>TypeConversion\CsvTypeConverterException.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\DateTimeConverter.cs">
+      <Link>TypeConversion\DateTimeConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\DecimalConverter.cs">
+      <Link>TypeConversion\DecimalConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\DefaultTypeConverter.cs">
+      <Link>TypeConversion\DefaultTypeConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\DoubleConverter.cs">
+      <Link>TypeConversion\DoubleConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\EnumConverter.cs">
+      <Link>TypeConversion\EnumConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\EnumerableConverter.cs">
+      <Link>TypeConversion\EnumerableConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\GuidConverter.cs">
+      <Link>TypeConversion\GuidConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\Int16Converter.cs">
+      <Link>TypeConversion\Int16Converter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\Int32Converter.cs">
+      <Link>TypeConversion\Int32Converter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\Int64Converter.cs">
+      <Link>TypeConversion\Int64Converter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\ITypeConverter.cs">
+      <Link>TypeConversion\ITypeConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\NullableConverter.cs">
+      <Link>TypeConversion\NullableConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\SByteConverter.cs">
+      <Link>TypeConversion\SByteConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\SingleConverter.cs">
+      <Link>TypeConversion\SingleConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\StringConverter.cs">
+      <Link>TypeConversion\StringConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\TimeSpanConverter.cs">
+      <Link>TypeConversion\TimeSpanConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\TypeConverterFactory.cs">
+      <Link>TypeConversion\TypeConverterFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\TypeConverterOptions.cs">
+      <Link>TypeConversion\TypeConverterOptions.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\TypeConverterOptionsFactory.cs">
+      <Link>TypeConversion\TypeConverterOptionsFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\UInt16Converter.cs">
+      <Link>TypeConversion\UInt16Converter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\UInt32Converter.cs">
+      <Link>TypeConversion\UInt32Converter.cs</Link>
+    </Compile>
+    <Compile Include="..\CsvHelper\TypeConversion\UInt64Converter.cs">
+      <Link>TypeConversion\UInt64Converter.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
This is mostly for iOS as it does not support `Expression` and the `Compile()` method.
iOS is not JIT, but rather AOT.

The new project is just a PCL version of the .NET 2.0 project. I am just using the 2.0 profile as this excludes the Expressions.

This is the same code changes as my other PR: #334, but without the component bits.
As that one was a big change, I can submit the actual component on your behalf. a.k.a. Xamarin will submit it. The publisher will be Xamarin Inc, but all credit and links will point to you. 

Let me know if this is a better option as we would really like to see your component in the Xamarin Component store.
