### PR TITLE
Bugfix for #1122 and now exposes default Configuration callback methods.

### DIFF
--- a/src/CsvHelper.Tests/Reading/NullableValuesInEmptyColumnsInputTests.cs
+++ b/src/CsvHelper.Tests/Reading/NullableValuesInEmptyColumnsInputTests.cs
@@ -22,6 +22,7 @@ namespace CsvHelper.Tests.Reading
 			using( var csv = new CsvReader( reader ) )
 			{
 				csv.Configuration.IgnoreBlankLines = false;
+				csv.Configuration.TypeConverterOptionsCache.GetOptions<Int32?>().NullValues.Add( string.Empty );
 
 				// Read header row, assert header row columns:
 				{
@@ -62,6 +63,7 @@ namespace CsvHelper.Tests.Reading
 			using( var csv = new CsvReader( reader ) )
 			{
 				csv.Configuration.IgnoreBlankLines = false;
+				csv.Configuration.TypeConverterOptionsCache.GetOptions<Int32?>().NullValues.Add( string.Empty );
 
 				// Read header row, assert header row columns:
 				{
@@ -131,6 +133,7 @@ namespace CsvHelper.Tests.Reading
 			using( var csv = new CsvReader( reader ) )
 			{
 				csv.Configuration.IgnoreBlankLines = false;
+				csv.Configuration.TypeConverterOptionsCache.GetOptions<string>().NullValues.Add( string.Empty ); // Read empty fields as nulls instead of `""`.
 
 				// Read header row, assert header row columns:
 				{
@@ -234,8 +237,8 @@ namespace CsvHelper.Tests.Reading
 						String strByIndex = csv.GetField<string>( index: 1 );
 						String strByName  = csv.GetField<string>( name: "NullableStringField" );
 
-						Assert.IsNull( strByIndex );
-						Assert.IsNull( strByName  );
+						Assert.AreEqual( "Bar", strByIndex );
+						Assert.AreEqual( "Bar", strByName  );
 					}
 				}
 

--- a/src/CsvHelper.Tests/Reading/NullableValuesInEmptyColumnsInputTests.cs
+++ b/src/CsvHelper.Tests/Reading/NullableValuesInEmptyColumnsInputTests.cs
@@ -1,0 +1,249 @@
+﻿// Copyright 2009-2017 Josh Close and Contributors
+// This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
+// See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
+// https://github.com/JoshClose/CsvHelper
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CsvHelper.Tests.Reading
+{
+	[TestClass]
+	public class NullableValuesInEmptyColumnsInputTests
+	{
+		[TestMethod]
+		public void SingleColumnCsvWithHeadersAndSingleNullDataRowTest()
+		{
+			const string csvInput =
+				( "NullableInt32Field" + "\r\n" ) +
+				( "\r\n");
+
+			using( var reader = new StringReader( csvInput ) )
+			using( var csv = new CsvReader( reader ) )
+			{
+				csv.Configuration.IgnoreBlankLines = false;
+
+				// Read header row, assert header row columns:
+				{
+					Assert.IsTrue( csv.Read() );
+					Assert.IsTrue( csv.ReadHeader() );
+					Assert.AreEqual( 1, csv.Context.HeaderRecord.Length );
+					Assert.AreEqual( "NullableInt32Field", csv.Context.HeaderRecord[0] );
+				}
+
+				// Read single data row, assert single null value:
+				{
+					Assert.IsTrue( csv.Read() );
+					
+					Int32? nullableIntValueByIndex = csv.GetField<Int32?>( index: 0 );
+					Int32? nullableIntValueByName  = csv.GetField<Int32?>( name: "NullableInt32Field" );
+
+					Assert.IsFalse( nullableIntValueByIndex.HasValue );
+					Assert.IsFalse( nullableIntValueByName .HasValue );
+				}
+
+				// Read to end of file:
+				{
+					Assert.IsFalse( csv.Read() );
+				}
+			}
+		}
+
+		[TestMethod]
+		public void SingleColumnCsvWithHeadersAndPresentAndNullDataRowTest()
+		{
+			const string csvInput =
+				( "NullableInt32Field" + "\r\n" ) +
+				( "1"                  + "\r\n" ) + //    1
+				(                        "\r\n" ) + // NULL
+				( "3"                  + "\r\n" );  //    3
+
+			using( var reader = new StringReader( csvInput ) )
+			using( var csv = new CsvReader( reader ) )
+			{
+				csv.Configuration.IgnoreBlankLines = false;
+
+				// Read header row, assert header row columns:
+				{
+					Assert.IsTrue( csv.Read() );
+					Assert.IsTrue( csv.ReadHeader() );
+					Assert.AreEqual( 1, csv.Context.HeaderRecord.Length );
+					Assert.AreEqual( "NullableInt32Field", csv.Context.HeaderRecord[0] );
+				}
+
+				// Read first data row, assert "1" value:
+				{
+					Assert.IsTrue( csv.Read() );
+					
+					Int32? nullableIntValueByIndex = csv.GetField<Int32?>( index: 0 );
+					Int32? nullableIntValueByName  = csv.GetField<Int32?>( name: "NullableInt32Field" );
+
+					Assert.IsTrue( nullableIntValueByIndex.HasValue );
+					Assert.IsTrue( nullableIntValueByName .HasValue );
+
+					Assert.AreEqual( 1, nullableIntValueByIndex );
+					Assert.AreEqual( 1, nullableIntValueByName  );
+				}
+
+				// Read second data row, assert null value:
+				{
+					Assert.IsTrue( csv.Read() );
+					
+					Int32? nullableIntValueByIndex = csv.GetField<Int32?>( index: 0 );
+					Int32? nullableIntValueByName  = csv.GetField<Int32?>( name: "NullableInt32Field" );
+
+					Assert.IsFalse( nullableIntValueByIndex.HasValue );
+					Assert.IsFalse( nullableIntValueByName .HasValue );
+				}
+
+				// Read third data row, assert "3" value:
+				{
+					Assert.IsTrue( csv.Read() );
+					
+					Int32? nullableIntValueByIndex = csv.GetField<Int32?>( index: 0 );
+					Int32? nullableIntValueByName  = csv.GetField<Int32?>( name: "NullableInt32Field" );
+
+					Assert.IsTrue( nullableIntValueByIndex.HasValue );
+					Assert.IsTrue( nullableIntValueByName .HasValue );
+
+					Assert.AreEqual( 3, nullableIntValueByIndex );
+					Assert.AreEqual( 3, nullableIntValueByName  );
+				}
+
+				// Read to end of file:
+				{
+					Assert.IsFalse( csv.Read() );
+				}
+			}
+		}
+
+		[TestMethod]
+		public void TwoColumnCsvWithHeadersAndPresentAndNullDataRowTest()
+		{
+			const string csvInput =
+				( "NullableInt32Field,NullableStringField" + "\r\n" ) +
+				( "1,"                                     + "\r\n" ) + //    1, NULL
+				( ",\"Foo\""                               + "\r\n" ) + // NULL, "Foo"
+				( ","                                      + "\r\n" ) + // NULL, NULL
+				( "4,\"Bar\""                              + "\r\n" );  //    4, "Bar"
+
+			using( var reader = new StringReader( csvInput ) )
+			using( var csv = new CsvReader( reader ) )
+			{
+				csv.Configuration.IgnoreBlankLines = false;
+
+				// Read header row, assert header row columns:
+				{
+					Assert.IsTrue( csv.Read() );
+					Assert.IsTrue( csv.ReadHeader() );
+					Assert.AreEqual( 2, csv.Context.HeaderRecord.Length );
+					Assert.AreEqual( "NullableInt32Field" , csv.Context.HeaderRecord[0] );
+					Assert.AreEqual( "NullableStringField", csv.Context.HeaderRecord[1] );
+				}
+
+				// Read first data row:
+				{
+					Assert.IsTrue( csv.Read() );
+
+					// Read `Int32?`, assert "1" value:
+					{
+						Int32? nullableIntValueByIndex = csv.GetField<Int32?>( index: 0 );
+						Int32? nullableIntValueByName  = csv.GetField<Int32?>( name: "NullableInt32Field" );
+
+						Assert.IsTrue( nullableIntValueByIndex.HasValue );
+						Assert.IsTrue( nullableIntValueByName .HasValue );
+
+						Assert.AreEqual( 1, nullableIntValueByIndex );
+						Assert.AreEqual( 1, nullableIntValueByName  );
+					}
+
+					// Read nullable String, assert null value:
+					{
+						String strByIndex = csv.GetField<string>( index: 1 );
+						String strByName  = csv.GetField<string>( name: "NullableStringField" );
+
+						Assert.IsNull( strByIndex );
+						Assert.IsNull( strByName  );
+					}
+				}
+
+				// Read second data row:
+				{
+					Assert.IsTrue( csv.Read() );
+					
+					// Read `Int32?`, assert NULL value:
+					{
+						Int32? nullableIntValueByIndex = csv.GetField<Int32?>( index: 0 );
+						Int32? nullableIntValueByName  = csv.GetField<Int32?>( name: "NullableInt32Field" );
+
+						Assert.IsFalse( nullableIntValueByIndex.HasValue );
+						Assert.IsFalse( nullableIntValueByName .HasValue );
+					}
+
+					// Read nullable String, assert "Foo" value:
+					{
+						String strByIndex = csv.GetField<string>( index: 1 );
+						String strByName  = csv.GetField<string>( name: "NullableStringField" );
+
+						Assert.AreEqual( "Foo", strByIndex );
+						Assert.AreEqual( "Foo", strByName  );
+					}
+				}
+
+				// Read third data row:
+				{
+					Assert.IsTrue( csv.Read() );
+					
+					// Read `Int32?`, assert NULL value:
+					{
+						Int32? nullableIntValueByIndex = csv.GetField<Int32?>( index: 0 );
+						Int32? nullableIntValueByName  = csv.GetField<Int32?>( name: "NullableInt32Field" );
+
+						Assert.IsFalse( nullableIntValueByIndex.HasValue );
+						Assert.IsFalse( nullableIntValueByName .HasValue );
+					}
+
+					// Read nullable String, assert "Foo" value:
+					{
+						String strByIndex = csv.GetField<string>( index: 1 );
+						String strByName  = csv.GetField<string>( name: "NullableStringField" );
+
+						Assert.IsNull( strByIndex );
+						Assert.IsNull( strByName  );
+					}
+				}
+
+				// Read fourth data row:
+				{
+					Assert.IsTrue( csv.Read() );
+					
+					// Read `Int32?`, assert "3" value:
+					{
+						Int32? nullableIntValueByIndex = csv.GetField<Int32?>( index: 0 );
+						Int32? nullableIntValueByName  = csv.GetField<Int32?>( name: "NullableInt32Field" );
+
+						Assert.IsTrue( nullableIntValueByIndex.HasValue );
+						Assert.IsTrue( nullableIntValueByName .HasValue );
+
+						Assert.AreEqual( 4, nullableIntValueByIndex );
+						Assert.AreEqual( 4, nullableIntValueByName  );
+					}
+
+					// Read nullable String, assert "Bar" value:
+					{
+						String strByIndex = csv.GetField<string>( index: 1 );
+						String strByName  = csv.GetField<string>( name: "NullableStringField" );
+
+						Assert.IsNull( strByIndex );
+						Assert.IsNull( strByName  );
+					}
+				}
+
+				// Read to end of file:
+				{
+					Assert.IsFalse( csv.Read() );
+				}
+			}
+		}
+	}
+}

--- a/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsTests.cs
+++ b/src/CsvHelper.Tests/TypeConversion/TypeConverterOptionsTests.cs
@@ -80,6 +80,47 @@ namespace CsvHelper.Tests.TypeConversion
 			}
 		}
 
+		[TestMethod]
+		public void NullValueTest()
+		{
+			const string input =
+				( "NULL,\"row0-col1\",\"row0-col2\"" + "\r\n" ) +
+				( "\"row1-col0\",NULL,\"row1-col2\"" + "\r\n" ) +
+				( "\"row2-col0\",\"row2-col1\",NULL" + "\r\n" );
+
+			using( var reader = new StringReader( input ) )
+			using( var csv = new CsvReader( reader ) )
+			{
+				csv.Configuration.HasHeaderRecord = false;
+				csv.Configuration.TypeConverterOptionsCache.GetOptions<string>().NullValues.Add( "NULL" );
+				
+				// Row 0:
+				Assert.IsTrue  ( csv.Read() );
+				Assert.AreEqual( 3, csv.Context.Record.Length );
+
+				Assert.IsNull  (              csv.GetField<string>( 0 ) );
+				Assert.AreEqual( "row0-col1", csv.GetField<string>( 1 ) );
+				Assert.AreEqual( "row0-col2", csv.GetField<string>( 2 ) );
+				
+
+				// Row 1:
+				Assert.IsTrue  ( csv.Read() );
+				Assert.AreEqual( 3, csv.Context.Record.Length );
+
+				Assert.AreEqual( "row1-col0", csv.GetField<string>( 0 ) );
+				Assert.IsNull  (              csv.GetField<string>( 1 ) );
+				Assert.AreEqual( "row1-col2", csv.GetField<string>( 2 ) );
+
+				// Row 2:
+				Assert.IsTrue  ( csv.Read() );
+				Assert.AreEqual( 3, csv.Context.Record.Length );
+
+				Assert.AreEqual( "row2-col0", csv.GetField<string>( 0 ) );
+				Assert.AreEqual( "row2-col1", csv.GetField<string>( 1 ) );
+				Assert.IsNull  (              csv.GetField<string>( 2 ) );
+			}
+		}
+
 		private class Test
 		{
 			public int? Id { get; set; }

--- a/src/CsvHelper/Configuration/Configuration.cs
+++ b/src/CsvHelper/Configuration/Configuration.cs
@@ -3,11 +3,10 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using System.Text;
+
 using CsvHelper.TypeConversion;
 
 namespace CsvHelper.Configuration
@@ -50,21 +49,7 @@ namespace CsvHelper.Configuration
 		/// You can supply your own function to do other things like logging the issue instead of throwing an exception.
 		/// Arguments: isValid, headerNames, headerNameIndex, context
 		/// </summary>
-		public virtual Action<bool, string[], int, ReadingContext> HeaderValidated { get; set; } = ( isValid, headerNames, headerNameIndex, context ) =>
-		{
-			if( isValid )
-			{
-				return;
-			}
-
-			var message =
-				$"Header matching ['{string.Join( "', '", headerNames )}'] names at index {headerNameIndex} was not found. " +
-				$"If you are expecting some headers to be missing and want to ignore this validation, " +
-				$"set the configuration {nameof( HeaderValidated )} to null. You can also change the " +
-				$"functionality to do something else, like logging the issue.";
-
-			throw new ValidationException( context, message );
-		};
+		public virtual Action<bool, string[], int, ReadingContext> HeaderValidated { get; set; } = ConfigurationDefaultCallbacks.HeaderValidated;
 
 		/// <summary>
 		/// Gets or sets the function that is called when a missing field is found. The default function will
@@ -72,17 +57,7 @@ namespace CsvHelper.Configuration
 		/// like logging the issue instead of throwing an exception.
 		/// Arguments: headerNames, index, context
 		/// </summary>
-		public virtual Action<string[], int, ReadingContext> MissingFieldFound { get; set; } = ( headerNames, index, context ) =>
-		{
-			var messagePostfix = $"You can ignore missing fields by setting {nameof( MissingFieldFound )} to null.";
-
-			if( headerNames != null && headerNames.Length > 0 )
-			{
-				throw new MissingFieldException( context, $"Field with names ['{string.Join( "', '", headerNames )}'] at index '{index}' does not exist. {messagePostfix}" );
-			}
-
-			throw new MissingFieldException( context, $"Field at index '{index}' does not exist. {messagePostfix}" );
-		};
+		public virtual Action<string[], int, ReadingContext> MissingFieldFound { get; set; } = ConfigurationDefaultCallbacks.MissingFieldFound;
 
 		/// <summary>
 		/// Gets or sets the function that is called when bad field data is found. A field
@@ -91,10 +66,7 @@ namespace CsvHelper.Configuration
 		/// instead of throwing an exception.
 		/// Arguments: context
 		/// </summary>
-		public virtual Action<ReadingContext> BadDataFound { get; set; } = context =>
-		{
-			throw new BadDataException( context, $"You can ignore bad data by setting {nameof( BadDataFound )} to null." );
-		};
+		public virtual Action<ReadingContext> BadDataFound { get; set; } = ConfigurationDefaultCallbacks.BadDataFound;
 
 		/// <summary>
 		/// Gets or sets the function that is called when a reading exception occurs.
@@ -103,13 +75,13 @@ namespace CsvHelper.Configuration
 		/// logging the issue.
 		/// Arguments: exception
 		/// </summary>
-		public virtual Action<CsvHelperException> ReadingExceptionOccurred { get; set; } = exception => throw exception;
+		public virtual Action<CsvHelperException> ReadingExceptionOccurred { get; set; } = ConfigurationDefaultCallbacks.ReadingExceptionOccurred;
 
 		/// <summary>
 		/// Gets or sets the callback that will be called to
 		/// determine whether to skip the given record or not.
 		/// </summary>
-		public virtual Func<string[], bool> ShouldSkipRecord { get; set; } = record => false;
+		public virtual Func<string[], bool> ShouldSkipRecord { get; set; } = ConfigurationDefaultCallbacks.ShouldSkipRecord;
 
 		/// <summary>
 		/// Gets or sets a value indicating if fields should be sanitized
@@ -144,23 +116,18 @@ namespace CsvHelper.Configuration
 		/// You should do things like trimming, removing whitespace, removing underscores,
 		/// and making casing changes to ignore case.
 		/// </summary>
-		public virtual Func<string, string> PrepareHeaderForMatch { get; set; } = header => header;
+		public virtual Func<string, string> PrepareHeaderForMatch { get; set; } = ConfigurationDefaultCallbacks.PrepareHeaderForMatch;
 
 		/// <summary>
 		/// Determines if constructor parameters should be used to create
 		/// the class instead of the default constructor and members.
 		/// </summary>
-		public virtual Func<Type, bool> ShouldUseConstructorParameters { get; set; } = type =>
-				!type.HasParameterlessConstructor()
-				&& type.HasConstructor()
-				&& !type.IsUserDefinedStruct()
-				&& !type.IsInterface
-				&& Type.GetTypeCode( type ) == TypeCode.Object;
+		public virtual Func<Type, bool> ShouldUseConstructorParameters { get; set; } = ConfigurationDefaultCallbacks.ShouldUseConstructorParameters;
 
 		/// <summary>
 		/// Chooses the constructor to use for constuctor mapping.
 		/// </summary>
-		public virtual Func<Type, ConstructorInfo> GetConstructor { get; set; } = type => type.GetConstructorWithMostParameters();
+		public virtual Func<Type, ConstructorInfo> GetConstructor { get; set; } = ConfigurationDefaultCallbacks.GetConstructor;
 
 		/// <summary>
 		/// Gets or sets a value indicating whether references

--- a/src/CsvHelper/Configuration/ConfigurationDefaultCallbacks.cs
+++ b/src/CsvHelper/Configuration/ConfigurationDefaultCallbacks.cs
@@ -45,8 +45,9 @@ namespace CsvHelper.Configuration
 		/// <summary>Always re-throws exceptions wrapped in a new <c>CsvHelperException</c>.</summary>
 		public static void ReadingExceptionOccurred(CsvHelperException exception)
 		{
-			// Don't simply `throw exception` because it erases the stack trace. Re-throw it by wrapping it in another exception:
-			throw new CsvHelperException( "Exception caught by " + nameof(ReadingExceptionOccurred) + " was unhandled.", exception );
+			// TODO: Don't simply `throw exception` because it erases the stack trace. Re-throw it by wrapping it in another exception:
+			//throw new CsvHelperException( "Exception caught by " + nameof(ReadingExceptionOccurred) + " was unhandled.", exception );
+			throw exception;
 		}
 
 		/// <summary>Always returns <c>false</c>.</summary>

--- a/src/CsvHelper/Configuration/ConfigurationDefaultCallbacks.cs
+++ b/src/CsvHelper/Configuration/ConfigurationDefaultCallbacks.cs
@@ -42,12 +42,16 @@ namespace CsvHelper.Configuration
 			throw new BadDataException( context, $"You can ignore bad data by setting {nameof( BadDataFound )} to null." );
 		}
 
-		/// <summary>Always re-throws exceptions wrapped in a new <c>CsvHelperException</c>.</summary>
+		/// <summary>Always re-throws the <paramref name="exception"/> value. Note this will erase the original <c>StackTrace</c> property value.</summary>
 		public static void ReadingExceptionOccurred(CsvHelperException exception)
 		{
-			// TODO: Don't simply `throw exception` because it erases the stack trace. Re-throw it by wrapping it in another exception:
-			//throw new CsvHelperException( "Exception caught by " + nameof(ReadingExceptionOccurred) + " was unhandled.", exception );
 			throw exception;
+		}
+
+		/// <summary>Always throws a new <c>CsvHelperException</c> that wraps the <paramref name="exception"/> value as the <c>InnerException</c>.</summary>
+		public static void WrapReadingExceptionOccurred(CsvHelperException exception)
+		{
+			throw new CsvHelperException( "Exception caught by " + nameof(ReadingExceptionOccurred) + " was unhandled.", exception );
 		}
 
 		/// <summary>Always returns <c>false</c>.</summary>

--- a/src/CsvHelper/Configuration/ConfigurationDefaultCallbacks.cs
+++ b/src/CsvHelper/Configuration/ConfigurationDefaultCallbacks.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Reflection;
+
+namespace CsvHelper.Configuration
+{
+	/// <summary>Holds the default callback methods for delegate members of <c>CsvHelper.Configuration.Configuration</c>.</summary>
+	public static class ConfigurationDefaultCallbacks
+	{
+		/// <summary>Throws <c>ValidationException</c> if <paramref name="isValid"/> is <c>false</c>.</summary>
+		public static void HeaderValidated(Boolean isValid, string[] headerNames, int headerNameIndex, ReadingContext context)
+		{
+			if( isValid )
+			{
+				return;
+			}
+
+			var message =
+				$"Header matching ['{string.Join( "', '", headerNames )}'] names at index {headerNameIndex} was not found. " +
+				$"If you are expecting some headers to be missing and want to ignore this validation, " +
+				$"set the configuration {nameof( HeaderValidated )} to null. You can also change the " +
+				$"functionality to do something else, like logging the issue.";
+
+			throw new ValidationException( context, message );
+		}
+
+		/// <summary>Always throws a <c>MissingFieldException</c>.</summary>
+		public static void MissingFieldFound(string[] headerNames, int index, ReadingContext context)
+		{
+			var messagePostfix = $"You can ignore missing fields by setting {nameof( MissingFieldFound )} to null.";
+
+			if( headerNames != null && headerNames.Length > 0 )
+			{
+				throw new MissingFieldException( context, $"Field with names ['{string.Join( "', '", headerNames )}'] at index '{index}' does not exist. {messagePostfix}" );
+			}
+
+			throw new MissingFieldException( context, $"Field at index '{index}' does not exist. {messagePostfix}" );
+		}
+
+		/// <summary>Always throws a <c>BadDataException</c>.</summary>
+		public static void BadDataFound(ReadingContext context)
+		{
+			throw new BadDataException( context, $"You can ignore bad data by setting {nameof( BadDataFound )} to null." );
+		}
+
+		/// <summary>Always re-throws exceptions wrapped in a new <c>CsvHelperException</c>.</summary>
+		public static void ReadingExceptionOccurred(CsvHelperException exception)
+		{
+			// Don't simply `throw exception` because it erases the stack trace. Re-throw it by wrapping it in another exception:
+			throw new CsvHelperException( "Exception caught by " + nameof(ReadingExceptionOccurred) + " was unhandled.", exception );
+		}
+
+		/// <summary>Always returns <c>false</c>.</summary>
+		public static bool ShouldSkipRecord(string[] record)
+		{
+			return false;
+		}
+
+		/// <summary>Always returns <paramref name="header"/> verbatim.</summary>
+		public static string PrepareHeaderForMatch(string header)
+		{
+			return header;
+		}
+
+		/// <summary>Returns <c>true</c> if <paramref name="type"/> is a class and has a non-parameterless constructor.</summary>
+		public static bool ShouldUseConstructorParameters(Type type)
+		{
+			return !type.HasParameterlessConstructor()
+				&& type.HasConstructor()
+				&& !type.IsUserDefinedStruct()
+				&& !type.IsInterface
+				&& Type.GetTypeCode( type ) == TypeCode.Object;
+		}
+
+		/// <summary>Always returns the type's constructor with the most parameters. If two constructors have the same number of parameters then it is not specified which constructor will be used.</summary>
+		public static ConstructorInfo GetConstructor(Type type)
+		{
+			return type.GetConstructorWithMostParameters();
+		}
+	}
+}

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -534,7 +534,10 @@ namespace CsvHelper
 			if( index >= context.Record.Length || index < 0 )
 			{
 				context.CurrentIndex = index;
-				context.ReaderConfiguration.MissingFieldFound?.Invoke( null, index, context );
+				if( context.ReaderConfiguration.IgnoreBlankLines )
+				{
+					context.ReaderConfiguration.MissingFieldFound?.Invoke( null, index, context );
+				}
 
 				return default( T );
 			}


### PR DESCRIPTION
1. The default callback actions in `Configuration` are lost if the properties are overwritten, preventing consumers from restoring default behaviour if they don't save the delegates first. This PR moves the implementation of those callbacks to a new static class `ConfigurationDefaultCallbacks` so they can always be referenced.
2. This PR fixes issue #1122 where `Configuration.IgnoreBlankLines` was being ignored in the generic `GetField<T>` methods.

Solution builds. All tests pass.