### PR TITLE
Updates to enable custom mappings using attributes.

### DIFF
--- a/src/CsvHelper/Configuration/Attributes/BooleanFalseValuesAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/BooleanFalseValuesAttribute.cs
@@ -10,7 +10,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// The string values used to represent a boolean false when converting.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class BooleanFalseValuesAttribute : Attribute
+	public class BooleanFalseValuesAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// Gets the false values.
@@ -34,5 +34,12 @@ namespace CsvHelper.Configuration.Attributes
 		{
 			FalseValues = falseValues;
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.TypeConverterOptions.BooleanFalseValues.Clear();
+            memberMap.Data.TypeConverterOptions.BooleanFalseValues.AddRange(FalseValues);
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/BooleanTrueValuesAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/BooleanTrueValuesAttribute.cs
@@ -10,8 +10,8 @@ namespace CsvHelper.Configuration.Attributes
 	/// The string values used to represent a boolean true when converting.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class BooleanTrueValuesAttribute : Attribute
-	{
+	public class BooleanTrueValuesAttribute : Attribute, IMemberMapper
+    {
 		/// <summary>
 		/// Gets the true values.
 		/// </summary>
@@ -34,5 +34,12 @@ namespace CsvHelper.Configuration.Attributes
 		{
 			TrueValues = trueValues;
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.TypeConverterOptions.BooleanTrueValues.Clear();
+            memberMap.Data.TypeConverterOptions.BooleanTrueValues.AddRange(TrueValues);
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/ConstantAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/ConstantAttribute.cs
@@ -12,7 +12,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// what other mapping configurations are specified.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class ConstantAttribute : Attribute
+	public class ConstantAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// Gets the constant.
@@ -29,5 +29,12 @@ namespace CsvHelper.Configuration.Attributes
 		{
 			Constant = constant;
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.Constant = Constant;
+            memberMap.Data.IsConstantSet = true;
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/CultureInfoAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/CultureInfoAttribute.cs
@@ -13,7 +13,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// setting.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class CultureInfoAttribute : Attribute
+	public class CultureInfoAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// Gets the culture info.
@@ -30,5 +30,11 @@ namespace CsvHelper.Configuration.Attributes
 		{
 			CultureInfo = CultureInfo.GetCultureInfo( culture );
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.TypeConverterOptions.CultureInfo = CultureInfo;
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/DateTimeStylesAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/DateTimeStylesAttribute.cs
@@ -12,7 +12,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// This is used when doing any <see cref="DateTime"/> conversions.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class DateTimeStylesAttribute : Attribute
+	public class DateTimeStylesAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// Gets the date time styles.
@@ -28,5 +28,10 @@ namespace CsvHelper.Configuration.Attributes
 		{
 			DateTimeStyles = dateTimeStyles;
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.TypeConverterOptions.DateTimeStyle = DateTimeStyles;
+        }
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/DefaultAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/DefaultAttribute.cs
@@ -11,7 +11,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// the CSV field is empty.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class DefaultAttribute : Attribute
+	public class DefaultAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// Gets the default value.
@@ -27,5 +27,12 @@ namespace CsvHelper.Configuration.Attributes
 		{
 			Default = defaultValue;
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.Default = Default;
+            memberMap.Data.IsDefaultSet = true;
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/FormatAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/FormatAttribute.cs
@@ -10,7 +10,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// The string format to be used when type converting.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class FormatAttribute : Attribute
+	public class FormatAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// Gets the formats.
@@ -34,5 +34,10 @@ namespace CsvHelper.Configuration.Attributes
 		{
 			Formats = formats;
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.TypeConverterOptions.Formats = Formats;
+        }
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/HeaderPrefixAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/HeaderPrefixAttribute.cs
@@ -10,7 +10,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// Appends a prefix to the header of each field of the reference member.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class HeaderPrefixAttribute : Attribute
+	public class HeaderPrefixAttribute : Attribute, IMemberReferenceMapper
 	{
 		/// <summary>
 		/// Gets the prefix.
@@ -30,5 +30,11 @@ namespace CsvHelper.Configuration.Attributes
 		{
 			Prefix = prefix;
 		}
-	}
+
+        public void ApplyTo(MemberReferenceMap referenceMap)
+        {
+            referenceMap.Data.Prefix = Prefix ?? referenceMap.Data.Member.Name + ".";
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/IMemberMapper.cs
+++ b/src/CsvHelper/Configuration/Attributes/IMemberMapper.cs
@@ -4,19 +4,16 @@
 // https://github.com/JoshClose/CsvHelper
 using System;
 
+
 namespace CsvHelper.Configuration.Attributes
 {
-	/// <summary>
-	/// Ignore the member when reading if no matching field name can be found.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
-	public class OptionalAttribute : Attribute, IMemberMapper
-	{
-
-        public void ApplyTo(MemberMap memberMap)
-        {
-            memberMap.Data.IsOptional = true;
-        }
+    /// <summary>
+    /// A base class that enables pluggable
+    /// configuration of member mapping.
+    /// </summary>
+    public interface IMemberMapper 
+    {
+        void ApplyTo(MemberMap memberMap);
 
     }
 }

--- a/src/CsvHelper/Configuration/Attributes/IMemberReferenceMapper.cs
+++ b/src/CsvHelper/Configuration/Attributes/IMemberReferenceMapper.cs
@@ -4,19 +4,16 @@
 // https://github.com/JoshClose/CsvHelper
 using System;
 
+
 namespace CsvHelper.Configuration.Attributes
 {
-	/// <summary>
-	/// Ignore the member when reading if no matching field name can be found.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
-	public class OptionalAttribute : Attribute, IMemberMapper
-	{
-
-        public void ApplyTo(MemberMap memberMap)
-        {
-            memberMap.Data.IsOptional = true;
-        }
+    /// <summary>
+    /// A base class that enables pluggable
+    /// configuration of member mapping.
+    /// </summary>
+    public interface IMemberReferenceMapper
+    {
+        void ApplyTo(MemberReferenceMap referenceMap);
 
     }
 }

--- a/src/CsvHelper/Configuration/Attributes/IgnoreAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/IgnoreAttribute.cs
@@ -14,7 +14,13 @@ namespace CsvHelper.Configuration.Attributes
 	/// tree that have already been mapped.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class IgnoreAttribute : Attribute
+	public class IgnoreAttribute : Attribute, IMemberMapper
 	{
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.Ignore = true;
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/IndexAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/IndexAttribute.cs
@@ -13,7 +13,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// indexes.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class IndexAttribute : Attribute
+	public class IndexAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// Gets the index.
@@ -38,5 +38,13 @@ namespace CsvHelper.Configuration.Attributes
 			Index = index;
 			IndexEnd = indexEnd;
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.Index = Index;
+            memberMap.Data.IndexEnd = IndexEnd;
+            memberMap.Data.IsIndexSet = true;
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/NameAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/NameAttribute.cs
@@ -16,7 +16,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// The first name will be used.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class NameAttribute : Attribute
+	public class NameAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// Gets the names.
@@ -57,5 +57,13 @@ namespace CsvHelper.Configuration.Attributes
 
 			Names = names;
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.Names.Clear();
+            memberMap.Data.Names.AddRange(Names);
+            memberMap.Data.IsNameSet = true;
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/NameIndexAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/NameIndexAttribute.cs
@@ -12,7 +12,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// are multiple names that are the same.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class NameIndexAttribute : Attribute
+	public class NameIndexAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// The name index.
@@ -29,5 +29,11 @@ namespace CsvHelper.Configuration.Attributes
 		{
 			NameIndex = nameIndex;
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.NameIndex = NameIndex;
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/NullValuesAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/NullValuesAttribute.cs
@@ -10,7 +10,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// The string values used to represent null when converting.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class NullValuesAttribute : Attribute
+	public class NullValuesAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// Gets the null values.
@@ -34,5 +34,12 @@ namespace CsvHelper.Configuration.Attributes
 		{
 			NullValues = nullValues;
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.TypeConverterOptions.NullValues.Clear();
+            memberMap.Data.TypeConverterOptions.NullValues.AddRange(NullValues);
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/NumberStylesAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/NumberStylesAttribute.cs
@@ -12,7 +12,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// This is used when doing any number conversions.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class NumberStylesAttribute : Attribute
+	public class NumberStylesAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// Gets the number styles.
@@ -28,5 +28,11 @@ namespace CsvHelper.Configuration.Attributes
 		{
 			NumberStyles = numberStyles;
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.TypeConverterOptions.NumberStyle = NumberStyles;
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/Attributes/TypeConverterAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/TypeConverterAttribute.cs
@@ -12,7 +12,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// when converting the member to and from a CSV field.
 	/// </summary>
 	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true )]
-	public class TypeConverterAttribute : Attribute
+	public class TypeConverterAttribute : Attribute, IMemberMapper
 	{
 		/// <summary>
 		/// Gets the type converter.
@@ -37,5 +37,11 @@ namespace CsvHelper.Configuration.Attributes
 				throw new ArgumentException( $"Type '{typeConverterType.FullName}' does not implement {nameof( ITypeConverter )}" );
 			}
 		}
-	}
+
+        public void ApplyTo(MemberMap memberMap)
+        {
+            memberMap.Data.TypeConverter = TypeConverter;
+        }
+
+    }
 }

--- a/src/CsvHelper/Configuration/ClassMap.cs
+++ b/src/CsvHelper/Configuration/ClassMap.cs
@@ -475,89 +475,13 @@ namespace CsvHelper.Configuration
 		{
 			var member = memberMap.Data.Member;
 
-			if (member.GetCustomAttribute(typeof(IndexAttribute)) is IndexAttribute indexAttribute)
-			{
-				memberMap.Data.Index = indexAttribute.Index;
-				memberMap.Data.IndexEnd = indexAttribute.IndexEnd;
-				memberMap.Data.IsIndexSet = true;
-			}
+            var attributes = member.GetCustomAttributes().OfType<IMemberMapper>();
 
-			if (member.GetCustomAttribute(typeof(NameAttribute)) is NameAttribute nameAttribute)
-			{
-				memberMap.Data.Names.Clear();
-				memberMap.Data.Names.AddRange(nameAttribute.Names);
-				memberMap.Data.IsNameSet = true;
-			}
-
-			if (member.GetCustomAttribute(typeof(NameIndexAttribute)) is NameIndexAttribute nameIndexAttribute)
-			{
-				memberMap.Data.NameIndex = nameIndexAttribute.NameIndex;
-			}
-
-			if (member.GetCustomAttribute(typeof(IgnoreAttribute)) is IgnoreAttribute ignoreAttribute)
-			{
-				memberMap.Data.Ignore = true;
-			}
-
-			if (member.GetCustomAttribute(typeof(OptionalAttribute)) is OptionalAttribute optionalAttribute)
-			{
-				memberMap.Data.IsOptional = true;
-			}
-
-			if (member.GetCustomAttribute(typeof(DefaultAttribute)) is DefaultAttribute defaultAttribute)
-			{
-				memberMap.Data.Default = defaultAttribute.Default;
-				memberMap.Data.IsDefaultSet = true;
-			}
-
-			if (member.GetCustomAttribute(typeof(ConstantAttribute)) is ConstantAttribute constantAttribute)
-			{
-				memberMap.Data.Constant = constantAttribute.Constant;
-				memberMap.Data.IsConstantSet = true;
-			}
-
-			if (member.GetCustomAttribute(typeof(TypeConverterAttribute)) is TypeConverterAttribute typeConverterAttribute)
-			{
-				memberMap.Data.TypeConverter = typeConverterAttribute.TypeConverter;
-			}
-
-			if (member.GetCustomAttribute(typeof(CultureInfoAttribute)) is CultureInfoAttribute cultureInfoAttribute)
-			{
-				memberMap.Data.TypeConverterOptions.CultureInfo = cultureInfoAttribute.CultureInfo;
-			}
-
-			if (member.GetCustomAttribute(typeof(DateTimeStylesAttribute)) is DateTimeStylesAttribute dateTimeStylesAttribute)
-			{
-				memberMap.Data.TypeConverterOptions.DateTimeStyle = dateTimeStylesAttribute.DateTimeStyles;
-			}
-
-			if (member.GetCustomAttribute(typeof(NumberStylesAttribute)) is NumberStylesAttribute numberStylesAttribute)
-			{
-				memberMap.Data.TypeConverterOptions.NumberStyle = numberStylesAttribute.NumberStyles;
-			}
-
-			if (member.GetCustomAttribute(typeof(FormatAttribute)) is FormatAttribute formatAttribute)
-			{
-				memberMap.Data.TypeConverterOptions.Formats = formatAttribute.Formats;
-			}
-
-			if (member.GetCustomAttribute(typeof(BooleanTrueValuesAttribute)) is BooleanTrueValuesAttribute booleanTrueValuesAttribute)
-			{
-				memberMap.Data.TypeConverterOptions.BooleanTrueValues.Clear();
-				memberMap.Data.TypeConverterOptions.BooleanTrueValues.AddRange(booleanTrueValuesAttribute.TrueValues);
-			}
-
-			if (member.GetCustomAttribute(typeof(BooleanFalseValuesAttribute)) is BooleanFalseValuesAttribute booleanFalseValuesAttribute)
-			{
-				memberMap.Data.TypeConverterOptions.BooleanFalseValues.Clear();
-				memberMap.Data.TypeConverterOptions.BooleanFalseValues.AddRange(booleanFalseValuesAttribute.FalseValues);
-			}
-
-			if (member.GetCustomAttribute(typeof(NullValuesAttribute)) is NullValuesAttribute nullValuesAttribute)
-			{
-				memberMap.Data.TypeConverterOptions.NullValues.Clear();
-				memberMap.Data.TypeConverterOptions.NullValues.AddRange(nullValuesAttribute.NullValues);
-			}
+            foreach (var attribute in attributes)
+            {
+                attribute.ApplyTo(memberMap);
+            }
+            
 		}
 
 		/// <summary>
@@ -567,11 +491,13 @@ namespace CsvHelper.Configuration
 		protected virtual void ApplyAttributes(MemberReferenceMap referenceMap)
 		{
 			var member = referenceMap.Data.Member;
+            var attributes = member.GetCustomAttributes().OfType<IMemberReferenceMapper>();
 
-			if (member.GetCustomAttribute(typeof(HeaderPrefixAttribute)) is HeaderPrefixAttribute headerPrefixAttribute)
-			{
-				referenceMap.Data.Prefix = headerPrefixAttribute.Prefix ?? member.Name + ".";
-			}
+            foreach (var attribute in attributes)
+            {
+                attribute.ApplyTo(referenceMap);
+            }
+
 		}
 	}
 }


### PR DESCRIPTION
Hi @JoshClose ,
I did a minor refactoring to enhance the configuration process using attributes.

With this enhancement:
1.  Two new interfaces are introduced (````IMemberMapper```` and ````IMemberReferenceMapper````).
2.  The mapping attributes were tagged with the appropriate interfaces.
3.  The mapping logic was moved out of ````ClassMap```` into the corresponding class.
4.  ````ClassMap```` was refactored to call the interface method instead of having a hard-coded set of mappings.

This will allow developers to extend/customize the process by simply creating their own custom ````Attribute```` that implements ````IMemberMapper```` or ````IMemberReferenceMapper````.

Would you please let me know what we need to do to get this change committed?

Thanks so much!