### PR TITLE
Test showing trim failing with small buffer size

### DIFF
--- a/src/CsvHelper.Tests/Parsing/TrimTests.cs
+++ b/src/CsvHelper.Tests/Parsing/TrimTests.cs
@@ -603,7 +603,27 @@ namespace CsvHelper.Tests.Parsing
 			}
 		}
 
-		[TestMethod]
+	    [TestMethod]
+	    public void InsideQuotesStartSpacesInFieldDelimiterInFieldSmallBufferNoNewlineTest()
+	    {
+	        using (var stream = new MemoryStream())
+	        using (var writer = new StreamWriter(stream))
+	        using (var reader = new StreamReader(stream))
+	        using (var parser = new CsvParser(reader))
+	        {
+	            writer.WriteLine("\" a ,b c\",b");
+	            writer.Flush();
+	            stream.Position = 0;
+
+	            parser.Configuration.TrimOptions = TrimOptions.InsideQuotes;
+	            parser.Configuration.BufferSize = 1;
+	            var record = parser.Read();
+
+	            Assert.AreEqual("a ,b c", record[0]);
+	        }
+	    }
+
+        [TestMethod]
 		public void InsideQuotesEndTest()
 		{
 			using( var stream = new MemoryStream() )


### PR DESCRIPTION
This unit test replicates the problem that still happens on 4.0.1 when the buffer has to be read while reading a quoted field. In my real world example, I'm using the default buffer size.