### PR TITLE
Implemented skip reference

### DIFF
--- a/src/CsvHelper.Tests/CsvReaderReferenceMappingSkipTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderReferenceMappingSkipTests.cs
@@ -1,0 +1,130 @@
+﻿// Copyright 2009-2017 Josh Close and Contributors
+// This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
+// See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
+// https://github.com/JoshClose/CsvHelper
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CsvHelper.Configuration;
+using System;
+
+namespace CsvHelper.Tests
+{
+	[TestClass]
+	public class CsvReaderReferenceMappingSkipTests
+	{
+		[TestMethod]
+		public void ReferencesWithSkipTest()
+		{
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var csv = new CsvReader(reader))
+			{
+				csv.Configuration.Delimiter = ",";
+				csv.Configuration.RegisterClassMap<AMap>();
+
+				writer.WriteLine("AId,BId,CId,DId");
+				writer.WriteLine("a1,b1,c1,d1");
+				writer.WriteLine("a2,b2,c2,skip");
+				writer.WriteLine("a3,b3,skip,d3");
+				writer.WriteLine("a4,skip,c4,d4");
+				writer.Flush();
+				stream.Position = 0;
+
+				var list = csv.GetRecords<A>().ToList();
+
+				Assert.IsNotNull(list);
+				Assert.AreEqual(4, list.Count);
+
+                for (var i = 0; i < 4; i++)
+				{
+					var rowId = i + 1;
+					var row = list[i];
+					Assert.AreEqual("a" + rowId, row.Id);
+
+                    if (i < 3)
+					    Assert.AreEqual("b" + rowId, row.B.Id);
+                    if (i < 2)
+					    Assert.AreEqual("c" + rowId, row.B.C.Id);
+                    if (i < 1)
+					    Assert.AreEqual("d" + rowId, row.B.C.D.Id);
+                }
+
+                Assert.IsNull(list[1].B.C.D);
+                Assert.IsNull(list[2].B.C);
+                Assert.IsNull(list[3].B);
+            }
+		}
+
+		private class A
+		{
+			public string Id { get; set; }
+
+			public B B { get; set; }
+		}
+
+		private class B
+		{
+			public string Id { get; set; }
+
+			public C C { get; set; }
+		}
+
+		private class C
+		{
+			public string Id { get; set; }
+
+			public D D { get; set; }
+		}
+
+		private class D
+		{
+			public string Id { get; set; }
+		}
+        
+		private sealed class AMap : ClassMap<A>
+		{
+			public AMap()
+			{
+				Map(m => m.Id).Name("AId");
+				References<BMap>(m => m.B).Skip(row =>
+                {
+                    return string.Equals(row.GetField("BId"), "skip", StringComparison.OrdinalIgnoreCase);
+                });
+			}
+		}
+
+		private sealed class BMap : ClassMap<B>
+		{
+			public BMap()
+			{
+				Map(m => m.Id).Name("BId");
+				References<CMap>(m => m.C).Skip(row =>
+                {
+                    return string.Equals(row.GetField("CId"), "skip", StringComparison.OrdinalIgnoreCase);
+                });
+			}
+		}
+
+		private sealed class CMap : ClassMap<C>
+		{
+			public CMap()
+			{
+				Map(m => m.Id).Name("CId");
+				References<DMap>(m => m.D).Skip(row =>
+                {
+                    return string.Equals(row.GetField("DId"), "skip", StringComparison.OrdinalIgnoreCase);
+                });
+			}
+		}
+
+		private sealed class DMap : ClassMap<D>
+		{
+			public DMap()
+			{
+                Map(m => m.Id).Name("DId");
+            }
+		}
+    }
+}

--- a/src/CsvHelper/Configuration/MemberReferenceMap.cs
+++ b/src/CsvHelper/Configuration/MemberReferenceMap.cs
@@ -4,6 +4,7 @@
 // https://github.com/JoshClose/CsvHelper
 using System;
 using System.Diagnostics;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace CsvHelper.Configuration
