### PR TITLE
Fix ConvertUsing to handle Ignore() and null values properly

### DIFF
--- a/src/CsvHelper.Tests/CsvReaderMappingTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderMappingTests.cs
@@ -41,7 +41,7 @@ namespace CsvHelper.Tests
 			Assert.AreEqual("two", records[1].StringColumn);
 		}
 
-        [TestMethod]
+		[TestMethod]
 		public void ReadWithConvertUsingWithIgnoreTest()
 		{
 			var data = new List<string[]>
@@ -377,7 +377,7 @@ namespace CsvHelper.Tests
 				Map( m => m.IntColumn ).ConvertUsing( row => 1 );
 			}
 		}
-        
+
 		private sealed class ConvertUsingClassMap : ClassMap<MultipleNamesClass>
 		{
 			public ConvertUsingClassMap()

--- a/src/CsvHelper.Tests/CsvReaderMappingTests.cs
+++ b/src/CsvHelper.Tests/CsvReaderMappingTests.cs
@@ -41,6 +41,30 @@ namespace CsvHelper.Tests
 			Assert.AreEqual("two", records[1].StringColumn);
 		}
 
+        [TestMethod]
+		public void ReadWithConvertUsingWithIgnoreTest()
+		{
+			var data = new List<string[]>
+			{
+				new[] { "int2", "string.3" },
+				new[] { "1", "one" },
+				null
+			};
+
+			var queue = new Queue<string[]>(data);
+			var parserMock = new ParserMock(queue);
+
+			var csvReader = new CsvReader(parserMock);
+			csvReader.Configuration.RegisterClassMap<ConvertUsingWithIgnoreClassMap>();
+
+			var records = csvReader.GetRecords<MultipleNamesClass>().ToList();
+
+			Assert.IsNotNull(records);
+			Assert.AreEqual(1, records.Count);
+			Assert.AreEqual(1, records[0].IntColumn);
+			Assert.IsNull(records[0].StringColumn);
+		}
+
 		[TestMethod]
 		public void ReadMultipleNamesTest()
 		{
@@ -353,13 +377,22 @@ namespace CsvHelper.Tests
 				Map( m => m.IntColumn ).ConvertUsing( row => 1 );
 			}
 		}
-
+        
 		private sealed class ConvertUsingClassMap : ClassMap<MultipleNamesClass>
 		{
 			public ConvertUsingClassMap()
 			{
 				Map( m => m.IntColumn ).Name( "int2" );
 				Map( m => m.StringColumn ).ConvertUsing( row => row.GetField( "string.3" ) );
+			}
+		}
+
+		private sealed class ConvertUsingWithIgnoreClassMap : ClassMap<MultipleNamesClass>
+		{
+			public ConvertUsingWithIgnoreClassMap()
+			{
+				Map( m => m.IntColumn ).Name( "int2" );
+				Map( m => m.StringColumn ).Ignore(true).ConvertUsing( row => row.GetField( "string.3" ) );
 			}
 		}
 

--- a/src/CsvHelper.Tests/CsvWriterMappingTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterMappingTests.cs
@@ -101,7 +101,7 @@ namespace CsvHelper.Tests
 			Assert.AreEqual("Converted1\r\n", result);
 		}
 
-        [TestMethod]
+		[TestMethod]
 		public void ConvertUsingWithIgnoreTest()
 		{
 			string result;
@@ -113,10 +113,10 @@ namespace CsvHelper.Tests
 				var records = new List<MultipleNamesClass>
 				{
 					new MultipleNamesClass
-                    {
-                        IntColumn = 1,
-                        StringColumn = "Hello world"
-                    }
+					{
+						IntColumn = 1,
+						StringColumn = "Hello world"
+					}
 				};
 
 				csv.Configuration.HasHeaderRecord = false;
@@ -243,7 +243,7 @@ namespace CsvHelper.Tests
 			 });
 			}
 		}
-        
+
 		private sealed class ConvertUsingConstantMap : ClassMap<TestClass>
 		{
 			public ConvertUsingConstantMap()

--- a/src/CsvHelper.Tests/CsvWriterMappingTests.cs
+++ b/src/CsvHelper.Tests/CsvWriterMappingTests.cs
@@ -101,6 +101,36 @@ namespace CsvHelper.Tests
 			Assert.AreEqual("Converted1\r\n", result);
 		}
 
