### PR TITLE
Rename ConvertUsing Overloads to be clearer

### DIFF
--- a/docs-src/public/2.x/index.md
+++ b/docs-src/public/2.x/index.md
@@ -278,7 +278,7 @@ public sealed class MyClassMap : CsvClassMap<MyClass>
 
 #### [mapping] Convert Using
 
-When all else fails, you can use ConvertUsing. ConvertUsing allows you to write custom code inline to convert the row into a single property value.
+When all else fails, you can use UseReadConversion. UseReadConversion allows you to write custom code inline to convert the row into a single property value.
 
 ```cs
 public sealed class MyClassMap : CsvClassMap<MyClass>
@@ -286,13 +286,13 @@ public sealed class MyClassMap : CsvClassMap<MyClass>
 	public MyClassMap()
 	{
 		// Constant value.
-		Map( m => m.Constant ).ConvertUsing( row => 3 );
+		Map( m => m.Constant ).UseReadConversion( row => 3 );
 		// Aggregate of two rows.
-		Map( m => m.Aggregate ).ConvertUsing( row => row.GetField<int>( 0 ) + row.GetField<int>( 1 ) );
+		Map( m => m.Aggregate ).UseReadConversion( row => row.GetField<int>( 0 ) + row.GetField<int>( 1 ) );
 		// Collection with a single value.
-		Map( m => m.Names ).ConvertUsing( row => new List<string>{ row.GetField<string>( "Name" ) } );
+		Map( m => m.Names ).UseReadConversion( row => new List<string>{ row.GetField<string>( "Name" ) } );
 		// Just about anything.
-		Map( m => m.Anything ).ConvertUsing( row =>
+		Map( m => m.Anything ).UseReadConversion( row =>
 		{
 			// You can do anything you want in a block.
 			// Just make sure to return the same type as the property.

--- a/docs-src/src/pages/mapping.md
+++ b/docs-src/src/pages/mapping.md
@@ -162,18 +162,16 @@ Map( m => m.Name ).TypeConverter( new MyConverter() );
 Map( m => m.Name ).TypeConverter<MyConverter>();
 ```
 
-### ConvertUsing
+### UseReadConversion
 
-Specifies an expression to be used to convert a field to a member, or a member to a field.
-
-Reading:
+Specifies an expression to be used to convert a field to a member.
 
 ```cs
 // Convert to member
-Map( m => m.Aggregate ).ConvertUsing( row => row.Get<int>( "A" ) + row.Get<int>( "B" ) );
+Map( m => m.Aggregate ).UseReadConversion( row => row.Get<int>( "A" ) + row.Get<int>( "B" ) );
 
 // Block
-Map( m => m.Aggregate ).ConvertUsing( row =>
+Map( m => m.Aggregate ).UseReadConversion( row =>
 {
 	var a = row.Get<int>( "A" );
 	var b = row.Get<int>( "B" );
@@ -181,14 +179,16 @@ Map( m => m.Aggregate ).ConvertUsing( row =>
 } );
 ```
 
