### PR TITLE
Remove ValueTuple requirement for .net 4.7

### DIFF
--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -11,7 +11,7 @@
 		<Version>12.1.2</Version>
 		<FileVersion>12.0.0.0</FileVersion>
 		<AssemblyVersion>12.0.0.0</AssemblyVersion>
-		<TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net45;net47</TargetFrameworks>
 		<LangVersion>7.1</LangVersion>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<AssemblyName>CsvHelper</AssemblyName>
@@ -37,6 +37,10 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
 		<PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
 		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
+		<Reference Include="Microsoft.CSharp" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Fixes #1241 

We had an issue where for some reason the ValueTuple.dll wasn't being copied with our deployment tooling which forced us to have to manually add it every time. No doubt something is wrong with our build process  but removing the dependency now it's a part of .Net works too and I think is a good solution.