### PR TITLE
Added callback to determine whether to skip a record or not

### DIFF
--- a/src/CsvHelper.Tests/CsvReaderTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderTests.cs
@@ -827,6 +827,34 @@ namespace CsvHelper.Tests
 		}
 
 		[TestMethod]
+		public void SkipRecordCallbackTest()
+		{
+			var queue = new Queue<string[]>();
+			queue.Enqueue(new[] { "1", "2", "3" });
+			queue.Enqueue(new[] { " ", "", "" });
+			queue.Enqueue(new[] { "4", "5", "6" });
+			queue.Enqueue(null);
+
+			var parserMock = new ParserMock(queue);
+
+			var reader = new CsvReader(parserMock);
+			reader.Configuration.HasHeaderRecord = false;
+			reader.Configuration.SkipRecordCallback = row => row[1] == "2";
+
+			reader.Read();
+			Assert.AreEqual(" ", reader.CurrentRecord[0]);
+			Assert.AreEqual("", reader.CurrentRecord[1]);
+			Assert.AreEqual("", reader.CurrentRecord[2]);
+
+			reader.Read();
+			Assert.AreEqual("4", reader.CurrentRecord[0]);
+			Assert.AreEqual("5", reader.CurrentRecord[1]);
+			Assert.AreEqual("6", reader.CurrentRecord[2]);
+
+			Assert.IsFalse(reader.Read());
+		}
+
+		[TestMethod]
 		public void MultipleGetRecordsCalls()
 		{
 			using( var stream = new MemoryStream() )

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Globalization;
 #if !NET_2_0
 using System.Linq;
+#else
+using CsvHelper.MissingFrom20;
 #endif
 using System.Reflection;
 using System.Text;
@@ -347,6 +349,14 @@ namespace CsvHelper.Configuration
 		///   <c>true</c> if [skip empty rows]; otherwise, <c>false</c>.
 		/// </value>
 		public virtual bool SkipEmptyRecords { get; set; }
+
+		/// <summary>
+		/// Gets or sets the callback that will be called to
+		/// determine whether to skip the given record or not.
+		/// This will will not be called for empty records if
+		/// <see cref="SkipEmptyRecords"/> is set to <c>true</c>.
+		/// </summary>
+		public virtual Func<string[], bool> SkipRecordCallback { get; set; }
 
 		/// <summary>
 		/// Gets or sets a value indicating if quotes should be

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -178,7 +178,7 @@ namespace CsvHelper
 			{
 				currentRecord = parser.Read();
 			} 
-			while( configuration.SkipEmptyRecords && IsRecordEmpty( false ) );
+			while( ShouldSkipRecord() );
 
 			currentIndex = -1;
 			hasBeenRead = true;
@@ -1232,6 +1232,33 @@ namespace CsvHelper
 					namedIndexes[name] = new List<int> { i };
 				}
 			}
+		}
+
+		/// <summary>
+		/// Checks if the current record should be skipped or not.
+		/// </summary>
+		/// <returns><c>true</c> if the current record should be skipped, <c>false</c> otherwise.</returns>
+		protected virtual bool ShouldSkipRecord()
+		{
+			CheckDisposed();
+
+			if( currentRecord == null )
+			{
+				return false;
+			}
+
+			if( configuration.SkipEmptyRecords && IsRecordEmpty( false ) )
+			{
+				return true;
+			}
+
+			var callback = configuration.SkipRecordCallback;
+			if( callback != null )
+			{
+				return callback( currentRecord );
+			}
+
+			return false;
 		}
 
 #if !NET_2_0


### PR DESCRIPTION
This PR adds a `SkipRecordCallback` property to `CsvConfiguration` that can be set to control which records should be skipped.