### PR TITLE
Fix record vs field confusion in ReadHeader docstring

### DIFF
--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -84,7 +84,7 @@ namespace CsvHelper
 		}
 
 		/// <summary>
-		/// Reads the header field without reading the first row.
+		/// Reads the header record without reading the first row.
 		/// </summary>
 		/// <returns>True if there are more records, otherwise false.</returns>
 		public virtual bool ReadHeader()

--- a/src/CsvHelper/IReader.cs
+++ b/src/CsvHelper/IReader.cs
@@ -21,7 +21,7 @@ namespace CsvHelper
 		IParser Parser { get; }
 
 		/// <summary>
-		/// Reads the header field without reading the first row.
+		/// Reads the header record without reading the first row.
 		/// </summary>
 		/// <returns>True if there are more records, otherwise false.</returns>
 		bool ReadHeader();


### PR DESCRIPTION
This puzzled me for a bit when it showed up in Visual Studio's autocomplete; I wasn't sure whether this was going to read the whole header record (yep!) or read a single column name from the header record (nope!). This should avoid anyone else experiencing the same confusion.