### PR TITLE
Enhancements to multi-character delimiter support

### DIFF
--- a/src/CsvHelper.Tests/CsvParserDelimiterTests.cs
+++ b/src/CsvHelper.Tests/CsvParserDelimiterTests.cs
@@ -122,6 +122,40 @@ namespace CsvHelper.Tests
 			}
 		}
 
+        [TestMethod]
+        public void MultipleCharDelimiterSameCharacterTest()
+        {
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            using (var parser = new CsvParser(reader))
+            {
+                writer.WriteLine("1|||2||||3");
+                writer.WriteLine("4||5|||6");
+                writer.Flush();
+                stream.Position = 0;
+
+                parser.Configuration.Delimiter = "|||";
+                parser.Configuration.HasHeaderRecord = false;
+
+                var row = parser.Read();
+                Assert.IsNotNull(row);
+                Assert.AreEqual(3, row.Length);
+                Assert.AreEqual("1", row[0]);
+                Assert.AreEqual("2", row[1]);
+                Assert.AreEqual("|3", row[2]);
+
+                row = parser.Read();
+                Assert.IsNotNull(row);
+                Assert.AreEqual(3, row.Length);
+                Assert.AreEqual("4||5", row[0]);
+                Assert.AreEqual("6", row[1]);
+
+                row = parser.Read();
+                Assert.IsNull(row);
+            }
+        }
+
 		[TestMethod]
 		public void AllFieldsEmptyTest()
 		{

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -443,25 +443,28 @@ namespace CsvHelper
 
 						inDelimiter = true;
 					}
-					
-					if( delimiterPosition == configuration.Delimiter.Length - 1 )
-					{
-						// We are done reading the delimeter.
 
-						// Include the delimiter in the byte count.
-						UpdateBytePosition( fieldStartPosition, readerBufferPosition - fieldStartPosition );
-						inDelimiter = false;
-						prevCharWasDelimiter = true;
-						fieldStartPosition = readerBufferPosition;
-					}
-					else if( configuration.Delimiter[delimiterPosition] != c )
-					{
-						// We're not actually in a delimiter. Reset things back
-						// to the previous field.
-						recordPosition--;
-						fieldStartPosition -= ( delimiterPosition + 1 );
-						inDelimiter = false;
-					}
+                    if (configuration.Delimiter[delimiterPosition] != c)
+                    {
+                        // We're not actually in a delimiter. Reset things back
+                        // to the previous field.
+                        recordPosition--;
+
+                        //rewind correctly to start of field
+                        fieldStartPosition -= (1 + record[recordPosition].Length);
+                        inDelimiter = false;
+                    }
+
+                    else if (delimiterPosition == configuration.Delimiter.Length - 1)
+                    {
+                        // We are done reading the delimeter.
+
+                        // Include the delimiter in the byte count.
+                        UpdateBytePosition(fieldStartPosition, readerBufferPosition - fieldStartPosition);
+                        inDelimiter = false;
+                        prevCharWasDelimiter = true;
+                        fieldStartPosition = readerBufferPosition;
+                    }
 					else
 					{
 						delimiterPosition++;


### PR DESCRIPTION
Correctly rewind cursor when processing non-delimiter characters that
are a subset of the multi-character delimiter
