### PR TITLE
 Avoid NullReferenceException when reader is Disposed more than once.

### DIFF
--- a/src/CsvHelper.Tests/CsvReaderTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderTests.cs
@@ -21,17 +21,17 @@ namespace CsvHelper.Tests
 	[TestClass]
 	public class CsvReaderTests
 	{
-        [TestMethod]
-        public void DisposeShouldBeCallableMultipleTimes()
-        {
-            var parserMock = new ParserMock( new Queue<string[]>() );
-            var reader = new CsvReader( parserMock );
+		[TestMethod]
+		public void DisposeShouldBeCallableMultipleTimes()
+		{
+			var parserMock = new ParserMock( new Queue<string[]>() );
+			var reader = new CsvReader( parserMock );
 
-            for ( var i = 0; i < 3; i++ )
-            {
-                reader.Dispose();
-            }
-        }
+			for ( var i = 0; i < 3; i++ )
+			{
+				reader.Dispose();
+			}
+		}
 
 		[TestMethod]
 		public void HasHeaderRecordNotReadExceptionTest()

--- a/src/CsvHelper.Tests/CsvReaderTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderTests.cs
@@ -21,6 +21,18 @@ namespace CsvHelper.Tests
 	[TestClass]
 	public class CsvReaderTests
 	{
+        [TestMethod]
+        public void DisposeShouldBeCallableMultipleTimes()
+        {
+            var parserMock = new ParserMock( new Queue<string[]>() );
+            var reader = new CsvReader( parserMock );
+
+            for ( var i = 0; i < 3; i++ )
+            {
+                reader.Dispose();
+            }
+        }
+
 		[TestMethod]
 		public void HasHeaderRecordNotReadExceptionTest()
 		{

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -1317,7 +1317,7 @@ namespace CsvHelper
 		/// <filterpriority>2</filterpriority>
 		public void Dispose()
 		{
-			Dispose( !context.LeaveOpen );
+			Dispose( !disposed && !context.LeaveOpen );
 			GC.SuppressFinalize( this );
 		}
 


### PR DESCRIPTION
Modified reader Dispose method so that subsequent calls to Dispose do not throw a NullReferenceException due to context being null.