### PR TITLE
NuGet package: separate 'net40' and 'net40-client' targets.

### DIFF
--- a/src/CsvHelper.nuspec
+++ b/src/CsvHelper.nuspec
@@ -15,6 +15,7 @@
 		</releaseNotes>
 	</metadata>
 	<files>
+		<file src="CsvHelper\bin\Release\CsvHelper.*" target="lib\net40\" />
 		<file src="CsvHelper\bin\Release\CsvHelper.*" target="lib\net40-client\" />
 		<file src="CsvHelper20\bin\Release\CsvHelper.*" target="lib\net20\" />
 		<file src="CsvHelper35\bin\Release\CsvHelper.*" target="lib\net35-client\" />

--- a/src/CsvHelper.nuspec
+++ b/src/CsvHelper.nuspec
@@ -15,8 +15,7 @@
 		</releaseNotes>
 	</metadata>
 	<files>
-		<file src="CsvHelper\bin\Release\CsvHelper.*" target="lib\net40\" />
-		<file src="CsvHelper\bin\Release\CsvHelper.*" target="lib\net40-client\" />
+		<file src="CsvHelper\bin\Release\CsvHelper.*" target="lib\net40+net40-client\" />
 		<file src="CsvHelper20\bin\Release\CsvHelper.*" target="lib\net20\" />
 		<file src="CsvHelper35\bin\Release\CsvHelper.*" target="lib\net35-client\" />
 		<file src="CsvHelperPcl\bin\Release\CsvHelper.*" target="lib\portable-net40+sl5+win8+wpa+wp8\" />


### PR DESCRIPTION
DNX does not care about client profile dependencies when building a non-client profile project.
So even for `net45` project it always loads highest possible non-client profile `CsvHelper` assembly, which is `net20` which lacks some functionality compared to the `net40-client` assembly.
Easiest way to fix this is to provide separate assemblies for `net40` target in the NuGet package.