### PR TITLE
Fixes issue #575

### DIFF
--- a/src/CsvHelper.Tests/Reading/ShouldSkipRecordTests.cs
+++ b/src/CsvHelper.Tests/Reading/ShouldSkipRecordTests.cs
@@ -48,5 +48,28 @@ namespace CsvHelper.Tests.Reading
 			Assert.AreEqual( "1", csv.GetField( 0 ) );
 			Assert.AreEqual( "2", csv.GetField( 1 ) );
 		}
+
+        [TestMethod]
+        public void ShouldSkipWithEmptyRows()
+        {
+            var rows = new Queue<string[]>();
+            rows.Enqueue(new[] { "First,Second" });
+            rows.Enqueue(new[] { "skipme," });
+            rows.Enqueue(new[] { "" });
+            rows.Enqueue(new[] { "1", "2" });
+
+            var parser = new ParserMock(rows);
+
+            var csv = new CsvReader(parser);
+            csv.Configuration.ShouldSkipRecord = row =>
+            {
+                return row[0].StartsWith("skipme");
+            };
+            csv.Configuration.SkipEmptyRecords = true;
+
+            csv.Read();
+            Assert.AreEqual("1", csv.GetField(0));
+            Assert.AreEqual("2", csv.GetField(1));
+        }
 	}
 }

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -1174,9 +1174,9 @@ namespace CsvHelper
 				return false;
 			}
 
-			return configuration.ShouldSkipRecord != null 
-				? configuration.ShouldSkipRecord( currentRecord ) 
-				: configuration.SkipEmptyRecords && IsRecordEmpty( false );
+            return configuration.ShouldSkipRecord != null
+                ? configuration.ShouldSkipRecord(currentRecord) || (configuration.SkipEmptyRecords && IsRecordEmpty(false))
+                : configuration.SkipEmptyRecords && IsRecordEmpty(false);
 		}
 
 #if !NET_2_0


### PR DESCRIPTION
https://github.com/JoshClose/CsvHelper/issues/575 Setting a Configuration.ShouldSkipRecord method always overrides the Configuration.SkipEmptyRecords setting.

Now if ShouldSkipRecord() returns false and IsRecordEmpty() returns true, the record will be skipped and vice versa