+        [TestMethod]
+		public void ConvertUsingWithIgnoreTest()
+		{
+			string result;
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var csv = new CsvWriter(writer))
+			{
+				var records = new List<MultipleNamesClass>
+				{
+					new MultipleNamesClass
+                    {
+                        IntColumn = 1,
+                        StringColumn = "Hello world"
+                    }
+				};
+
+				csv.Configuration.HasHeaderRecord = false;
+				csv.Configuration.RegisterClassMap<ConvertUsingWithIgnoreMap>();
+				csv.WriteRecords(records);
+				writer.Flush();
+				stream.Position = 0;
+
+				result = reader.ReadToEnd();
+			}
+
+			Assert.AreEqual("2\r\n", result);
+		}
+
 		[TestMethod]
 		public void ConvertUsingBlockTest()
 		{
@@ -213,12 +243,21 @@ namespace CsvHelper.Tests
 			 });
 			}
 		}
-
+        
 		private sealed class ConvertUsingConstantMap : ClassMap<TestClass>
 		{
 			public ConvertUsingConstantMap()
 			{
 				Map(m => m.IntColumn).ConvertUsing(m => "Constant");
+			}
+		}
+
+		private sealed class ConvertUsingWithIgnoreMap : ClassMap<MultipleNamesClass>
+		{
+			public ConvertUsingWithIgnoreMap()
+			{
+				Map(m => m.IntColumn).ConvertUsing(m => (m.IntColumn * 2).ToString());
+				Map(m => m.StringColumn).Ignore(true).ConvertUsing(m => m.StringColumn);
 			}
 		}
 	}

--- a/src/CsvHelper.Tests/Writing/NoPropertyMappingTests.cs
+++ b/src/CsvHelper.Tests/Writing/NoPropertyMappingTests.cs
@@ -55,7 +55,6 @@ namespace CsvHelper.Tests.Writing
 			using (var csv = new CsvWriter(writer))
 			{
 				csv.Configuration.Delimiter = ",";
-                csv.Configuration.IgnoreReferences = true;
 				var list = new List<Test>
 				{
 					new Test { Id = 1, Name = "Bob", Required = "Hello world" },

--- a/src/CsvHelper.Tests/Writing/NoPropertyMappingTests.cs
+++ b/src/CsvHelper.Tests/Writing/NoPropertyMappingTests.cs
@@ -57,11 +57,11 @@ namespace CsvHelper.Tests.Writing
 				csv.Configuration.Delimiter = ",";
 				var list = new List<Test>
 				{
-					new Test { Id = 1, Name = "Bob", Required = "Hello world" },
-					new Test { Id = 2, Required = "Hello world" }
+					new Test { Id = 1, Name = "Bob" },
+					new Test { Id = 2 }
 				};
 
-				csv.Configuration.RegisterClassMap<TestWithNameAndRequiredAndConvertUsingMap>();
+				csv.Configuration.RegisterClassMap<TestWithNameAndConvertUsingMap>();
 				csv.WriteRecords(list);
 
 				writer.Flush();
@@ -70,9 +70,9 @@ namespace CsvHelper.Tests.Writing
 				var result = reader.ReadToEnd();
 
 				var expected = new StringBuilder();
-				expected.AppendLine("Id,Constant,Name,Required");
-				expected.AppendLine("1,const,Bob,Hello world");
-				expected.AppendLine("2,const,,Hello world");
+				expected.AppendLine("Id,Constant,Name");
+				expected.AppendLine("1,const,Bob");
+				expected.AppendLine("2,const,");
 
 				Assert.AreEqual(expected.ToString(), result);
 			}
@@ -211,8 +211,6 @@ namespace CsvHelper.Tests.Writing
 			public int Id { get; set; }
 
 			public string Name { get; set; }
-
-			public string Required { get; set; }
 		}
 
 		private sealed class TestWithNameMap : ClassMap<Test>
@@ -225,14 +223,13 @@ namespace CsvHelper.Tests.Writing
 			}
 		}
 
-		private sealed class TestWithNameAndRequiredAndConvertUsingMap : ClassMap<Test>
+		private sealed class TestWithNameAndConvertUsingMap : ClassMap<Test>
 		{
-			public TestWithNameAndRequiredAndConvertUsingMap()
+			public TestWithNameAndConvertUsingMap()
 			{
 				Map(m => m.Id);
 				Map().Name("Constant").Constant("const");
 				Map(m => m.Name).ConvertUsing(m => m.Name);
-				Map(m => m.Required);
 			}
 		}
 

--- a/src/CsvHelper/Expressions/ExpressionManager.cs
+++ b/src/CsvHelper/Expressions/ExpressionManager.cs
@@ -150,16 +150,16 @@ namespace CsvHelper.Expressions
 		/// <param name="memberMap">The mapping for the member.</param>
 		public virtual Expression CreateGetFieldExpression(MemberMap memberMap)
 		{
+			if (!reader.CanRead(memberMap))
+			{
+				return null;
+			}
+
 			if (memberMap.Data.ReadingConvertExpression != null)
 			{
 				// The user is providing the expression to do the conversion.
 				Expression exp = Expression.Invoke(memberMap.Data.ReadingConvertExpression, Expression.Constant(reader));
 				return Expression.Convert(exp, memberMap.Data.Member.MemberType());
-			}
-
-			if (!reader.CanRead(memberMap))
-			{
-				return null;
 			}
 
 			if (memberMap.Data.TypeConverter == null)

--- a/src/CsvHelper/Expressions/ObjectRecordWriter.cs
+++ b/src/CsvHelper/Expressions/ObjectRecordWriter.cs
@@ -59,18 +59,20 @@ namespace CsvHelper.Expressions
 					continue;
 				}
 
