### PR TITLE
Add missing condition of Escape char in Async reader

### DIFF
--- a/src/CsvHelper.Tests/Writing/DoubleEdgeTest.cs
+++ b/src/CsvHelper.Tests/Writing/DoubleEdgeTest.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CsvHelper.Tests.Writing
+{
+    [TestClass]
+    public class DoubleEdgeTest
+    {
+        [TestMethod]
+        public void Test1()
+        {
+            var records = new List<Double>
+            {
+                123d,
+                Double.MaxValue,
+                Double.MinValue
+            };
+
+            using (var writeStream = new MemoryStream())
+            {
+
+                using (var writer = new StreamWriter(writeStream))
+                {
+                    using (var csv = new CsvWriter(writer))
+                    {
+                        csv.WriteRecords(records);
+                    }
+                }
+
+                writeStream.Flush();
+                var csvText = Encoding.ASCII.GetString(writeStream.ToArray());
+                using (var reader = new StringReader(csvText))
+                using (var csv = new CsvReader(reader))
+                {
+                    csv.Configuration.HasHeaderRecord = false;
+                    var readRecords = csv.GetRecords<Double>().ToList();
+                    Assert.AreEqual(3, readRecords.Count);
+                }
+
+            }
+        }
+    }
+}

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -787,7 +787,7 @@ namespace CsvHelper
 					}
 				}
 
-				if (c == context.ParserConfiguration.Quote)
+				if (c == context.ParserConfiguration.Quote || c == context.ParserConfiguration.Escape)
 				{
 					inQuotes = !inQuotes;
 					quoteCount++;

--- a/src/CsvHelper/TypeConversion/DoubleConverter.cs
+++ b/src/CsvHelper/TypeConversion/DoubleConverter.cs
@@ -7,28 +7,37 @@ using CsvHelper.Configuration;
 
 namespace CsvHelper.TypeConversion
 {
-	/// <summary>
-	/// Converts a <see cref="double"/> to and from a <see cref="string"/>.
-	/// </summary>
-	public class DoubleConverter : DefaultTypeConverter
-	{
-		/// <summary>
-		/// Converts the string to an object.
-		/// </summary>
-		/// <param name="text">The string to convert to an object.</param>
-		/// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
-		/// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
-		/// <returns>The object created from the string.</returns>
-		public override object ConvertFromString( string text, IReaderRow row, MemberMapData memberMapData )
-		{
-			var numberStyle = memberMapData.TypeConverterOptions.NumberStyle ?? NumberStyles.Float;
+    /// <summary>
+    /// Converts a <see cref="double"/> to and from a <see cref="string"/>.
+    /// </summary>
+    public class DoubleConverter : DefaultTypeConverter
+    {
+        /// <summary>
+        /// Converts the string to an object.
+        /// </summary>
+        /// <param name="text">The string to convert to an object.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+        /// <returns>The object created from the string.</returns>
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+        {
+            var numberStyle = memberMapData.TypeConverterOptions.NumberStyle ?? NumberStyles.Float;
 
-			if( double.TryParse( text, numberStyle, memberMapData.TypeConverterOptions.CultureInfo, out var d ) )
-			{
-				return d;
-			}
+            if (double.TryParse(text, numberStyle | NumberStyles.AllowExponent, memberMapData.TypeConverterOptions.CultureInfo, out var d))
+            {
+                return d;
+            }
+            if (text.Equals(double.MaxValue.ToString()))
+            {
+                return double.MaxValue;
+            }
+            if (text.Equals(double.MinValue.ToString()))
+            {
+                return double.MinValue;
+            }
 
-			return base.ConvertFromString( text, row, memberMapData );
-		}
-	}
+
+            return base.ConvertFromString(text, row, memberMapData);
+        }
+    }
 }


### PR DESCRIPTION
Fix for #1381 
The issue was that async reader didn't cover Escape character.