### PR TITLE
Added raw file line number to reader, just as has been done for parser

### DIFF
--- a/src/CsvHelper.Tests/CsvReaderConstructorTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderConstructorTests.cs
@@ -82,8 +82,9 @@ namespace CsvHelper.Tests
 			}
 
 			public string RawRecord { get; private set; }
+		    public int RawRow { get; }
 
-			public string[] Read()
+		    public string[] Read()
 			{
 				throw new NotImplementedException();
 			}

--- a/src/CsvHelper.Tests/CsvReaderTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderTests.cs
@@ -906,7 +906,55 @@ namespace CsvHelper.Tests
 			Assert.AreEqual( 2, csv.Row );
 		}
 
-		[TestMethod]
+        [TestMethod]
+        public void RowRawTest()
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new StreamWriter(stream))
+            using (var reader = new StreamReader(stream))
+            using (var csvReader = new CsvReader(reader))
+            {
+                writer.WriteLine("1,\"2");
+                writer.WriteLine("2 continued");
+                writer.WriteLine("end of 2\",3");
+                writer.WriteLine("4,5,6");
+                writer.WriteLine("7,\"8");
+                writer.WriteLine("8 continued");
+                writer.WriteLine("end of 8\",9");
+                writer.WriteLine("10,11,12");
+                writer.Flush();
+                stream.Position = 0;
+
+                csvReader.Configuration.HasHeaderRecord = false;
+
+                var isRead = csvReader.Read();
+                
+                Assert.AreEqual("1", csvReader[0]);
+                Assert.AreEqual("2\r\n2 continued\r\nend of 2", csvReader[1]);
+                Assert.AreEqual("3", csvReader[2]);
+                Assert.AreEqual(3, csvReader.RawRow);
+
+                isRead = csvReader.Read();
+                Assert.AreEqual("4", csvReader[0]);
+                Assert.AreEqual("5", csvReader[1]);
+                Assert.AreEqual("6", csvReader[2]);
+                Assert.AreEqual(4, csvReader.RawRow);
+
+                isRead = csvReader.Read();
+                Assert.AreEqual("7", csvReader[0]);
+                Assert.AreEqual("8\r\n8 continued\r\nend of 8", csvReader[1]);
+                Assert.AreEqual("9", csvReader[2]);
+                Assert.AreEqual(7, csvReader.RawRow);
+
+                isRead = csvReader.Read();
+                Assert.AreEqual("10", csvReader[0]);
+                Assert.AreEqual("11", csvReader[1]);
+                Assert.AreEqual("12", csvReader[2]);
+                Assert.AreEqual(8, csvReader.RawRow);
+            }
+        }
+
+        [TestMethod]
 		public void DoNotIgnoreBlankLinesTest()
 		{
 			using( var stream = new MemoryStream() )

--- a/src/CsvHelper.Tests/Mocks/ParserMock.cs
+++ b/src/CsvHelper.Tests/Mocks/ParserMock.cs
@@ -24,8 +24,9 @@ namespace CsvHelper.Tests.Mocks
 		public long BytePosition { get; private set; }
 		public int Row { get; private set; }
 		public string RawRecord { get; private set; }
+	    public int RawRow { get; }
 
-		public ParserMock()
+	    public ParserMock()
 		{
 			Configuration = new CsvConfiguration();
 			rows = new Queue<string[]>();

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -99,12 +99,27 @@ namespace CsvHelper
 			}
 		}
 
-		/// <summary>
-		/// Creates a new CSV reader using the given <see cref="TextReader"/> and
-		/// <see cref="CsvParser"/> as the default parser.
+        /// <summary>
+		/// Gets the row of the CSV file that the parser is currently on.
+	    /// This is the actual file row.
 		/// </summary>
-		/// <param name="reader">The reader.</param>
-		public CsvReader( TextReader reader ) : this( reader, new CsvConfiguration() ) {}
+		public int RawRow
+        {
+            get
+            {
+                CheckDisposed();
+                CheckHasBeenRead();
+
+                return parser.RawRow;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new CSV reader using the given <see cref="TextReader"/> and
+        /// <see cref="CsvParser"/> as the default parser.
+        /// </summary>
+        /// <param name="reader">The reader.</param>
+        public CsvReader( TextReader reader ) : this( reader, new CsvConfiguration() ) {}
 
 		/// <summary>
 		/// Creates a new CSV reader using the given <see cref="TextReader"/> and

--- a/src/CsvHelper/ICsvParser.cs
+++ b/src/CsvHelper/ICsvParser.cs
@@ -42,7 +42,13 @@ namespace CsvHelper
 		/// </summary>
 		string RawRecord { get; }
 
-		/// <summary>
+	    /// <summary>
+	    /// Gets the row of the CSV file that the parser is currently on.
+	    /// This is the actual file row.
+	    /// </summary>
+	    int RawRow { get; }
+
+	    /// <summary>
 		/// Reads a record from the CSV file.
 		/// </summary>
 		/// <returns>A <see cref="T:String[]" /> of fields for the record read.</returns>


### PR DESCRIPTION
For parser there is a RawRow, there wasn't one for reader. 

When you want to show progress and use File.Readlines("filename").Count() to get the total number of lines and set this as the maximum, but the file contains linefeeds you can't show actual progress based on Row, whith the RawRow you can.
