### PR TITLE
Fix large numbers in Excel

### DIFF
--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -184,7 +184,7 @@ namespace CsvHelper
 				field = field.Replace( configuration.QuoteString, configuration.DoubleQuoteString );
 			}
 
-			if( configuration.UseExcelLeadingZerosFormatForNumerics && !string.IsNullOrEmpty( field ) && field[0] == '0' && field.All( Char.IsDigit ) )
+			if( configuration.UseExcelLeadingZerosFormatForNumerics && !string.IsNullOrEmpty( field ) && field.All( Char.IsDigit ) )
 			{
 				field = "=" + configuration.Quote + field + configuration.Quote;
 			}


### PR DESCRIPTION
The UseExcelLeadingZerosFormatForNumerics option prepends the value with "=" but only when a leading 0 is present. Excel actually requires this at all times for large numbers.