### PR TITLE
Bugfix for nullable types

### DIFF
--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -185,7 +185,7 @@ namespace CsvHelper
 		{
 			CheckDisposed();
 
-			var type = field.GetType();
+			var type = typeof(T);
 			if( type == typeof( string ) )
 			{
 				WriteField( field as string );


### PR DESCRIPTION
if the value of field is null the GetType method throws a NullReferenceException.
Also using GetType will return the underlying type when T is Nullable<T> so the NullableConverter is not used.