### PR TITLE
Mismatched data in Column names

### DIFF
--- a/docs-src/src/content/examples/configuration/class-maps/mapping-by-name.md
+++ b/docs-src/src/content/examples/configuration/class-maps/mapping-by-name.md
@@ -32,8 +32,8 @@ public sealed class FooMap : ClassMap<Foo>
 {
 	public FooMap()
 	{
-		Map(m => m.Id).Name("ColumnA");
-		Map(m => m.Name).Name("ColumnB");
+		Map(m => m.Id).Name("Column1");
+		Map(m => m.Name).Name("Column2");
 	}
 }
 ```


### PR DESCRIPTION
Corrected the example ClassMap to match the column names in the sample CSV data