### PR TITLE
Fix typo in QuoteNoFields codesample.

### DIFF
--- a/index.md
+++ b/index.md
@@ -504,7 +504,7 @@ A flag that tell the writer whether all fields written should not have quotes ar
 
 ```cs
 // Default value
-csv.Configuration.QuoteAllFields = false;
+csv.Configuration.QuoteNoFields = false;
 ```
 
 ### [configuration] Reading Exception Callback

--- a/index.md
+++ b/index.md
@@ -491,7 +491,7 @@ csv.Configuration.Quote = '"';
 
 ### [configuration] Quote All Fields
 
-A flag that tells the writer whether all fields written should have quotes around them; regardless if the field contains anything that should be escaped. Both QuoteAllFields and QuoteNotFields cannot be true at the same time. Setting one to true will set the other to false.
+A flag that tells the writer whether all fields written should have quotes around them; regardless if the field contains anything that should be escaped. Both QuoteAllFields and QuoteNoFields cannot be true at the same time. Setting one to true will set the other to false.
 
 ```cs
 // Default value
@@ -500,7 +500,7 @@ csv.Configuration.QuoteAllFields = false;
 
 ### [configuration] Quote No Fields
 
-A flag that tell the writer whether all fields written should not have quotes around them; regardless if the field contains anything that should be escaped. Both QuoteAllFields and QuoteNotFields cannot be true at the same time. Setting one to true will set the other to false.
+A flag that tell the writer whether all fields written should not have quotes around them; regardless if the field contains anything that should be escaped. Both QuoteAllFields and QuoteNoFields cannot be true at the same time. Setting one to true will set the other to false.
 
 ```cs
 // Default value


### PR DESCRIPTION
This change fixes an apparent typo in the documentation where QuoteNoFields section shows an example with QuoteAllFields rather than QuoteNoFields.