### PR TITLE
Fix broken links in docs - Need relative path within gh-pages web site.

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -39,6 +39,6 @@ Want to contribute? Great! Here are a few guidelines.
 4. Pull requests should have a single commit. If you have multiple commits, squash them into a single commit before requesting a pull.
 5. Try and follow the code styling already in place.
 
-Looking for 2.x documentation? You can find it [here](/2.x).
+Looking for 2.x documentation? You can find it [here](2.x).
 
 <br/>

--- a/pages/reading.md
+++ b/pages/reading.md
@@ -171,6 +171,6 @@ When reading, all the information in the system is held in a context object. If 
 
 <hr/>
 
-See [configuration](/configuration)
+See [configuration](configuration)
 
 <br/>

--- a/pages/writing.md
+++ b/pages/writing.md
@@ -189,6 +189,6 @@ When writing, all the information in the system is held in a context object. If 
 
 <hr/>
 
-See [configuration](/configuration)
+See [configuration](configuration)
 
 <br/>


### PR DESCRIPTION
Fix some broken links in CsvHelper docs website - Need relative path within gh-pages web site.

Web Root = http://joshclose.github.io/CsvHelper/

`configuration` -> http://joshclose.github.io/CsvHelper/configuration

`2.x` -> http://joshclose.github.io/CsvHelper/2.x/

Currently, for example, in the doc section http://joshclose.github.io/CsvHelper/reading#configuration
the " See [configuration] " link is an absolute path and points to `http://joshclose.github.io/configuration`  which is 404 NotFound.
