### PR TITLE
Unit Tests for Carriage Return line ending and next row empty value

### DIFF
--- a/src/CsvHelper.Tests/CsvParserTests.cs
+++ b/src/CsvHelper.Tests/CsvParserTests.cs
@@ -423,7 +423,41 @@ namespace CsvHelper.Tests
 			}
 		}
 
-		[TestMethod]
+	    [TestMethod]
+	    public void ParseRecordWhereOnlyCarriageReturnLineEndingIsUsedWithNextRowEmptyValue()
+	    {
+	        using (var memoryStream = new MemoryStream())
+	        using (var streamReader = new StreamReader(memoryStream))
+	        using (var streamWriter = new StreamWriter(memoryStream))
+	        using (var parser = new CsvParser(streamReader))
+	        {
+	            streamWriter.Write("one,two\r");
+	            streamWriter.Write(",four\r");
+	            streamWriter.Write("five,six\r");
+	            streamWriter.Flush();
+	            memoryStream.Position = 0;
+
+	            var record = parser.Read();
+	            Assert.IsNotNull(record);
+	            Assert.AreEqual(2, record.Length);
+	            Assert.AreEqual("one", record[0]);
+	            Assert.AreEqual("two", record[1]);
+
+	            record = parser.Read();
+	            Assert.IsNotNull(record);
+	            Assert.AreEqual(2, record.Length);
+	            Assert.AreEqual("", record[0]);
+	            Assert.AreEqual("four", record[0]);
+
+	            record = parser.Read();
+	            Assert.IsNotNull(record);
+	            Assert.AreEqual(2, record.Length);
+	            Assert.AreEqual("five", record[0]);
+	            Assert.AreEqual("six", record[1]);
+	        }
+	    }
+
+        [TestMethod]
 		public void ParseRecordWhereOnlyLineFeedLineEndingIsUsed()
 		{
 			using( var memoryStream = new MemoryStream() )
@@ -457,7 +491,41 @@ namespace CsvHelper.Tests
 			}
 		}
 
-		[TestMethod]
+	    [TestMethod]
+	    public void ParseRecordWhereOnlyLineFeedLineEndingIsUsedWithNextRowEmptyValue()
+	    {
+	        using (var memoryStream = new MemoryStream())
+	        using (var streamReader = new StreamReader(memoryStream))
+	        using (var streamWriter = new StreamWriter(memoryStream))
+	        using (var parser = new CsvParser(streamReader))
+	        {
+	            streamWriter.Write("one,two\n");
+	            streamWriter.Write(",four\n");
+	            streamWriter.Write("five,six\n");
+	            streamWriter.Flush();
+	            memoryStream.Position = 0;
+
+	            var record = parser.Read();
+	            Assert.IsNotNull(record);
+	            Assert.AreEqual(2, record.Length);
+	            Assert.AreEqual("one", record[0]);
+	            Assert.AreEqual("two", record[1]);
+
+	            record = parser.Read();
+	            Assert.IsNotNull(record);
+	            Assert.AreEqual(2, record.Length);
+	            Assert.AreEqual("", record[0]);
+	            Assert.AreEqual("four", record[1]);
+
+	            record = parser.Read();
+	            Assert.IsNotNull(record);
+	            Assert.AreEqual(2, record.Length);
+	            Assert.AreEqual("five", record[0]);
+	            Assert.AreEqual("six", record[1]);
+	        }
+	    }
+
+        [TestMethod]
 		public void ParseCommentedOutLineWithCommentsOn()
 		{
 			var stream = new MemoryStream();


### PR DESCRIPTION
Strange behavior with first empty value in a row and carriage return as line separator.