### PR TITLE
Fix printing '{expression}' using interpolation

### DIFF
--- a/src/CsvHelper/Configuration/ClassMap`1.cs
+++ b/src/CsvHelper/Configuration/ClassMap`1.cs
@@ -31,7 +31,7 @@ namespace CsvHelper.Configuration
 			var stack = ReflectionHelper.GetMembers( expression );
 			if( stack.Count == 0 )
 			{
-				throw new InvalidOperationException( "No members were found in expression '{expression}'." );
+				throw new InvalidOperationException( $"No members were found in expression '{expression}'." );
 			}
 
 			ClassMap currentClassMap = this;


### PR DESCRIPTION
String interpolation was not set on the InvalidOperationException error message being thrown so no context of the value of 'expression' was provided.