### PR TITLE
Fixes #967: CsvWriter.Flush() fails to call .Flush() on underlying Te…

### DIFF
--- a/src/CsvHelper.Tests/CsvWriterTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterTests.cs
@@ -836,7 +836,49 @@ namespace CsvHelper.Tests
 			}
 		}
 
-		private class GetOnly
+        /// <summary>
+        /// Asserts that csv.Flush() results in the underlying TextWriter being flushed
+        /// </summary>
+        [TestMethod]
+        public void WriteRecordsFlushTest()
+        {
+            var records = new List<TestRecord>
+            {
+                new TestRecord
+                {
+                    IntColumn     = 1,
+                    StringColumn  = "string column",
+                    IgnoredColumn = "ignored column",
+                    FirstColumn   = "first column",
+                },
+                new TestRecord
+                {
+                    IntColumn     = 2,
+                    StringColumn  = "string column 2",
+                    IgnoredColumn = "ignored column 2",
+                    FirstColumn   = "first column 2",
+                },
+            };
+
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream) { AutoFlush = false }; // Autoflush not set
+            var csv    = new CsvWriter(writer);
+            csv.Configuration.RegisterClassMap<TestRecordMap>();
+
+            csv.WriteRecords(records);
+            csv.Flush();
+
+            stream.Position = 0;
+            var reader      = new StreamReader(stream);
+            var csvFile     = reader.ReadToEnd();
+            var expected    = "FirstColumn,Int Column,StringColumn,TypeConvertedColumn\r\n";
+            expected += "first column,1,string column,test\r\n";
+            expected += "first column 2,2,string column 2,test\r\n";
+
+            Assert.AreEqual(expected, csvFile);
+        }
+
+        private class GetOnly
 		{
 			internal GetOnly(string someParam)
 			{

--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -221,6 +221,7 @@ namespace CsvHelper
 
 			serializer.Write( context.Record.ToArray() );
 			context.Record.Clear();
+            context.Flush();
 		}
 
 		/// <summary>
@@ -230,6 +231,7 @@ namespace CsvHelper
 		{
 			await serializer.WriteAsync( context.Record.ToArray() );
 			context.Record.Clear();
+            await context.FlushAsync();
 		}
 
 		/// <summary>

--- a/src/CsvHelper/WritingContext.cs
+++ b/src/CsvHelper/WritingContext.cs
@@ -7,6 +7,7 @@ using CsvHelper.TypeConversion;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace CsvHelper
 {
@@ -104,6 +105,28 @@ namespace CsvHelper
 				TypeActions.Clear();
 			}
 		}
+
+        /// <summary>
+        /// Clears all buffers for the current context and causes any buffered data to be
+        /// written to the underlying stream.
+        /// </summary>
+        public void Flush() => Writer?.Flush();
+
+        /// <summary>
+        /// Asynchronously clears all buffers for the current context and causes any buffered
+        /// data to be written to the underlying stream.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous flush operation.</returns>
+        /// <exception cref="System.InvalidOperationException">The context is currently in use by a previous write operation.</exception>
+        public Task FlushAsync()
+        {
+            if (Writer == null)
+            {
+                return Task.FromResult<object>(null);
+            }
+
+            return Writer.FlushAsync();
+        }
 
 		/// <summary>
 		/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.


### PR DESCRIPTION
I ended up making the suggested changes and placing them in my own package feed. Figured I'd push them back in case you felt that they might be of use to others.

Let me know if there's anything further that you'd appreciate RE tests etc to improve the change.