### PR TITLE
Simple use case with custom class having internal constructor requires special config in 3.0.0

### DIFF
--- a/src/CsvHelper.Tests/CsvWriterTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterTests.cs
@@ -818,6 +818,33 @@ namespace CsvHelper.Tests
 			}
 		}
 
+
+		[TestMethod]
+		public void WriteInternalConstructorClassTest()
+		{
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var csv = new CsvWriter(writer))
+			{
+				csv.WriteRecords(new List<GetOnly>());
+				writer.Flush();
+				stream.Position = 0;
+
+				var text = reader.ReadToEnd();
+				Assert.AreEqual("One\r\n", text);
+			}
+		}
+
+		private class GetOnly
+		{
+			internal GetOnly(string someParam)
+			{
+			}
+
+			public int One { get; }
+		}
+
 		private class TestWithStatic
 		{
 			public int Id { get; set; }


### PR DESCRIPTION
commit adds WriteInternalConstructorClassTest

This test currently fails because of `internal` constructor (in 3.0.0).
CsvHelper.Configuration.Configuration{ ShouldUseConstructorParameters = type => false } fixes this but should not be necessary for such a simple use case.

Worked before and I think it should work again without special Configuration.