### PR TITLE
fix read multi delimiter bug

### DIFF
--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -1,9 +1,12 @@
-﻿// Copyright 2009-2019 Josh Close and Contributors
+﻿// Copyright 2009-2017 Josh Close and Contributors
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using CsvHelper.Configuration;
 using System.Threading.Tasks;
 
@@ -121,7 +124,7 @@ namespace CsvHelper
 		/// <filterpriority>2</filterpriority>
 		public virtual void Dispose()
 		{
-			Dispose(!context?.LeaveOpen ?? true);
+			Dispose(!context.LeaveOpen);
 			GC.SuppressFinalize(this);
 		}
 
@@ -579,7 +582,7 @@ namespace CsvHelper
 				}
 
 				// Trim end inside quotes.
-				if (inQuotes && c == ' ' && (context.ParserConfiguration.TrimOptions & TrimOptions.InsideQuotes) == TrimOptions.InsideQuotes)
+				if (inQuotes && c == ' ')
 				{
 					fieldReader.SetFieldEnd(-1);
 					fieldReader.AppendField();
@@ -587,7 +590,7 @@ namespace CsvHelper
 					ReadSpaces();
 					cPrev = ' ';
 
-					if (c == context.ParserConfiguration.Escape || c == context.ParserConfiguration.Quote)
+					if (c == context.ParserConfiguration.Quote)
 					{
 						inQuotes = !inQuotes;
 						quoteCount++;
@@ -629,7 +632,7 @@ namespace CsvHelper
 					}
 				}
 
-				if (inQuotes && c == context.ParserConfiguration.Escape || c == context.ParserConfiguration.Quote)
+				if (c == context.ParserConfiguration.Quote)
 				{
 					inQuotes = !inQuotes;
 					quoteCount++;
@@ -888,6 +891,13 @@ namespace CsvHelper
 				c = fieldReader.GetChar();
 				if (c != context.ParserConfiguration.Delimiter[i])
 				{
+					if (c == context.ParserConfiguration.Delimiter[0])
+                    {
+                        fieldReader.SetFieldEnd(-1);
+                        i = 0;
+                        continue;
+                    }
+
 					return false;
 				}
 			}
@@ -923,6 +933,13 @@ namespace CsvHelper
 				c = fieldReader.GetChar();
 				if (c != context.ParserConfiguration.Delimiter[i])
 				{
+					if (c == context.ParserConfiguration.Delimiter[0])
+                    {
+                        fieldReader.SetFieldEnd(-1);
+                        i = 0;
+                        continue;
+                    }
+
 					return false;
 				}
 			}

--- a/src/CsvHelper/CsvParser.tt
+++ b/src/CsvHelper/CsvParser.tt
@@ -14,7 +14,7 @@ using CsvHelper.Configuration;
 using System.Threading.Tasks;
 
 // This file is generated from a T4 template.
-// Modifiying it directly won't do you any good.
+// Modifying it directly won't do you any good.
 
 namespace CsvHelper
 {
@@ -84,7 +84,7 @@ namespace CsvHelper
 		for (var i = 0; i < 2; i++)
 		{
 			var isAsync = i != 0;
-		#>	
+		#>
 		/// <summary>
 		/// Reads a record from the CSV file<#= isAsync ? " asynchronously" : string.Empty #>.
 		/// </summary>
@@ -104,8 +104,8 @@ namespace CsvHelper
 				throw ex as CsvHelperException ?? new ParserException(context, "An unexpected error occurred.", ex);
 			}
 		}
-		<# } 
-		#>	
+		<# }
+		#>
 		/// <summary>
 		/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
 		/// </summary>
@@ -140,7 +140,7 @@ namespace CsvHelper
 		for (var i = 0; i < 2; i++)
 		{
 			var isAsync = i != 0;
-		#>	
+		#>
 		/// <summary>
 		/// Reads a line of the CSV file.
 		/// </summary>
@@ -205,13 +205,13 @@ namespace CsvHelper
 
 			return context.RecordBuilder.ToArray();
 		}
-		<# 
+		<#
 		}
-		
+
 		for (var i = 0; i < 2; i++)
 		{
 			var isAsync = i != 0;
-		#>	
+		#>
 		/// <summary>
 		/// Reads a blank line. This accounts for empty lines
 		/// and commented out lines.
@@ -246,13 +246,13 @@ namespace CsvHelper
 				c = fieldReader.GetChar();
 			}
 		}