-                if( memberMap.Data.WritingConvertExpression != null )
-				{
-					// The user is providing the expression to do the conversion.
-					Expression exp = Expression.Invoke( memberMap.Data.WritingConvertExpression, recordParameterConverted );
-					exp = Expression.Call( Expression.Constant( Writer ), nameof( Writer.WriteConvertedField ), null, exp );
-					delegates.Add( Expression.Lambda<Action<T>>( exp, recordParameter ).Compile() );
-					continue;
-				}
-
 				Expression fieldExpression;
 
-				if( memberMap.Data.IsConstantSet )
+				if( memberMap.Data.WritingConvertExpression != null )
+				{
+					// The user is providing the expression to do the conversion.
+					fieldExpression = Expression.Invoke( memberMap.Data.WritingConvertExpression, recordParameterConverted );
+
+                    if( type.GetTypeInfo().IsClass )
+					{
+						var areEqualExpression = Expression.Equal( fieldExpression, Expression.Constant( null ) );
+						fieldExpression = Expression.Condition( areEqualExpression, Expression.Constant( string.Empty ), fieldExpression );
+					}
+				}
+                else if( memberMap.Data.IsConstantSet )
 				{
 					if( memberMap.Data.Constant == null )
 					{

--- a/src/CsvHelper/Expressions/ObjectRecordWriter.cs
+++ b/src/CsvHelper/Expressions/ObjectRecordWriter.cs
@@ -66,13 +66,13 @@ namespace CsvHelper.Expressions
 					// The user is providing the expression to do the conversion.
 					fieldExpression = Expression.Invoke( memberMap.Data.WritingConvertExpression, recordParameterConverted );
 
-                    if( type.GetTypeInfo().IsClass )
+					if( type.GetTypeInfo().IsClass )
 					{
 						var areEqualExpression = Expression.Equal( fieldExpression, Expression.Constant( null ) );
 						fieldExpression = Expression.Condition( areEqualExpression, Expression.Constant( string.Empty ), fieldExpression );
 					}
 				}
-                else if( memberMap.Data.IsConstantSet )
+				else if( memberMap.Data.IsConstantSet )
 				{
 					if( memberMap.Data.Constant == null )
 					{

--- a/src/CsvHelper/Expressions/ObjectRecordWriter.cs
+++ b/src/CsvHelper/Expressions/ObjectRecordWriter.cs
@@ -54,17 +54,17 @@ namespace CsvHelper.Expressions
 
 			foreach( var memberMap in members )
 			{
-				if( memberMap.Data.WritingConvertExpression != null )
+				if( !Writer.CanWrite( memberMap ) )
+				{
+					continue;
+				}
+
+                if( memberMap.Data.WritingConvertExpression != null )
 				{
 					// The user is providing the expression to do the conversion.
 					Expression exp = Expression.Invoke( memberMap.Data.WritingConvertExpression, recordParameterConverted );
 					exp = Expression.Call( Expression.Constant( Writer ), nameof( Writer.WriteConvertedField ), null, exp );
 					delegates.Add( Expression.Lambda<Action<T>>( exp, recordParameter ).Compile() );
-					continue;
-				}
-
-				if( !Writer.CanWrite( memberMap ) )
-				{
 					continue;
 				}
 


### PR DESCRIPTION
Related issue #1074 

There are some problems with ConvertUsing mapping.

1. ConvertUsing with Ignore.
```csharp
// IntColumn = 1; StringColumn = "Hello world";
Map(m => m.IntColumn);
Map(m => m.StringColumn).Ignore(true).ConvertUsing(m => m.StringColumn);
```
Produces:

| IntColumn |  |
| ------------- | ---------------- |
| 1 |  Hello world |

Note that header was ignored, but value wasn't.

2. ConvertUsing with null value
```csharp
// IntColumn = 1; StringColumn = null; ThirdColumn = "Hello world"
Map(m => m.IntColumn);
Map(m => m.StringColumn).ConvertUsing(m => m.StringColumn);
Map(m => m.ThirdColumn);
```
Produces:

| IntColumn | StringColumn | ThirdColumn |
| ------------- | ---------------- | --------------- |
| 1 |  Hello world |

Note that ThirdColumn value was shifted and displayed below StringColumn