### PR TITLE
Unit test to reproduce bug when using TrimOptions.InsideQuotes

### DIFF
--- a/src/CsvHelper.Tests/Parsing/TrimTests.cs
+++ b/src/CsvHelper.Tests/Parsing/TrimTests.cs
@@ -875,5 +875,24 @@ namespace CsvHelper.Tests.Parsing
 				Assert.AreEqual( "d e f", record.B );
 			}
 		}
-	}
+
+        [TestMethod]
+        public void InsideQuotesWithDelimiterAndSpacesInFieldTest()
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new StreamWriter(stream))
+            using (var reader = new StreamReader(stream))
+            using (var parser = new CsvParser(reader))
+            {
+                writer.WriteLine("\"  a ,b c\",b");
+                writer.Flush();
+                stream.Position = 0;
+
+                parser.Configuration.TrimOptions = TrimOptions.InsideQuotes;
+                var record = parser.Read();
+
+                Assert.AreEqual("a ,b c", record[0]);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Here is a unit test showing an issue related to #795 

You'll see I have a example of a quoted string with TrimOptions.InsideQuotes, and inside the quoted string I have a delimiter, and it is incorrectly trimming the string in the middle.