### PR TITLE
System.ValueTuple and Newtonsoft package updates.

### DIFF
--- a/src/CsvHelper.DocsGenerator/CsvHelper.DocsGenerator.csproj
+++ b/src/CsvHelper.DocsGenerator/CsvHelper.DocsGenerator.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+	  <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="ModuleInit.Fody" Version="1.8.3" PrivateAssets="all" />
     <PackageReference Include="Obsolete.Fody" Version="4.4.3" PrivateAssets="all" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   
   <!-- .NET 4.5 -->


### PR DESCRIPTION
System.ValueTuple is a package whose lower version is causing no end of headaches (and assembly bindings) when we're trying to integrate it in older projects that use its updated version. 

It's also a package that tends to get updated [once per year](https://www.nuget.org/packages/System.ValueTuple/), more or less, so staying on top of it should not be an issue.

All tests pass in the same fashion as they used to before and after updating. 