### PR TITLE
#290 Do not cache "default" TypeConverterOptions

### DIFF
--- a/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
+++ b/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
@@ -70,6 +70,26 @@ namespace CsvHelper.Tests.TypeConversion
         }
 
         [TestMethod]
+        public void GetFieldSwitchCulturesTest()
+        {
+            GetFieldForCultureTest("\"1234,32\",\"5678,44\"", "fr-FR", 1234.32M, 5678.44M);
+            GetFieldForCultureTest("\"9876.54\",\"3210.98\"", "en-GB", 9876.54M, 3210.98M);
+            GetFieldForCultureTest("\"4455,6677\",\"9988,77\"", "el-GR", 4455.6677M, 9988.77M);
+        }
+
+        private static void GetFieldForCultureTest(string csvText, string culture, decimal expected1, decimal expected2)
+        {
+            using (var reader = new StringReader(csvText))
+            using (var csvReader = new CsvReader(reader, new CsvConfiguration { CultureInfo = CultureInfo.GetCultureInfo(culture) }))
+            {
+                csvReader.Configuration.HasHeaderRecord = false;
+                csvReader.Read();
+                Assert.AreEqual(expected1, csvReader.GetField<decimal>(0));
+                Assert.AreEqual(expected2, csvReader.GetField(typeof(decimal), 1));
+            }
+        }
+
+        [TestMethod]
         public void GetRecordsTest()
         {
             var options = new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands };

--- a/src/CsvHelper/TypeConversion/DefaultTypeConverter.cs
+++ b/src/CsvHelper/TypeConversion/DefaultTypeConverter.cs
@@ -42,7 +42,8 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public virtual object ConvertFromString( TypeConverterOptions options, string text )
 		{
-			throw new CsvTypeConverterException( "The conversion cannot be performed." );
+			throw new CsvTypeConverterException( string.Format( "The conversion cannot be performed. Converter: {0}, text: \"{1}\"",
+                GetType().FullName, text ) );
 		}
 
 		/// <summary>

--- a/src/CsvHelper/TypeConversion/TypeConverterOptionsFactory.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterOptionsFactory.cs
@@ -93,7 +93,6 @@ namespace CsvHelper.TypeConversion
 				if( !typeConverterOptions.TryGetValue( type, out options ) )
 				{
 					options = new TypeConverterOptions();
-					typeConverterOptions.Add( type, options );
 				}
 
 				return options;


### PR DESCRIPTION
Caching TypeConverterOptions cached the current culture and caused subsequently specified cultures to be ignored. (Test case based on PR #313 by cleftheris.)