### PR TITLE
Allow FieldHeaders to be set externally

### DIFF
--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -64,7 +64,12 @@ namespace CsvHelper
 
 				return headerRecord;
 			}
-		}
+            set
+            {
+                headerRecord = value;
+                ParseNamedIndexes();
+            }
+        }
 
 		/// <summary>
 		/// Get the current record;
@@ -1228,7 +1233,7 @@ namespace CsvHelper
 				throw new ArgumentNullException( nameof( names ) );
 			}
 
-			if( !configuration.HasHeaderRecord )
+			if( !configuration.HasHeaderRecord && FieldHeaders == null )
 			{
 				throw new CsvReaderException( "There is no header record to determine the index by name." );
 			}

--- a/src/CsvHelper/ICsvReaderRow.cs
+++ b/src/CsvHelper/ICsvReaderRow.cs
@@ -23,7 +23,7 @@ namespace CsvHelper
 		/// <summary>
 		/// Gets the field headers.
 		/// </summary>
-		string[] FieldHeaders { get; }
+		string[] FieldHeaders { get; set; }
 
 		/// <summary>
 		/// Get the current record;


### PR DESCRIPTION
Having the ability to set FieldHeaders property manually (when HasHeaderRecord is false) would be good.    This would be needed when headers aren't provided in the file and header names are needed during reading.