-		<# 
+		<#
 		}
 
 		for (var i = 0; i < 2; i++)
 		{
 			var isAsync = i != 0;
-		#>	
+		#>
 		/// <summary>
 		/// Reads until a delimiter or line ending is found.
 		/// </summary>
@@ -351,15 +351,15 @@ namespace CsvHelper
 				c = fieldReader.GetChar();
 			}
 		}
-		<# 
+		<#
 		}
 
 		for (var i = 0; i < 2; i++)
 		{
 			var isAsync = i != 0;
-		#>	
+		#>
 		/// <summary>
-		/// Reads until the field is not quoted and a delimeter is found.
+		/// Reads until the field is not quoted and a delimiter is found.
 		/// </summary>
 		/// <returns>True if the end of the line was found, otherwise false.</returns>
 		protected virtual <#= AsyncType("bool", isAsync) #> ReadQuotedField<#= AsyncPostfix(isAsync) #>()
@@ -515,15 +515,15 @@ namespace CsvHelper
 				}
 			}
 		}
-		<# 
+		<#
 		}
 
 		for (var i = 0; i < 2; i++)
 		{
 			var isAsync = i != 0;
-		#>	
+		#>
 		/// <summary>
-		/// Reads until the delimeter is done.
+		/// Reads until the delimiter is done.
 		/// </summary>
 		/// <returns>True if a delimiter was read. False if the sequence of
 		/// chars ended up not being the delimiter.</returns>
@@ -550,19 +550,26 @@ namespace CsvHelper
 				c = fieldReader.GetChar();
 				if (c != context.ParserConfiguration.Delimiter[i])
 				{
+					if (c == context.ParserConfiguration.Delimiter[0])
+                    {
+                        fieldReader.SetFieldEnd(-1);
+                        i = 0;
+                        continue;
+                    }
+
 					return false;
 				}
 			}
 
 			return true;
 		}
-		<# 
+		<#
 		}
 
 		for (var i = 0; i < 2; i++)
 		{
 			var isAsync = i != 0;
-		#>	
+		#>
 		/// <summary>
 		/// Reads until the line ending is done.
 		/// </summary>
@@ -593,14 +600,14 @@ namespace CsvHelper
 
 			return fieldStartOffset;
 		}
-		<# 
-		} 
+		<#
+		}
 
 		for (var i = 0; i < 2; i++)
 		{
 			var isAsync = i != 0;
 		#>
-	
+
 		/// <summary>
 		/// Reads until a non-space character is found.
 		/// </summary>


### PR DESCRIPTION
Parsing a CSV with a multi character delimiter (!@~) goes wrong.

Example line

`1!@~20190523 06:00:08!@~556!@~BLAH!!!!@~11!@~Z!@~N!@~0!@~0!@~N!@~N!@~0!@~N!@~,000`

parsed fields
1: 1
2: 20190523 06:00:08
3: 556
4: `BLAH!!!!@~11` --> but should be --> `BLAH!!!`
5: and so on...

The `ReadDelimiter` implementation has a bug where it reads the next character without checking if the next character is the first character of the delimiter. If that's the case it should start over and reset the field end.

I've changed the `CsvParser.tt` at the `ReadDelimiter` implementation adding only 4 lines + some spelling:

```
protected virtual bool ReadDelimiter()
{
	if (c != context.ParserConfiguration.Delimiter[0])
	{
		throw new InvalidOperationException("Tried reading a delimiter when the first delimiter char didn't match the current char.");
	}

	if (context.ParserConfiguration.Delimiter.Length == 1)
	{
		return true;
	}

	for (var i = 1; i < context.ParserConfiguration.Delimiter.Length; i++)
	{
		if (fieldReader.IsBufferEmpty && !fieldReader.FillBuffer())
		{
			// End of file.
			return false;
		}

		c = fieldReader.GetChar();
		if (c != context.ParserConfiguration.Delimiter[i])
		{
		        //start change here
			if (c == context.ParserConfiguration.Delimiter[0])
			{
				fieldReader.SetFieldEnd(-1);
				i = 0;
				continue;
			}
			//end change here

			return false;
		}
	}

	return true;
}
```

The T4 template is generating also other changes (not made by me). Not sure what's going on there. Maybe someone else not changed the T4?
