### PR TITLE
Fail on reading large fields

### DIFF
--- a/src/CsvHelper.Tests/Parsing/MaxFieldSizeTests.cs
+++ b/src/CsvHelper.Tests/Parsing/MaxFieldSizeTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2009-2019 Josh Close and Contributors
+// This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
+// See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
+// https://github.com/JoshClose/CsvHelper
+
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CsvHelper.Tests.Parsing
+{
+	[TestClass]
+	public class MaxFieldSizeTests
+	{
+		[TestMethod]
+		[ExpectedException(typeof(MaxFieldSizeException))]
+		public void LargeRecordFieldThrowsMaxFieldSizeExceptionTest()
+		{
+			var config = new CsvHelper.Configuration.Configuration
+			{
+				Delimiter = ",",
+				MaxFieldSize = 10
+			};
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.Write("1,2,3\r\n");
+				writer.Write("ok,1234567890,x\r\n");
+				writer.Write("nok,12345678901,y\r\n");
+				writer.Flush();
+				stream.Position = 0;
+
+				parser.Read();
+				parser.Read();
+				parser.Read();
+			}
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(MaxFieldSizeException))]
+		public void LargeHeaderFieldThrowsMaxFieldSizeExceptionTest()
+		{
+			var config = new CsvHelper.Configuration.Configuration
+			{
+				Delimiter = ",",
+				MaxFieldSize = 10
+			};
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.Write("1,very long header name\r\n");
+				writer.Write("2,some data\r\n");
+				writer.Write("3,more data\r\n");
+				writer.Flush();
+				stream.Position = 0;
+
+				parser.Read();
+			}
+		}
+	}
+}

--- a/src/CsvHelper/Configuration/Configuration.cs
+++ b/src/CsvHelper/Configuration/Configuration.cs
@@ -362,6 +362,13 @@ namespace CsvHelper.Configuration
 		public virtual bool UseNewObjectForNullReferenceMembers { get; set; } = true;
 
 		/// <summary>
+		/// Gets or sets the maximum size of a field.
+		/// Defaults to 0, indicating maximum field size is
+		/// not checked.
+		/// </summary>
+		public virtual int MaxFieldSize { get; set; } = 0;
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="Configuration"/> class.
 		/// </summary>
 		public Configuration() : this(CultureInfo.CurrentCulture) { }

--- a/src/CsvHelper/Configuration/IParserConfiguration.cs
+++ b/src/CsvHelper/Configuration/IParserConfiguration.cs
@@ -102,5 +102,5 @@ namespace CsvHelper.Configuration
 		/// not checked.
 		/// </summary>
 		int MaxFieldSize { get; set; }
-    }
+	}
 }

--- a/src/CsvHelper/Configuration/IParserConfiguration.cs
+++ b/src/CsvHelper/Configuration/IParserConfiguration.cs
@@ -95,5 +95,12 @@ namespace CsvHelper.Configuration
 		/// Gets or sets the field trimming options.
 		/// </summary>
 		TrimOptions TrimOptions { get; set; }
-	}
+
+		/// <summary>
+		/// Gets or sets the maximum size of a field.
+		/// Defaults to 0, indicating maximum field size is
+		/// not checked.
+		/// </summary>
+		int MaxFieldSize { get; set; }
+    }
 }

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -443,8 +443,7 @@ namespace CsvHelper
 
 				if (context.ParserConfiguration.MaxFieldSize > 0)
 				{
-					var fieldStart = context.FieldStartPosition;
-					var fieldSize = context.CharPosition - fieldStart;
+					var fieldSize = context.RawRecordEndPosition - context.FieldStartPosition;
 					if (context.ParserConfiguration.MaxFieldSize < fieldSize)
 					{
 						throw new MaxFieldSizeException(Context, "Field size exceeded maximum field size.");

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -441,6 +441,16 @@ namespace CsvHelper
 					return true;
 				}
 
+				if (context.ParserConfiguration.MaxFieldSize > 0)
+				{
+					var fieldStart = context.FieldStartPosition;
+					var fieldSize = context.CharPosition - fieldStart;
+					if (context.ParserConfiguration.MaxFieldSize < fieldSize)
+					{
+						throw new MaxFieldSizeException(Context, "Field size exceeded maximum field size.");
+					}
+				}
+
 				c = fieldReader.GetChar();
 			}
 		}

--- a/src/CsvHelper/MaxFieldSizeException.cs
+++ b/src/CsvHelper/MaxFieldSizeException.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2009-2019 Josh Close and Contributors
+// This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
+// See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
+// https://github.com/JoshClose/CsvHelper
+using System;
+
+namespace CsvHelper
+{
+	/// <summary>
+	/// Represents errors that occur due to bad data.
+	/// </summary>
+	[Serializable]
+	public class MaxFieldSizeException : CsvHelperException
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MaxFieldSizeException"/> class.
+		/// </summary>
+		/// <param name="context">The reading context.</param>
+		public MaxFieldSizeException(ReadingContext context) : base(context) { }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MaxFieldSizeException"/> class
+		/// with a specified error message.
+		/// </summary>
+		/// <param name="context">The reading context.</param>
+		/// <param name="message">The message that describes the error.</param>
+		public MaxFieldSizeException(ReadingContext context, string message) : base(context, message) { }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MaxFieldSizeException"/> class
+		/// with a specified error message and a reference to the inner exception that 
+		/// is the cause of this exception.
+		/// </summary>
+		/// <param name="context">The reading context.</param>
+		/// <param name="message">The error message that explains the reason for the exception.</param>
+		/// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+		public MaxFieldSizeException(ReadingContext context, string message, Exception innerException) : base(context, message, innerException) { }
+	}
+}


### PR DESCRIPTION
Sometimes our customers deliver an invalid csv file containing a long record with \0 characters. Too prevent reading the file until either the end of file is reached or an OutOfMemoryException occurs (by resizing the field buffer) we introduced a MaxFieldSize property. When the max field size property is configured, the reader aborts further reading when the field length exceeds the configured maximum.