### PR TITLE
Add overload to References that takes CsvClassMap instance

### DIFF
--- a/src/CsvHelper.Tests/CsvHelper.Tests.csproj
+++ b/src/CsvHelper.Tests/CsvHelper.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="ClearRecordsCacheTests.cs" />
     <Compile Include="LocalCultureTests.cs" />
     <Compile Include="MappingInheritedClassTests.cs" />
+    <Compile Include="Mappings\ReferenceClassMapTests.cs" />
     <Compile Include="Mappings\ReferenceConstructorArgsTests.cs" />
     <Compile Include="Mocks\ParserMock.cs" />
     <Compile Include="Mocks\SerializerMock.cs" />

--- a/src/CsvHelper.Tests/Mappings/ReferenceClassMapTests.cs
+++ b/src/CsvHelper.Tests/Mappings/ReferenceClassMapTests.cs
@@ -1,0 +1,46 @@
+namespace CsvHelper.Tests.Mappings
+{
+    using Configuration;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ReferenceClassMapTests
+    {
+        [TestMethod]
+        public void Test()
+        {
+            var map = new AMap( "A Field" );
+            var name = map.ReferenceMaps[0].Data.Mapping.PropertyMap<B>( m => m.Name ).Data.Names[0];
+            Assert.AreEqual( "B Field", name );
+        }
+
+        private class A
+        {
+            public string Name { get; set; }
+
+            public B B { get; set; }
+        }
+
+        private class B
+        {
+            public string Name { get; set; }
+        }
+
+        private sealed class AMap : CsvClassMap<A>
+        {
+            public AMap( string name )
+            {
+                Map( m => m.Name ).Name( name );
+                References( m => m.B, new BMap("B Field") );
+            }
+        }
+
+        private sealed class BMap : CsvClassMap<B>
+        {
+            public BMap( string name )
+            {
+                Map( m => m.Name ).Name( name );
+            }
+        }
+    }
+}

--- a/src/CsvHelper/Configuration/CsvClassMap`1.cs
+++ b/src/CsvHelper/Configuration/CsvClassMap`1.cs
@@ -78,16 +78,44 @@ namespace CsvHelper.Configuration
 			ReferenceMaps.Add( reference );
 
 			return reference;
-		}
+        }
 
-		/// <summary>
-		/// Maps a property to another class map.
-		/// </summary>
-		/// <param name="type">The type.</param>
-		/// <param name="expression">The expression.</param>
-		/// <param name="constructorArgs">Constructor arguments used to create the reference map.</param>
-		/// <returns>The reference mapping for the property</returns>
-		[Obsolete( "This method is deprecated and will be removed in the next major release. Use References<TClassMap>( Expression<Func<T, object>> expression, params object[] constructorArgs ) instead.", false )]
+        /// <summary>
+        /// Maps a property to another class map.
+        /// </summary>
+        /// <typeparam name="T">The type of the class to map.</typeparam>
+        /// <param name="expression">The expression.</param>
+        /// <param name="map">The class map.</param>
+        /// <returns>The reference mapping for the property.</returns>
+        public virtual CsvPropertyReferenceMap References(Expression<Func<T, object>> expression, CsvClassMap map)
+        {
+            var property = ReflectionHelper.GetProperty(expression);
+
+            var existingMap = ReferenceMaps.SingleOrDefault(m =>
+               m.Data.Property == property
+               || m.Data.Property.Name == property.Name
+               && (m.Data.Property.DeclaringType.IsAssignableFrom(property.DeclaringType) || property.DeclaringType.IsAssignableFrom(m.Data.Property.DeclaringType)));
+            if (existingMap != null)
+            {
+                return existingMap;
+            }
+            
+            map.CreateMap();
+            map.ReIndex(GetMaxIndex() + 1);
+            var reference = new CsvPropertyReferenceMap(property, map);
+            ReferenceMaps.Add(reference);
+
+            return reference;
+        }
+
+        /// <summary>
+        /// Maps a property to another class map.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="expression">The expression.</param>
+        /// <param name="constructorArgs">Constructor arguments used to create the reference map.</param>
+        /// <returns>The reference mapping for the property</returns>
+        [Obsolete( "This method is deprecated and will be removed in the next major release. Use References<TClassMap>( Expression<Func<T, object>> expression, params object[] constructorArgs ) instead.", false )]
 		protected virtual CsvPropertyReferenceMap References( Type type, Expression<Func<T, object>> expression, params object[] constructorArgs )
 		{
 			var property = ReflectionHelper.GetProperty( expression );


### PR DESCRIPTION
This PR adds an overload to to the `References` method that takes a `CsvClassMap` instance, instead of creating it using reflection.

The added functionality is also tested.
