### PR TITLE
Update write-dynamic-objects.md

### DIFF
--- a/docs-src/src/content/examples/writing/write-dynamic-objects.md
+++ b/docs-src/src/content/examples/writing/write-dynamic-objects.md
@@ -16,8 +16,6 @@ void Main()
 	using (var csv = new CsvWriter(writer))
 	{
 		csv.WriteRecords(records);
-		
-		writer.ToString().Dump();
 	}
 }
 ```

--- a/docs-src/src/content/examples/writing/write-dynamic-objects.md
+++ b/docs-src/src/content/examples/writing/write-dynamic-objects.md
@@ -12,7 +12,7 @@ void Main()
 	record.Name = "one";
 	records.Add(record);
 	
-	using (var writer = new StringWriter())
+	using (var writer = new StreamWriter("path\\to\\file.csv"))
 	using (var csv = new CsvWriter(writer))
 	{
 		csv.WriteRecords(records);


### PR DESCRIPTION
Looks like `StringWriter` is a copy/paste hold over from the Test classes, the other examples use `new StreamWriter("path\\to\\file.csv")`