### PR TITLE
Fixed crash on exporting an array.

### DIFF
--- a/src/CsvHelper.Tests/CsvWriterTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterTests.cs
@@ -156,6 +156,26 @@ namespace CsvHelper.Tests
         }
 
         [TestMethod]
+        public void WriteEmptyArrayTest()
+        {
+            var records = new TestRecord[] { };
+
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream) { AutoFlush = true };
+            var csv = new CsvWriter(writer);
+            csv.Configuration.RegisterClassMap<TestRecordMap>();
+
+            csv.WriteRecords(records);
+
+            stream.Position = 0;
+            var reader = new StreamReader(stream);
+            var csvFile = reader.ReadToEnd();
+            var expected = "FirstColumn,Int Column,StringColumn,TypeConvertedColumn\r\n";
+
+            Assert.AreEqual(expected, csvFile);
+        }
+
+        [TestMethod]
         public void WriteRecordsCalledWithTwoParametersTest()
         {
             var records = new List<object>

--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -428,7 +428,7 @@ namespace CsvHelper
 
 			// Write the header. If records is a List<dynamic>, the header won't be written.
 			// This is because typeof( T ) = Object.
-			var genericEnumerable = records.GetType().GetInterfaces().FirstOrDefault( t => t.GetGenericTypeDefinition() == typeof( IEnumerable<> ) );
+			var genericEnumerable = records.GetType().GetInterfaces().FirstOrDefault( t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof( IEnumerable<> ) );
 			if( genericEnumerable != null )
 			{
 				var type = genericEnumerable.GetGenericArguments().Single();


### PR DESCRIPTION
Hi Josh,

I noticed that the latest version of CsvHelper (2.11.0) crashes when the target collection to export is an array.

type.GetGenericTypeDefinition throws InvalidOperationException ("This operation is only valid on generic types.") on non generic interfaces.

In this Pull Request I
- Fixed the CsvWriter.WriteRecords method
- Added WriteEmptyArrayTest

Please let me know if I'm missing something.

Regards,
Dan