### PR TITLE
adds a test showing that a custom typeconverter for Uri fails

### DIFF
--- a/tests/CsvHelper.Tests/TypeConversion/TypeConverterTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/TypeConverterTests.cs
@@ -3,7 +3,9 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using CsvHelper.Configuration;
@@ -43,6 +45,30 @@ namespace CsvHelper.Tests.TypeConversion
 
 		private class Converter : Int32Converter
 		{
+		}
+		
+		
+		[TestMethod]
+		public void CustomUriConverter()
+		{
+			var sw = new StringWriter();
+			var entries = new[] {(new {Uri = new Uri("http://host/path")})};
+			using (var cw = new CsvWriter(sw))
+			{
+				cw.Configuration.Delimiter = ";";
+				cw.Configuration.TypeConverterCache.AddConverter<Uri>(new MyUriConverter());
+				cw.WriteRecords(entries);
+			}
+			Assert.AreEqual("Uri\r\nhttp://host/path\r\n", sw.ToString());
+		}
+
+		private class MyUriConverter : DefaultTypeConverter
+		{
+			public override object ConvertFromString(string text,IReaderRow row,MemberMapData memberMapData) => 
+				new Uri(text);
+
+			// public override string ConvertToString(object value,IWriterRow row,MemberMapData memberMapData) => 
+			//     value is Uri uri ? uri.ToString() : base.ConvertToString(value, row, memberMapData);
 		}
 	}
 }


### PR DESCRIPTION
This is a failing test.

Seems the problem has to do with the usage of an anonymous type where Uri is a constructor parameter type.
Perhaps `AutoMap` is building a map that can be used to read, too -- but we need just a `IWriterConfiguration`.
Finally using Uri type results in some StackOverflow exception (but I hoped `MyUriConverter` would avoid this).

