### PR TITLE
CsvWriter.cs: Fix for IndexOutOfRangeException

### DIFF
--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -156,7 +156,7 @@ namespace CsvHelper
 		{
 			CheckDisposed();
 
-			if( configuration.UseExcelLeadingZerosFormatForNumerics && field[0] == '0' && field.All( Char.IsDigit ) )
+			if( configuration.UseExcelLeadingZerosFormatForNumerics && field.All( Char.IsDigit ) && field[0] == '0' )
 			{
 				field = "=" + configuration.Quote + field + configuration.Quote;
 			}


### PR DESCRIPTION
In a situation where UseExcelLeadingZerosFormatForNumerics = True, and any fields are empty, an IndexOutOfRangeException will be thrown when evaluating " field[0] == '0' ".

Swopped around the logic to test for all digits first, and then if first character is a 0.

Alternatively you could introduce a test for !string.IsNullOrEmpty( field ), although I'm not sure which would be more suitable from a performance perspective?

Thanks.

Stacktrace:
   at System.String.get_Chars(Int32 index)
   at CsvHelper.CsvWriter.WriteField(String field, Boolean shouldQuote) in c:\Projects\CsvHelper\src\CsvHelper\CsvWriter.cs:line 159
   at CsvHelper.CsvWriter.WriteField(String field) in c:\Projects\CsvHelper\src\CsvHelper\CsvWriter.cs:line 140
   at CsvHelper.CsvWriter.WriteField(Type type, Object field) in c:\Projects\CsvHelper\src\CsvHelper\CsvWriter.cs:line 234
   at CsvHelper.CsvWriter.WriteField[T](T field) in c:\Projects\CsvHelper\src\CsvHelper\CsvWriter.cs:line 183
   at lambda_method(Closure , PatientViewModel )
   at System.Action`1.Invoke(T obj)