### PR TITLE
Add method Optional() to MemberMap. Mirrors Optional() in MemberMap<TClass, TMember>

### DIFF
--- a/src/CsvHelper.Tests/Mappings/RuntimeMapping.cs
+++ b/src/CsvHelper.Tests/Mappings/RuntimeMapping.cs
@@ -65,7 +65,35 @@ namespace CsvHelper.Tests.Mappings
 			}
 		}
 
-		[TestMethod]
+        [TestMethod]
+        public void OptionalTest()
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new StreamWriter(stream))
+            using (var reader = new StreamReader(stream))
+            using (var csv = new CsvReader(reader))
+            {
+                csv.Configuration.Delimiter = ",";
+                writer.WriteLine("BId,CId");
+                writer.WriteLine("2,3");
+                writer.Flush();
+                stream.Position = 0;
+
+                var map = new DefaultClassMap<A>();
+                map.AutoMap();
+
+                var type = typeof(A);
+                var member = type.GetProperty("AId");
+                map.Map(type, member).Optional();
+
+                csv.Configuration.RegisterClassMap(map);
+                var records = csv.GetRecords<A>().ToList();
+
+                Assert.AreEqual(0, records[0].AId);
+            }
+        }
+
+        [TestMethod]
 		public void ConstantValueTypeNullTest()
 		{
 			Assert.ThrowsException<ArgumentException>(() => new ConstantValueTypeNullMap());

--- a/src/CsvHelper/Configuration/MemberMap.cs
+++ b/src/CsvHelper/Configuration/MemberMap.cs
@@ -210,11 +210,21 @@ namespace CsvHelper.Configuration
 			return this;
 		}
 
-		/// <summary>
-		/// Specifies an expression to be used to validate a field when reading.
-		/// </summary>
-		/// <param name="validateExpression"></param>
-		public virtual MemberMap Validate( Func<string, bool> validateExpression )
+        /// <summary>
+        /// Ignore the member when reading if no matching field name can be found.
+        /// </summary>
+        public virtual MemberMap Optional()
+        {
+            Data.IsOptional = true;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies an expression to be used to validate a field when reading.
+        /// </summary>
+        /// <param name="validateExpression"></param>
+        public virtual MemberMap Validate( Func<string, bool> validateExpression )
 		{
 			Data.ValidateExpression = (Expression<Func<string, bool>>)( x => validateExpression( x ) );
 

--- a/src/CsvHelper/Configuration/MemberMap`1.cs
+++ b/src/CsvHelper/Configuration/MemberMap`1.cs
@@ -202,7 +202,7 @@ namespace CsvHelper.Configuration
 		/// <summary>
 		/// Ignore the member when reading if no matching field name can be found.
 		/// </summary>
-		public virtual MemberMap<TClass, TMember> Optional()
+		public virtual new MemberMap<TClass, TMember> Optional()
 		{
 			Data.IsOptional = true;
 


### PR DESCRIPTION
MemberMap was missing the Optional() method that was added to MemberMap<TClass, TMember>.