-Writing:
+### UseWriteConversion
+
+Specifies an expression to be used to convert a member to a field.
 
 ```cs
 // Convert to field
-Map( m => m.Aggregate ).ConvertUsing( m => $"A + B = {m.A + m.B}" );
+Map( m => m.Aggregate ).UseWriteConversion( m => $"A + B = {m.A + m.B}" );
 
 // Block
-Map( m => m.Aggregate ).ConvertUsing( m =>
+Map( m => m.Aggregate ).UseWriteConversion( m =>
 {
 	var field = "A + B = ";
 	field += ( m.A + m.B ).ToString();

--- a/src/CsvHelper.Tests/Configuration/ClassMapBuilderTests.cs
+++ b/src/CsvHelper.Tests/Configuration/ClassMapBuilderTests.cs
@@ -22,7 +22,7 @@ namespace CsvHelper.Tests.Configuration
 		private static readonly ClassMap<FakeClass> map = csvFactory.CreateClassMapBuilder<FakeClass>()
 			/*
 			.Map( m => m.A ).Constant( "a" )
-			.Map( m => m.A ).ConvertUsing( row => row.GetField( 0 ) )
+			.Map( m => m.A ).UseReadConversion( row => row.GetField( 0 ) )
 			.Map( m => m.A ).Default( "a" )
 			.Map( m => m.A ).Index( 0 )
 			.Map( m => m.A ).Index( 0 ).Validate( field => true )
@@ -54,7 +54,7 @@ namespace CsvHelper.Tests.Configuration
 			.Map( m => m.B ).Name( "B2" ).Default( 2 )
 			.Map( m => m.C ).Index( 2 ).TypeConverter( new DateTimeConverter() )
 			.Map( m => m.D ).Name( "D4" ).TypeConverter<DoubleConverter>().Default( 4d )
-			.Map( m => m.E ).ConvertUsing( ConvertExpression )
+			.Map( m => m.E ).UseReadConversion( ConvertExpression )
 			.Build();
 
 		[TestMethod]

--- a/src/CsvHelper.Tests/CsvReaderMappingTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderMappingTests.cs
@@ -201,7 +201,7 @@ namespace CsvHelper.Tests
 		{
 			public CovarianceClassMap()
 			{
-				Map( m => m.Id ).ConvertUsing( row => row.GetField<int>( 0 ) );
+				Map( m => m.Id ).UseReadConversion( row => row.GetField<int>( 0 ) );
 			}
 		}
 
@@ -215,7 +215,7 @@ namespace CsvHelper.Tests
 		//{
 		//	public ContravarianceClassMap()
 		//	{
-		//		Map( m => m.Id ).ConvertUsing( row => row.GetField<int?>( 0 ) );
+		//		Map( m => m.Id ).UseReadConversion( row => row.GetField<int?>( 0 ) );
 		//	}
 		//}
 
@@ -276,7 +276,7 @@ namespace CsvHelper.Tests
 		{
 			public ConvertUsingMap()
 			{
-				Map( m => m.IntColumn ).ConvertUsing( row => row.GetField<int>( 0 ) + row.GetField<int>( 1 ) );
+				Map( m => m.IntColumn ).UseReadConversion( row => row.GetField<int>( 0 ) + row.GetField<int>( 1 ) );
 			}
 		}
 
@@ -284,7 +284,7 @@ namespace CsvHelper.Tests
 		{
 			public ConvertUsingBlockMap()
 			{
-				Map( m => m.IntColumn ).ConvertUsing( row =>
+				Map( m => m.IntColumn ).UseReadConversion( row =>
 				{
 					var x = row.GetField<int>( 0 );
 					var y = row.GetField<int>( 1 );
@@ -297,7 +297,7 @@ namespace CsvHelper.Tests
 		{
 			public ConvertUsingConstantMap()
 			{
-				Map( m => m.IntColumn ).ConvertUsing( row => 1 );
+				Map( m => m.IntColumn ).UseReadConversion( row => 1 );
 			}
 		}
 
@@ -306,7 +306,7 @@ namespace CsvHelper.Tests
 			public ConvertUsingClassMap()
 			{
 				Map( m => m.IntColumn ).Name( "int2" );
-				Map( m => m.StringColumn ).ConvertUsing( row => row.GetField( "string.3" ) );
+				Map( m => m.StringColumn ).UseReadConversion( row => row.GetField( "string.3" ) );
 			}
 		}
 	}

--- a/src/CsvHelper.Tests/CsvWriterMappingTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterMappingTests.cs
@@ -197,7 +197,7 @@ namespace CsvHelper.Tests
 		{
 			public ConvertUsingMap()
 			{
-				Map( m => m.IntColumn ).ConvertUsing( m => $"Converted{m.IntColumn}" );
+				Map( m => m.IntColumn ).UseWriteConversion( m => $"Converted{m.IntColumn}" );
 			}
 		}
 
@@ -205,7 +205,7 @@ namespace CsvHelper.Tests
 		{
 			public ConvertUsingBlockMap()
 			{
-				Map( m => m.IntColumn ).ConvertUsing( m =>
+				Map( m => m.IntColumn ).UseWriteConversion( m =>
 				{
 					var x = "Converted";
 					x += m.IntColumn;
@@ -218,7 +218,7 @@ namespace CsvHelper.Tests
 		{
 			public ConvertUsingConstantMap()
 			{
-				Map( m => m.IntColumn ).ConvertUsing( m => "Constant" );
+				Map( m => m.IntColumn ).UseWriteConversion( m => "Constant" );
 			}
 		}
 	}

--- a/src/CsvHelper/Configuration/ClassMapBuilder.cs
+++ b/src/CsvHelper/Configuration/ClassMapBuilder.cs
@@ -179,14 +179,14 @@ namespace CsvHelper.Configuration
 		/// row to the member.
 		/// </summary>
 		/// <param name="convertExpression">The convert expression.</param>
-		IHasMap<TClass> ConvertUsing( Func<IReaderRow, TMember> convertExpression );
+		IHasMap<TClass> UseReadConversion( Func<IReaderRow, TMember> convertExpression );
 
 		/// <summary>
 		/// Specifies an expression to be used to convert the object
 		/// to a field.
 		/// </summary>
 		/// <param name="convertExpression">The convert expression.</param>
-		IHasMap<TClass> ConvertUsing( Func<TClass, string> convertExpression );
+		IHasMap<TClass> UseWriteConversion( Func<TClass, string> convertExpression );
 	}
 
 	/// <summary>
@@ -323,15 +323,15 @@ namespace CsvHelper.Configuration
 		}
 #pragma warning restore CS0693 // Type parameter has the same name as the type parameter from outer type
 
-		public IHasMap<TClass> ConvertUsing( Func<IReaderRow, TMember> convertExpression )
+		public IHasMap<TClass> UseReadConversion( Func<IReaderRow, TMember> convertExpression )
 		{
-			memberMap.ConvertUsing( convertExpression );
+			memberMap.UseReadConversion( convertExpression );
 			return this;
 		}
 
-		public IHasMap<TClass> ConvertUsing( Func<TClass, string> convertExpression )
+		public IHasMap<TClass> UseWriteConversion( Func<TClass, string> convertExpression )
 		{
-			memberMap.ConvertUsing( convertExpression );
+			memberMap.UseWriteConversion( convertExpression );
 			return this;
 		}
 

--- a/src/CsvHelper/Configuration/ClassMap`1.cs
+++ b/src/CsvHelper/Configuration/ClassMap`1.cs
@@ -78,7 +78,7 @@ namespace CsvHelper.Configuration
 		/// Meant for internal use only. 
 		/// Maps a member to another class map. When this is used, accessing a property through
 		/// sub-property mapping later won't work. You can only use one or the other. When using
-		/// this, ConvertUsing will also not work.
+		/// this, UseReadConversion will also not work.
 		/// </summary>
 		/// <typeparam name="TClassMap">The type of the class map.</typeparam>
 		/// <param name="expression">The expression.</param>

--- a/src/CsvHelper/Configuration/MemberMap`1.cs
+++ b/src/CsvHelper/Configuration/MemberMap`1.cs
@@ -180,7 +180,7 @@ namespace CsvHelper.Configuration
 		/// row to the member.
 		/// </summary>
 		/// <param name="convertExpression">The convert expression.</param>
-		public virtual MemberMap<TClass, TMember> ConvertUsing( Func<IReaderRow, TMember> convertExpression )
+		public virtual MemberMap<TClass, TMember> UseReadConversion( Func<IReaderRow, TMember> convertExpression )
 		{
 			Data.ReadingConvertExpression = (Expression<Func<IReaderRow, TMember>>)( x => convertExpression( x ) );
 
@@ -192,7 +192,7 @@ namespace CsvHelper.Configuration
 		/// to a field.
 		/// </summary>
 		/// <param name="convertExpression">The convert expression.</param>
-		public virtual MemberMap<TClass, TMember> ConvertUsing( Func<TClass, string> convertExpression )
+		public virtual MemberMap<TClass, TMember> UseWriteConversion( Func<TClass, string> convertExpression )
 		{
 			Data.WritingConvertExpression = (Expression<Func<TClass, string>>)( x => convertExpression( x ) );
 

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -170,7 +170,7 @@ namespace CsvHelper
 
 				if( memberMap.Data.ReadingConvertExpression != null || memberMap.Data.IsConstantSet )
 				{
-					// If ConvertUsing and Constant don't require a header.
+					// If UseReadConversion and Constant don't require a header.
 					continue;
 				}
 
@@ -1223,7 +1223,7 @@ namespace CsvHelper
 				throw new ReaderException( context, "There is no header record to determine the index by name." );
 			}
 
-			// Caching the named index speeds up mappings that use ConvertUsing tremendously.
+			// Caching the named index speeds up mappings that use UseReadConversion tremendously.
 			var nameKey = string.Join( "_", names ) + index;
 			if( context.NamedIndexCache.ContainsKey( nameKey ) )
 			{


### PR DESCRIPTION
TL;DR: Renamed `ConvertUsing` overloaded method to clearer `UseReadConversion` and `UseWriteConversion`

The overloads for `ConvertUsing` can be pretty confusing for new users, since one is meant for reading from an `IReaderRow` to a target type, and one is meant for writing from`T` to a string.  

It can result in really frustrating Intellisense confusion where you start your lambda like so:

```csharp
            Map(d => d.MyDecimalField).ConvertUsing(row =>
            {
                var val =  row.GetField<string>("MyHeader");
                // ready to do some parsing
            });
```
But Intellisense thinks you are using the Write overload and assumes `row` is `T` of the source type and not an `IReaderRow` so you get a confusing "`T` does not have the method `GetField`" error.

To get around this, you have to stub in a return value so Intellisense can figure out what you're doing, like so:

```csharp
            Map(d => d.MyDecimalField).ConvertUsing(row =>
            {
                var val =  row.GetField<string>("MyHeader");
                // ready to do some parsing
               return 0.0m; // temp return value until I finish my parsing
            });
```

At this point it can match the `Func` signature and removes the compilation error indication.  

In general, it seems clearer to name these functions differently as they are doing different conversions in opposite directions.   I chose the names `UseReadConversion` and `UseWriteConversion` but that is just a suggestion. 