### PR TITLE
Fix for bug #423 - WriteField() & nullable types

### DIFF
--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -185,7 +185,7 @@ namespace CsvHelper
 		{
 			CheckDisposed();
 
-			var type = field.GetType();
+			var type = field == null ? typeof(T) : field.GetType();
 			if( type == typeof( string ) )
 			{
 				WriteField( field as string );
@@ -209,8 +209,8 @@ namespace CsvHelper
 		public virtual void WriteField<T>( T field, ITypeConverter converter )
 		{
 			CheckDisposed();
-
-			var typeConverterOptions = TypeConverterOptionsFactory.GetOptions( field.GetType() );
+            var type = field == null ? typeof(T) : field.GetType();
+			var typeConverterOptions = TypeConverterOptionsFactory.GetOptions( type );
 			if( typeConverterOptions.CultureInfo == null )
 			{
 				typeConverterOptions.CultureInfo = configuration.CultureInfo;


### PR DESCRIPTION
This cahnge allows for a nullable type with a null value to be
successfully passed succesfully to WriteField<T>. Null reference error
occured because the GetType() method was being called (and is required for
unboxing) but would fail when a null field value was passed. This fix
allows typeof() to be called when the field passed in has a null value.