### PR TITLE
Option to prevent Excel macro injection attack

### DIFF
--- a/src/CsvHelper.Tests/CsvWriterTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterTests.cs
@@ -368,6 +368,114 @@ namespace CsvHelper.Tests
         }
 
         [TestMethod]
+        public void WriteRecordsEscapeExcelMacrosTest()
+        {
+            var records = new[]
+            {
+                new TestRecord
+                {
+                    IntColumn = 1,
+                    StringColumn = "=ABS(-1337)"
+                },
+                new TestRecord
+                {
+                    IntColumn = 2,
+                    StringColumn = "+100"
+                },
+                new TestRecord
+                {
+                    IntColumn = 3,
+                    StringColumn = "-100"
+                },
+                new TestRecord
+                {
+                    IntColumn = 4,
+                    StringColumn = "@evil"
+                }
+            };
+
+            var csv = new string[records.Length];
+
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            using (var csvWriter = new CsvWriter(writer))
+            {
+                csvWriter.Configuration.HasHeaderRecord = false;
+                csvWriter.Configuration.EscapeExcelMacros = true;
+                csvWriter.Configuration.RegisterClassMap<TestRecordMap>();
+                csvWriter.WriteRecords(records);
+
+                writer.Flush();
+                stream.Position = 0;
+
+                for (var i = 0; i < records.Length; i++)
+                {
+                    csv[i] = reader.ReadLine();
+                }
+            }
+
+            Assert.AreEqual(",1,'=ABS(-1337),test", csv[0]);
+            Assert.AreEqual(",2,'+100,test", csv[1]);
+            Assert.AreEqual(",3,'-100,test", csv[2]);
+            Assert.AreEqual(",4,'@evil,test", csv[3]);
+        }
+
+        [TestMethod]
+        public void WriteRecordsNoEscapeExcelMacrosTest()
+        {
+            var records = new[]
+            {
+                new TestRecord
+                {
+                    IntColumn = 1,
+                    StringColumn = "=ABS(-1337)"
+                },
+                new TestRecord
+                {
+                    IntColumn = 2,
+                    StringColumn = "+100"
+                },
+                new TestRecord
+                {
+                    IntColumn = 3,
+                    StringColumn = "-100"
+                },
+                new TestRecord
+                {
+                    IntColumn = 4,
+                    StringColumn = "@evil"
+                }
+            };
+
+            var csv = new string[records.Length];
+
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            using (var csvWriter = new CsvWriter(writer))
+            {
+                csvWriter.Configuration.HasHeaderRecord = false;
+                csvWriter.Configuration.EscapeExcelMacros = false;
+                csvWriter.Configuration.RegisterClassMap<TestRecordMap>();
+                csvWriter.WriteRecords(records);
+
+                writer.Flush();
+                stream.Position = 0;
+
+                for (var i = 0; i < records.Length; i++)
+                {
+                    csv[i] = reader.ReadLine();
+                }
+            }
+
+            Assert.AreEqual(",1,=ABS(-1337),test", csv[0]);
+            Assert.AreEqual(",2,+100,test", csv[1]);
+            Assert.AreEqual(",3,-100,test", csv[2]);
+            Assert.AreEqual(",4,@evil,test", csv[3]);
+        }
+
+        [TestMethod]
         public void WriteHeaderTest()
         {
             string csv;

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -287,7 +287,21 @@ namespace CsvHelper.Configuration
 		/// </summary>
 		public virtual bool IncludePrivateMembers { get; set; }
 
-		/// <summary>
+	    /// <summary>
+	    /// Gets or sets a value indicating if Excel macros should be escaped
+	    /// to prevent Excel macro injection attacks.
+	    /// Escaped macro characters are '=', '+', '-' and '@'.
+	    /// True to escape, otherwise false. Default is false.
+	    /// </summary>
+        public bool EscapeExcelMacros { get; set; }
+
+	    /// <summary>
+	    /// Gets or sets the character used to escape Excel macros.
+	    /// Default is '.
+	    /// </summary>
+        public char ExcelMacrosEscapeCharacter { get; set; } = '\'';
+
+	    /// <summary>
 		/// Gets or sets the member types that are used when auto mapping.
 		/// MemberTypes are flags, so you can choose more than one.
 		/// Default is Properties.
@@ -309,7 +323,7 @@ namespace CsvHelper.Configuration
 		/// </summary>
 		public virtual bool PrefixReferenceHeaders { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// Gets or sets a value indicating if an exception should
 		/// be thrown when bad field data is detected.
 		/// True to throw, otherwise false. Default is false.

--- a/src/CsvHelper/Configuration/ICsvWriterConfiguration.cs
+++ b/src/CsvHelper/Configuration/ICsvWriterConfiguration.cs
@@ -118,12 +118,26 @@ namespace CsvHelper.Configuration
 		/// </summary>
 		bool PrefixReferenceHeaders { get; set; }
 
-		/// <summary>
-		/// Gets or sets the member types that are used when auto mapping.
-		/// MemberTypes are flags, so you can choose more than one.
-		/// Default is Properties.
-		/// </summary>
-		MemberTypes MemberTypes { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating if Excel macros should be escaped
+        /// to prevent Excel macro injection attacks.
+        /// Escaped macro characters are '=', '+', '-' and '@'.
+        /// True to escape, otherwise false. Default is false.
+        /// </summary>
+        bool EscapeExcelMacros { get; set; }
+
+        /// <summary>
+        /// Gets or sets the character used to escape Excel macros.
+        /// Default is '.
+        /// </summary>
+        char ExcelMacrosEscapeCharacter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the member types that are used when auto mapping.
+        /// MemberTypes are flags, so you can choose more than one.
+        /// Default is Properties.
+        /// </summary>
+        MemberTypes MemberTypes { get; set; }
 
 		/// <summary>
 		/// The configured <see cref="CsvClassMap"/>s.

--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -37,7 +37,8 @@ namespace CsvHelper
 		private readonly Dictionary<Type, TypeConverterOptions> typeConverterOptionsCache = new Dictionary<Type, TypeConverterOptions>();
 		private readonly ICsvWriterConfiguration configuration;
 		private int row = 1;
-		private CsvPropertyMapData reusablePropertyMapData = new CsvPropertyMapData( null );
+		private readonly CsvPropertyMapData reusablePropertyMapData = new CsvPropertyMapData( null );
+	    private readonly IEnumerable<char> excelMacroCharacters = new[] { '=', '+', '-', '@' };
 
 		/// <summary>
 		/// Gets the serializer.
@@ -179,6 +180,11 @@ namespace CsvHelper
 		/// <param name="shouldQuote">True to quote the field, otherwise false.</param>
 		public virtual void WriteField( string field, bool shouldQuote )
 		{
+		    if( configuration.EscapeExcelMacros && !string.IsNullOrEmpty(field) && excelMacroCharacters.Contains(field.First()) )
+		    {
+		        field = configuration.ExcelMacrosEscapeCharacter + field;
+		    }
+
             // All quotes must be doubled.       
 			if( shouldQuote && !string.IsNullOrEmpty( field ) )
 			{


### PR DESCRIPTION
Add config option to escape Excel macros. This prevents Excel macro injection attacks for CSV that contain user input.

More details on the attack:
https://www.owasp.org/index.php/CSV_Excel_Macro_Injection
http://blog.securelayer7.net/how-to-perform-csv-excel-macro-injection