@@ -11,7 +12,7 @@ namespace CsvHelper.Configuration
 	/// <summary>
 	/// Mapping info for a reference member mapping to a class.
 	/// </summary>
-	[DebuggerDisplay( "Member = {Data.Member}, Prefix = {Data.Prefix}" )]
+	[DebuggerDisplay( "Member = {Data.Member}, Prefix = {Data.Prefix}, Skip = {Data.Skip}" )]
 	public class MemberReferenceMap
 	{
 		private readonly MemberReferenceMapData data;
@@ -53,12 +54,21 @@ namespace CsvHelper.Configuration
 			return this;
 		}
 
-		/// <summary>
-		/// Get the largest index for the
-		/// members and references.
+        /// <summary>
+		/// Specifies an expression to be used to set this reference to it's default.
 		/// </summary>
-		/// <returns>The max index.</returns>
-		internal int GetMaxIndex()
+		/// <param name="skipExpression">The skip expression.</param>
+        public virtual void Skip(Func<IReaderRow, bool> skipExpression)
+        {
+            data.Skip = (Expression<Func<IReaderRow, bool>>)(x => skipExpression(x));
+        }
+
+        /// <summary>
+        /// Get the largest index for the
+        /// members and references.
+        /// </summary>
+        /// <returns>The max index.</returns>
+        internal int GetMaxIndex()
 		{
 			return data.Mapping.GetMaxIndex();
 		}

--- a/src/CsvHelper/Configuration/MemberReferenceMapData.cs
+++ b/src/CsvHelper/Configuration/MemberReferenceMapData.cs
@@ -2,6 +2,7 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace CsvHelper.Configuration
@@ -28,12 +29,17 @@ namespace CsvHelper.Configuration
 				}
 			}
 		}
-
-		/// <summary>
-		/// Gets the <see cref="MemberInfo"/> that the data
-		/// is associated with.
+        
+        /// <summary>
+		/// Gets or sets the expression to skip (make default) reference.
 		/// </summary>
-		public virtual MemberInfo Member { get; private set; }
+		public virtual Expression Skip { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="MemberInfo"/> that the data
+        /// is associated with.
+        /// </summary>
+        public virtual MemberInfo Member { get; private set; }
 
 		/// <summary>
 		/// Gets the mapping this is a reference for.

--- a/src/CsvHelper/Expressions/ExpressionManager.cs
+++ b/src/CsvHelper/Expressions/ExpressionManager.cs
@@ -141,7 +141,16 @@ namespace CsvHelper.Expressions
 					referenceBody = CreateInstanceAndAssignMembers(referenceMap.Data.Member.MemberType(), referenceAssignments);
 				}
 
-				assignments.Add(Expression.Bind(referenceMap.Data.Member, referenceBody));
+                if (referenceMap.Data.Skip != null)
+                {
+                    Expression exp = Expression.Invoke(referenceMap.Data.Skip, Expression.Constant(reader));
+                    var condition = Expression.Condition(exp, Expression.Default(referenceMap.Data.Member.MemberType()), referenceBody);
+                    assignments.Add(Expression.Bind(referenceMap.Data.Member, condition));
+                }
+                else
+                {
+                    assignments.Add(Expression.Bind(referenceMap.Data.Member, referenceBody));
+                }
 			}
 		}
 


### PR DESCRIPTION
Hey Josh,
First of all great library, keep up the good work.
I have come across issue #994 which I needed something very similar: ignore referenced maps based on the input of the current row. So I implemented a Skip method on the MemberReferenceClass which does exactly that.

Ex:

            References<TestSourceMap>(o => o.TestSource).Skip(row =>
            {
                return string.IsNullOrEmpty(row.GetField(0));
            });

I'm bad at giving names to stuff (like methods, for instance) but let me know if there's something you don't agree with on the code.
Cheers,
Fernando Jesus.

Push message:
Implemented skip reference - sets the object to its default (null) if skip function returns true.
Added unit tests for skip reference.