### PR TITLE
Fixed DoubleConverter to return 0 instead of throwing TypeConverterEx…

### DIFF
--- a/src/CsvHelper/TypeConversion/DoubleConverter.cs
+++ b/src/CsvHelper/TypeConversion/DoubleConverter.cs
@@ -26,7 +26,11 @@ namespace CsvHelper.TypeConversion
 			if( double.TryParse( text, numberStyle, memberMapData.TypeConverterOptions.CultureInfo, out var d ) )
 			{
 				return d;
-			}
+			} else if (string.IsNullOrEmpty(text))
+            {
+                double zeroValue = 0;
+                return zeroValue;
+            }
 
 			return base.ConvertFromString( text, row, memberMapData );
 		}


### PR DESCRIPTION
Currently, when passing a null or empty string to a double value a TypeConverterException is thrown. I have added the logic to check for a null or empty string and return a new double set to 0 instead of throwing an exception.