### PR TITLE
add & pass CancellationToken

### DIFF
--- a/src/CsvHelper/CsvFieldReader.cs
+++ b/src/CsvHelper/CsvFieldReader.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using CsvHelper.Configuration;
 using System.Threading.Tasks;
+using System.Threading;
 
 // This file is generated from a T4 template.
 // Modifying it directly won't do you any good.
@@ -84,7 +85,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <returns>True if there is more data left.
 		/// False if all the data has been read.</returns>
-		public virtual async Task<bool> FillBufferAsync()
+		public virtual async Task<bool> FillBufferAsync(CancellationToken cancellationToken = default )
 		{
 			if (!IsBufferEmpty)
 			{

--- a/src/CsvHelper/CsvFieldReader.tt
+++ b/src/CsvHelper/CsvFieldReader.tt
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using CsvHelper.Configuration;
 using System.Threading.Tasks;
+using System.Threading;
 
 // This file is generated from a T4 template.
 // Modifying it directly won't do you any good.
@@ -43,7 +44,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <returns>True if there is more data left.
 		/// False if all the data has been read.</returns>
-		public virtual <#= AsyncType("bool", isAsync) #> FillBuffer<#= AsyncPostfix(isAsync) #>()
+		public virtual <#= AsyncType("bool", isAsync) #> FillBuffer<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenDeclaration(isAsync) #>)
 		{
 			if (!IsBufferEmpty)
 			{

--- a/src/CsvHelper/CsvParser.tt
+++ b/src/CsvHelper/CsvParser.tt
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using CsvHelper.Configuration;
 using System.Threading.Tasks;
+using System.Threading;
 using System.Globalization;
 
 // This file is generated from a T4 template.
@@ -89,13 +90,13 @@ namespace CsvHelper
 		/// Reads a record from the CSV file<#= isAsync ? " asynchronously" : string.Empty #>.
 		/// </summary>
 		/// <returns>A <see cref="T:String[]" /> of fields for the record read.</returns>
-		public virtual <#= AsyncType("string[]", isAsync) #> Read<#= AsyncPostfix(isAsync) #>()
+		public virtual <#= AsyncType("string[]", isAsync) #> Read<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenDeclaration(isAsync) #>)
 		{
 			try
 			{
 				context.ClearCache(Caches.RawRecord);
 
-				var row = <#= Await(isAsync) #>ReadLine<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>;
+				var row = <#= Await(isAsync) #>ReadLine<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>;
 
 				return row;
 			}
@@ -145,7 +146,7 @@ namespace CsvHelper
 		/// Reads a line of the CSV file.
 		/// </summary>
 		/// <returns>The CSV line.</returns>
-		protected virtual <#= AsyncType("string[]", isAsync) #> ReadLine<#= AsyncPostfix(isAsync) #>()
+		protected virtual <#= AsyncType("string[]", isAsync) #> ReadLine<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenDeclaration(isAsync) #>)
 		{
 			context.RecordBuilder.Clear();
 			context.Row++;
@@ -153,7 +154,7 @@ namespace CsvHelper
 
 			while (true)
 			{
-				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 				{
 					// End of file.
 					if (context.RecordBuilder.Length > 0)
@@ -171,7 +172,7 @@ namespace CsvHelper
 
 				if (context.RecordBuilder.Length == 0 && ((c == context.ParserConfiguration.Comment && context.ParserConfiguration.AllowComments) || c == '\r' || c == '\n'))
 				{
-					<#= Await(isAsync) #>ReadBlankLine<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>;
+					<#= Await(isAsync) #>ReadBlankLine<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>;
 					if (!context.ParserConfiguration.IgnoreBlankLines)
 					{
 						break;
@@ -183,20 +184,20 @@ namespace CsvHelper
 				// Trim start outside of quotes.
 				if (c == ' ' && (context.ParserConfiguration.TrimOptions & TrimOptions.Trim) == TrimOptions.Trim)
 				{
-					<#= Await(isAsync) #>ReadSpaces<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>;
+					<#= Await(isAsync) #>ReadSpaces<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>;
 					fieldReader.SetFieldStart(-1);
 				}
 
 				if (c == context.ParserConfiguration.Quote && !context.ParserConfiguration.IgnoreQuotes)
 				{
-					if (<#= Await(isAsync) #>ReadQuotedField<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+					if (<#= Await(isAsync) #>ReadQuotedField<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 					{
 						break;
 					}
 				}
 				else
 				{
-					if (<#= Await(isAsync) #>ReadField<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+					if (<#= Await(isAsync) #>ReadField<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 					{
 						break;
 					}
@@ -216,7 +217,7 @@ namespace CsvHelper
 		/// Reads a blank line. This accounts for empty lines
 		/// and commented out lines.
 		/// </summary>
-		protected virtual <#= AsyncType(null, isAsync) #> ReadBlankLine<#= AsyncPostfix(isAsync) #>()
+		protected virtual <#= AsyncType(null, isAsync) #> ReadBlankLine<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenDeclaration(isAsync) #>)
 		{
 			if (context.ParserConfiguration.IgnoreBlankLines)
 			{
@@ -227,7 +228,7 @@ namespace CsvHelper
 			{
 				if (c == '\r' || c == '\n')
 				{
-					<#= Await(isAsync) #>ReadLineEnding<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>;
+					<#= Await(isAsync) #>ReadLineEnding<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>;
 					fieldReader.SetFieldStart();
 					return;
 				}
@@ -237,7 +238,7 @@ namespace CsvHelper
 				// need to set the field start every char.
 				fieldReader.SetFieldStart();
 
-				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 				{
 					// End of file.
 					return;
@@ -257,11 +258,11 @@ namespace CsvHelper
 		/// Reads until a delimiter or line ending is found.
 		/// </summary>
 		/// <returns>True if the end of the line was found, otherwise false.</returns>
-		protected virtual <#= AsyncType("bool", isAsync) #> ReadField<#= AsyncPostfix(isAsync) #>()
+		protected virtual <#= AsyncType("bool", isAsync) #> ReadField<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenDeclaration(isAsync) #>)
 		{
 			if (c != context.ParserConfiguration.Delimiter[0] && c != '\r' && c != '\n')
 			{
-				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 				{
 					// End of file.
 					fieldReader.SetFieldEnd();
@@ -310,7 +311,7 @@ namespace CsvHelper
 					fieldReader.SetFieldEnd(-1);
 
 					// End of field.
-					if (<#= Await(isAsync) #>ReadDelimiter<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+					if (<#= Await(isAsync) #>ReadDelimiter<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 					{
 						// Set the end of the field to the char before the delimiter.
 						context.RecordBuilder.Add(fieldReader.GetField());
@@ -322,7 +323,7 @@ namespace CsvHelper
 				{
 					// End of line.
 					fieldReader.SetFieldEnd(-1);
-					var offset = <#= Await(isAsync) #>ReadLineEnding<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>;
+					var offset = <#= Await(isAsync) #>ReadLineEnding<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>;
 					fieldReader.SetRawRecordEnd(offset);
 					context.RecordBuilder.Add(fieldReader.GetField());
 
@@ -332,7 +333,7 @@ namespace CsvHelper
 					return true;
 				}
 
-				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 				{
 					// End of file.
 					fieldReader.SetFieldEnd();
@@ -361,7 +362,7 @@ namespace CsvHelper
 		/// Reads until the field is not quoted and a delimiter is found.
 		/// </summary>
 		/// <returns>True if the end of the line was found, otherwise false.</returns>
-		protected virtual <#= AsyncType("bool", isAsync) #> ReadQuotedField<#= AsyncPostfix(isAsync) #>()
+		protected virtual <#= AsyncType("bool", isAsync) #> ReadQuotedField<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenDeclaration(isAsync) #>)
 		{
 			var inQuotes = true;
 			var quoteCount = 1;
@@ -372,7 +373,7 @@ namespace CsvHelper
 			{
 				var cPrev = c;
 
-				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 				{
 					// End of file.
 					fieldReader.SetFieldEnd();
@@ -386,7 +387,7 @@ namespace CsvHelper
 				// Trim start inside quotes.
 				if (quoteCount == 1 && c == ' ' && cPrev == context.ParserConfiguration.Quote && (context.ParserConfiguration.TrimOptions & TrimOptions.InsideQuotes) == TrimOptions.InsideQuotes)
 				{
-					<#= Await(isAsync) #>ReadSpaces<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>;
+					<#= Await(isAsync) #>ReadSpaces<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>;
 					cPrev = ' ';
 					fieldReader.SetFieldStart(-1);
 				}
@@ -397,7 +398,7 @@ namespace CsvHelper
 					fieldReader.SetFieldEnd(-1);
 					fieldReader.AppendField();
 					fieldReader.SetFieldStart(-1);
-					ReadSpaces();
+					<#= Await(isAsync) #>ReadSpaces<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>;
 					cPrev = ' ';
 
 					if (c == context.ParserConfiguration.Escape || c == context.ParserConfiguration.Quote)
@@ -407,7 +408,7 @@ namespace CsvHelper
 
 						cPrev = c;
 
-						if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+						if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 						{
 							// End of file.
 							fieldReader.SetFieldStart();
@@ -477,7 +478,7 @@ namespace CsvHelper
 					// Trim end outside of quotes.
 					if (c == ' ' && (context.ParserConfiguration.TrimOptions & TrimOptions.Trim) == TrimOptions.Trim)
 					{
-						<#= Await(isAsync) #>ReadSpaces<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>;
+						<#= Await(isAsync) #>ReadSpaces<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>;
 						fieldReader.SetFieldStart(-1);
 					}
 
@@ -485,7 +486,7 @@ namespace CsvHelper
 					{
 						fieldReader.SetFieldEnd(-1);
 
-						if (<#= Await(isAsync) #>ReadDelimiter<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+						if (<#= Await(isAsync) #>ReadDelimiter<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 						{
 							// Add an extra offset because of the end quote.
 							context.RecordBuilder.Add(fieldReader.GetField());
@@ -496,7 +497,7 @@ namespace CsvHelper
 					else if (c == '\r' || c == '\n')
 					{
 						fieldReader.SetFieldEnd(-1);
-						var offset = <#= Await(isAsync) #>ReadLineEnding<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>;
+						var offset = <#= Await(isAsync) #>ReadLineEnding<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>;
 						fieldReader.SetRawRecordEnd(offset);
 						context.RecordBuilder.Add(fieldReader.GetField());
 
@@ -509,7 +510,7 @@ namespace CsvHelper
 					{
 						// We're out of quotes. Read the reset of
 						// the field like a normal field.
-						return <#= Await(isAsync) #>ReadField<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>;
+						return <#= Await(isAsync) #>ReadField<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>;
 					}
 				}
 			}
@@ -526,7 +527,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <returns>True if a delimiter was read. False if the sequence of
 		/// chars ended up not being the delimiter.</returns>
-		protected virtual <#= AsyncType("bool", isAsync) #> ReadDelimiter<#= AsyncPostfix(isAsync) #>()
+		protected virtual <#= AsyncType("bool", isAsync) #> ReadDelimiter<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenDeclaration(isAsync) #>)
 		{
 			if (c != context.ParserConfiguration.Delimiter[0])
 			{
@@ -540,7 +541,7 @@ namespace CsvHelper
 
 			for (var i = 1; i < context.ParserConfiguration.Delimiter.Length; i++)
 			{
-				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 				{
 					// End of file.
 					return false;
@@ -566,7 +567,7 @@ namespace CsvHelper
 		/// Reads until the line ending is done.
 		/// </summary>
 		/// <returns>The field start offset.</returns>
-		protected virtual <#= AsyncType("int", isAsync) #> ReadLineEnding<#= AsyncPostfix(isAsync) #>()
+		protected virtual <#= AsyncType("int", isAsync) #> ReadLineEnding<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenDeclaration(isAsync) #>)
 		{
 			if (c != '\r' && c != '\n')
 			{
@@ -576,7 +577,7 @@ namespace CsvHelper
 			var fieldStartOffset = 0;
 			if (c == '\r')
 			{
-				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 				{
 					// End of file.
 					return fieldStartOffset;
@@ -605,7 +606,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <returns>True if there is more data to read.
 		/// False if the end of the file has been reached.</returns>
-		protected virtual <#= AsyncType("bool", isAsync) #> ReadSpaces<#= AsyncPostfix(isAsync) #>()
+		protected virtual <#= AsyncType("bool", isAsync) #> ReadSpaces<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenDeclaration(isAsync) #>)
 		{
 			while (true)
 			{
@@ -614,7 +615,7 @@ namespace CsvHelper
 					break;
 				}
 
-				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>)
+				if (fieldReader.IsBufferEmpty && !<#= Await(isAsync) #>fieldReader.FillBuffer<#= AsyncPostfix(isAsync) #>(<#= CancellationTokenParameter(isAsync) #>)<#= ConfigureAwait(isAsync) #>)
 				{
 					// End of file.
 					return false;

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using CsvHelper.Expressions;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace CsvHelper
@@ -1250,7 +1251,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The <see cref="System.Type"/> of the record.</typeparam>
 		/// <returns>An <see cref="IAsyncEnumerable{T}" /> of records.</returns>
-		public virtual async IAsyncEnumerable<T> GetRecordsAsync<T>(CancellationToken cancellationToken = default)
+		public virtual async IAsyncEnumerable<T> GetRecordsAsync<T>([EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			// Don't need to check if it's been read
 			// since we're doing the reading ourselves.
@@ -1329,7 +1330,7 @@ namespace CsvHelper
 		/// <param name="type">The <see cref="System.Type"/> of the record.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{Object}" /> of records.</returns>
-		public virtual async IAsyncEnumerable<object> GetRecordsAsync(Type type, CancellationToken cancellationToken = default)
+		public virtual async IAsyncEnumerable<object> GetRecordsAsync(Type type, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			// Don't need to check if it's been read
 			// since we're doing the reading ourselves.
@@ -1387,7 +1388,7 @@ namespace CsvHelper
 		/// <param name="record">The record to fill each enumeration.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{T}"/> of records.</returns>
-		public virtual async IAsyncEnumerable<T> EnumerateRecordsAsync<T>(T record, CancellationToken cancellationToken = default)
+		public virtual async IAsyncEnumerable<T> EnumerateRecordsAsync<T>(T record, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			// Don't need to check if it's been read
 			// since we're doing the reading ourselves.

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using CsvHelper.Expressions;
 using System.Globalization;
+using System.Threading;
 
 namespace CsvHelper
 {
@@ -238,11 +239,11 @@ namespace CsvHelper
 		/// for the headers to be read.
 		/// </summary>
 		/// <returns>True if there are more records, otherwise false.</returns>
-		public virtual async Task<bool> ReadAsync()
+		public virtual async Task<bool> ReadAsync(CancellationToken cancellationToken = default)
 		{
 			do
 			{
-				context.Record = await parser.ReadAsync().ConfigureAwait(false);
+				context.Record = await parser.ReadAsync(cancellationToken).ConfigureAwait(false);
 			}
 			while (context.Record != null && Configuration.ShouldSkipRecord(context.Record));
 
@@ -1249,14 +1250,14 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The <see cref="System.Type"/> of the record.</typeparam>
 		/// <returns>An <see cref="IAsyncEnumerable{T}" /> of records.</returns>
-		public virtual async IAsyncEnumerable<T> GetRecordsAsync<T>()
+		public virtual async IAsyncEnumerable<T> GetRecordsAsync<T>(CancellationToken cancellationToken = default)
 		{
 			// Don't need to check if it's been read
 			// since we're doing the reading ourselves.
 
 			if (context.ReaderConfiguration.HasHeaderRecord && context.HeaderRecord == null)
 			{
-				if (!await ReadAsync().ConfigureAwait(false))
+				if (!await ReadAsync(cancellationToken).ConfigureAwait(false))
 				{
 					yield break;
 				}
@@ -1265,7 +1266,7 @@ namespace CsvHelper
 				ValidateHeader<T>();
 			}
 
-			while (await ReadAsync().ConfigureAwait(false))
+			while (await ReadAsync(cancellationToken).ConfigureAwait(false))
 			{
 				T record;
 				try
@@ -1303,8 +1304,9 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The <see cref="System.Type"/> of the record.</typeparam>
 		/// <param name="anonymousTypeDefinition">The anonymous type definition to use for the records.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>An <see cref="IEnumerable{T}"/> of records.</returns>
-		public virtual IAsyncEnumerable<T> GetRecordsAsync<T>(T anonymousTypeDefinition)
+		public virtual IAsyncEnumerable<T> GetRecordsAsync<T>(T anonymousTypeDefinition, CancellationToken cancellationToken = default)
 		{
 			if (anonymousTypeDefinition == null)
 			{
@@ -1316,7 +1318,7 @@ namespace CsvHelper
 				throw new ArgumentException($"Argument is not an anonymous type.", nameof(anonymousTypeDefinition));
 			}
 
-			return GetRecordsAsync<T>();
+			return GetRecordsAsync<T>(cancellationToken);
 		}
 
 		/// <summary>
@@ -1325,15 +1327,16 @@ namespace CsvHelper
 		/// should not be used when using this.
 		/// </summary>
 		/// <param name="type">The <see cref="System.Type"/> of the record.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{Object}" /> of records.</returns>
-		public virtual async IAsyncEnumerable<object> GetRecordsAsync(Type type)
+		public virtual async IAsyncEnumerable<object> GetRecordsAsync(Type type, CancellationToken cancellationToken = default)
 		{
 			// Don't need to check if it's been read
 			// since we're doing the reading ourselves.
 
 			if (context.ReaderConfiguration.HasHeaderRecord && context.HeaderRecord == null)
 			{
-				if (!await ReadAsync().ConfigureAwait(false))
+				if (!await ReadAsync(cancellationToken).ConfigureAwait(false))
 				{
 					yield break;
 				}
@@ -1342,7 +1345,7 @@ namespace CsvHelper
 				ValidateHeader(type);
 			}
 
-			while (await ReadAsync().ConfigureAwait(false))
+			while (await ReadAsync(cancellationToken).ConfigureAwait(false))
 			{
 				object record;
 				try
@@ -1382,15 +1385,16 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The type of the record.</typeparam>
 		/// <param name="record">The record to fill each enumeration.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{T}"/> of records.</returns>
-		public virtual async IAsyncEnumerable<T> EnumerateRecordsAsync<T>(T record)
+		public virtual async IAsyncEnumerable<T> EnumerateRecordsAsync<T>(T record, CancellationToken cancellationToken = default)
 		{
 			// Don't need to check if it's been read
 			// since we're doing the reading ourselves.
 
 			if (context.ReaderConfiguration.HasHeaderRecord && context.HeaderRecord == null)
 			{
-				if (!await ReadAsync().ConfigureAwait(false))
+				if (!await ReadAsync(cancellationToken).ConfigureAwait(false))
 				{
 					yield break;
 				}
@@ -1399,7 +1403,7 @@ namespace CsvHelper
 				ValidateHeader<T>();
 			}
 
-			while (await ReadAsync().ConfigureAwait(false))
+			while (await ReadAsync(cancellationToken).ConfigureAwait(false))
 			{
 				try
 				{

--- a/src/CsvHelper/CsvSerializer.cs
+++ b/src/CsvHelper/CsvSerializer.cs
@@ -8,6 +8,7 @@ using CsvHelper.Configuration;
 using System.Threading.Tasks;
 using System.Linq;
 using System.Globalization;
+using System.Threading;
 
 namespace CsvHelper
 {
@@ -91,20 +92,21 @@ namespace CsvHelper
 		/// Writes a record to the CSV file.
 		/// </summary>
 		/// <param name="record">The record to write.</param>
-		public virtual async Task WriteAsync(string[] record)
+		/// <param name="cancellationToken">The cancellation token.</param>
+		public virtual async Task WriteAsync(string[] record, CancellationToken cancellationToken = default)
 		{
 			for (var i = 0; i < record.Length; i++)
 			{
 				if (i > 0)
 				{
-					await context.Writer.WriteAsync(context.SerializerConfiguration.Delimiter).ConfigureAwait(false);
+					await context.Writer.WriteAsync(context.SerializerConfiguration.Delimiter, cancellationToken).ConfigureAwait(false);
 				}
 
 				var field = Configuration.SanitizeForInjection
 					? SanitizeForInjection(record[i])
 					: record[i];
 
-				await context.Writer.WriteAsync(field).ConfigureAwait(false);
+				await context.Writer.WriteAsync(field, cancellationToken).ConfigureAwait(false);
 			}
 		}
 
@@ -121,9 +123,9 @@ namespace CsvHelper
 		/// <summary>
 		/// Writes a new line to the CSV file.
 		/// </summary>
-		public virtual async Task WriteLineAsync()
+		public virtual async Task WriteLineAsync(CancellationToken cancellationToken = default)
 		{
-			await context.Writer.WriteAsync(context.SerializerConfiguration.NewLineString).ConfigureAwait(false);
+			await context.Writer.WriteAsync(context.SerializerConfiguration.NewLineString, cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <summary>

--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -15,6 +15,7 @@ using System.Dynamic;
 using System.Threading.Tasks;
 using CsvHelper.Expressions;
 using System.Globalization;
+using System.Threading;
 
 #pragma warning disable 649
 #pragma warning disable 169
@@ -219,9 +220,9 @@ namespace CsvHelper
 		/// <summary>
 		/// Serializes the row to the <see cref="TextWriter"/>.
 		/// </summary>
-		public virtual async Task FlushAsync()
+		public virtual async Task FlushAsync(CancellationToken cancellationToken = default)
 		{
-			await serializer.WriteAsync(context.Record.ToArray()).ConfigureAwait(false);
+			await serializer.WriteAsync(context.Record.ToArray(), cancellationToken).ConfigureAwait(false);
 			context.Record.Clear();
 		}
 
@@ -249,12 +250,12 @@ namespace CsvHelper
 		/// Ends writing of the current record and starts a new record.
 		/// This automatically flushes the writer.
 		/// </summary>
-		public virtual async Task NextRecordAsync()
+		public virtual async Task NextRecordAsync(CancellationToken cancellationToken = default)
 		{
 			try
 			{
-				await FlushAsync().ConfigureAwait(false);
-				await serializer.WriteLineAsync().ConfigureAwait(false);
+				await FlushAsync(cancellationToken).ConfigureAwait(false);
+				await serializer.WriteLineAsync(cancellationToken).ConfigureAwait(false);
 				context.Row++;
 			}
 			catch (Exception ex)
@@ -526,7 +527,8 @@ namespace CsvHelper
 		/// Writes the list of records to the CSV file.
 		/// </summary>
 		/// <param name="records">The records to write.</param>
-		public virtual async Task WriteRecordsAsync(IEnumerable records)
+		/// <param name="cancellationToken">The cancellation token.</param>
+		public virtual async Task WriteRecordsAsync(IEnumerable records, CancellationToken cancellationToken = default)
 		{
 			// Changes in this method require changes in method WriteRecords<T>(IEnumerable<T> records) also.
 
@@ -541,7 +543,7 @@ namespace CsvHelper
 						if (context.WriterConfiguration.HasHeaderRecord && !context.HasHeaderBeenWritten)
 						{
 							WriteDynamicHeader(dynamicObject);
-							await NextRecordAsync().ConfigureAwait(false);
+							await NextRecordAsync(cancellationToken).ConfigureAwait(false);
 						}
 					}
 					else
@@ -552,7 +554,7 @@ namespace CsvHelper
 						if (context.WriterConfiguration.HasHeaderRecord && !context.HasHeaderBeenWritten && !isPrimitive)
 						{
 							WriteHeader(recordType);
-							await NextRecordAsync().ConfigureAwait(false);
+							await NextRecordAsync(cancellationToken).ConfigureAwait(false);
 						}
 					}
 
@@ -565,7 +567,7 @@ namespace CsvHelper
 						throw ex.InnerException;
 					}
 
-					await NextRecordAsync().ConfigureAwait(false);
+					await NextRecordAsync(cancellationToken).ConfigureAwait(false);
 				}
 			}
 			catch (Exception ex)
@@ -579,7 +581,8 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">Record type.</typeparam>
 		/// <param name="records">The records to write.</param>
-		public virtual async Task WriteRecordsAsync<T>(IEnumerable<T> records)
+		/// <param name="cancellationToken">The cancellation token.</param>
+		public virtual async Task WriteRecordsAsync<T>(IEnumerable<T> records, CancellationToken cancellationToken = default)
 		{
 			// Changes in this method require changes in method WriteRecords(IEnumerable records) also.
 
@@ -594,7 +597,7 @@ namespace CsvHelper
 					WriteHeader(recordType);
 					if (context.HasHeaderBeenWritten)
 					{
-						await NextRecordAsync().ConfigureAwait(false);
+						await NextRecordAsync(cancellationToken).ConfigureAwait(false);
 					}
 				}
 
@@ -611,7 +614,7 @@ namespace CsvHelper
 						if (context.WriterConfiguration.HasHeaderRecord && !context.HasHeaderBeenWritten)
 						{
 							WriteDynamicHeader(dynamicObject);
-							await NextRecordAsync().ConfigureAwait(false);
+							await NextRecordAsync(cancellationToken).ConfigureAwait(false);
 						}
 					}
 					else
@@ -622,7 +625,7 @@ namespace CsvHelper
 						if (context.WriterConfiguration.HasHeaderRecord && !context.HasHeaderBeenWritten && !isPrimitive)
 						{
 							WriteHeader(recordType);
-							await NextRecordAsync().ConfigureAwait(false);
+							await NextRecordAsync(cancellationToken).ConfigureAwait(false);
 						}
 					}
 
@@ -635,7 +638,7 @@ namespace CsvHelper
 						throw ex.InnerException;
 					}
 
-					await NextRecordAsync().ConfigureAwait(false);
+					await NextRecordAsync(cancellationToken).ConfigureAwait(false);
 				}
 			}
 			catch (Exception ex)

--- a/src/CsvHelper/IFieldReader.cs
+++ b/src/CsvHelper/IFieldReader.cs
@@ -3,6 +3,7 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CsvHelper
@@ -35,7 +36,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <returns>True if there is more data left.
 		/// False if all the data has been read.</returns>
-		Task<bool> FillBufferAsync();
+		Task<bool> FillBufferAsync(CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Gets the next char as an <see cref="int"/>.

--- a/src/CsvHelper/IParser.cs
+++ b/src/CsvHelper/IParser.cs
@@ -3,6 +3,7 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
 using System;
+using System.Threading;
 using CsvHelper.Configuration;
 using System.Threading.Tasks;
 
@@ -38,6 +39,6 @@ namespace CsvHelper
 		/// Reads a record from the CSV file asynchronously.
 		/// </summary>
 		/// <returns>A <see cref="T:String[]" /> of fields for the record read.</returns>
-		Task<string[]> ReadAsync();
+		Task<string[]> ReadAsync(CancellationToken cancellationToken = default);
 	}
 }

--- a/src/CsvHelper/IReader.cs
+++ b/src/CsvHelper/IReader.cs
@@ -4,6 +4,7 @@
 // https://github.com/JoshClose/CsvHelper
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CsvHelper
@@ -39,7 +40,7 @@ namespace CsvHelper
 		/// for the headers to be read.
 		/// </summary>
 		/// <returns>True if there are more records, otherwise false.</returns>
-		Task<bool> ReadAsync();
+		Task<bool> ReadAsync(CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Gets all the records in the CSV file and
@@ -89,7 +90,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The <see cref="Type"/> of the record.</typeparam>
 		/// <returns>An <see cref="IAsyncEnumerable{T}" /> of records.</returns>
-		IAsyncEnumerable<T> GetRecordsAsync<T>();
+		IAsyncEnumerable<T> GetRecordsAsync<T>(CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Gets all the records in the CSV file and converts
@@ -98,8 +99,9 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The <see cref="System.Type"/> of the record.</typeparam>
 		/// <param name="anonymousTypeDefinition">The anonymous type definition to use for the records.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{T}"/> of records.</returns>
-		IAsyncEnumerable<T> GetRecordsAsync<T>(T anonymousTypeDefinition);
+		IAsyncEnumerable<T> GetRecordsAsync<T>(T anonymousTypeDefinition, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Gets all the records in the CSV file and
@@ -107,8 +109,9 @@ namespace CsvHelper
 		/// should not be used when using this.
 		/// </summary>
 		/// <param name="type">The <see cref="Type"/> of the record.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{Object}" /> of records.</returns>
-		IAsyncEnumerable<object> GetRecordsAsync(Type type);
+		IAsyncEnumerable<object> GetRecordsAsync(Type type, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Enumerates the records hydrating the given record instance with row data.
@@ -119,8 +122,9 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The type of the record.</typeparam>
 		/// <param name="record">The record to fill each enumeration.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{T}"/> of records.</returns>
-		IAsyncEnumerable<T> EnumerateRecordsAsync<T>(T record);
+		IAsyncEnumerable<T> EnumerateRecordsAsync<T>(T record, CancellationToken cancellationToken = default);
 #endif // NET47 || NETSTANDARD
 	}
 }

--- a/src/CsvHelper/ISerializer.cs
+++ b/src/CsvHelper/ISerializer.cs
@@ -3,6 +3,7 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
 using System;
+using System.Threading;
 using CsvHelper.Configuration;
 using System.Threading.Tasks;
 
@@ -36,7 +37,8 @@ namespace CsvHelper
 		/// Writes a record to the CSV file.
 		/// </summary>
 		/// <param name="record">The record to write.</param>
-		Task WriteAsync( string[] record );
+		/// <param name="cancellationToken">The cancellation token.</param>
+		Task WriteAsync( string[] record, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Writes a new line to the CSV file.
@@ -46,6 +48,6 @@ namespace CsvHelper
 		/// <summary>
 		/// Writes a new line to the CSV file.
 		/// </summary>
-		Task WriteLineAsync();
+		Task WriteLineAsync(CancellationToken cancellationToken = default);
 	}
 }

--- a/src/CsvHelper/IWriter.cs
+++ b/src/CsvHelper/IWriter.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.IO;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace CsvHelper
 {
@@ -26,7 +27,7 @@ namespace CsvHelper
 		/// <summary>
 		/// Serializes the row to the <see cref="TextWriter"/>.
 		/// </summary>
-		Task FlushAsync();
+		Task FlushAsync(CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Ends writing of the current record and starts a new record.
@@ -38,7 +39,7 @@ namespace CsvHelper
 		/// Ends writing of the current record and starts a new record.
 		/// This automatically flushes the writer.
 		/// </summary>
-		Task NextRecordAsync();
+		Task NextRecordAsync(CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Writes the list of records to the CSV file.
@@ -57,13 +58,15 @@ namespace CsvHelper
 		/// Writes the list of records to the CSV file.
 		/// </summary>
 		/// <param name="records">The records to write.</param>
-		Task WriteRecordsAsync(IEnumerable records);
+		/// <param name="cancellationToken">The cancellation token.</param>
+		Task WriteRecordsAsync(IEnumerable records, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Writes the list of records to the CSV file.
 		/// </summary>
 		/// <typeparam name="T">Record type.</typeparam>
 		/// <param name="records">The records to write.</param>
-		Task WriteRecordsAsync<T>(IEnumerable<T> records);
+		/// <param name="cancellationToken">The cancellation token.</param>
+		Task WriteRecordsAsync<T>(IEnumerable<T> records, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/CsvHelper/T4Methods.tt
+++ b/src/CsvHelper/T4Methods.tt
@@ -32,4 +32,14 @@
 	{
 		return isAsync ? "await " : string.Empty;
 	}
+
+	private string CancellationTokenDeclaration(bool isAsync)
+	{
+		return isAsync ? "CancellationToken cancellationToken = default " : string.Empty;
+	}
+
+	private string CancellationTokenParameter(bool isAsync)
+	{
+		return isAsync ? "cancellationToken" : string.Empty;
+	}
 #>

--- a/src/CsvHelper/TextReaderExtensions.cs
+++ b/src/CsvHelper/TextReaderExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2020 Bianco Veigel
+// This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
+// See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
+// https://github.com/JoshClose/CsvHelper
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CsvHelper
+{
+	internal static class TextReaderWriterExtensions
+	{
+		public static Task WriteAsync(this TextWriter writer, string value, CancellationToken cancellationToken)
+		{
+#if NETSTANDARD2_1
+			return writer.WriteAsync(value.AsMemory(), cancellationToken);
+#else
+			cancellationToken.ThrowIfCancellationRequested();
+			return writer.WriteAsync(value);
+#endif
+		}
+
+#if NETSTANDARD2_1
+		public static ValueTask<int> ReadAsync(this TextReader reader, char[] buffer, int index, int count, CancellationToken cancellationToken)
+#else
+		public static Task<int> ReadAsync(this TextReader reader, char[] buffer, int index, int count, CancellationToken cancellationToken)
+#endif
+		{
+#if NETSTANDARD2_1
+			return reader.ReadAsync(buffer.AsMemory().Slice(index, count), cancellationToken);
+#else
+			cancellationToken.ThrowIfCancellationRequested();
+			return reader.ReadAsync(buffer, index, count);
+#endif
+		}
+	}
+}

--- a/src/CsvHelper/TextReaderExtensions.cs
+++ b/src/CsvHelper/TextReaderExtensions.cs
@@ -29,7 +29,7 @@ namespace CsvHelper
 #endif
 		{
 #if NETSTANDARD2_1
-			return reader.ReadAsync(buffer.AsMemory().Slice(index, count), cancellationToken);
+			return reader.ReadAsync(buffer.AsMemory(index, count), cancellationToken);
 #else
 			cancellationToken.ThrowIfCancellationRequested();
 			return reader.ReadAsync(buffer, index, count);

--- a/tests/CsvHelper.Tests/Mocks/ParserMock.cs
+++ b/tests/CsvHelper.Tests/Mocks/ParserMock.cs
@@ -9,6 +9,7 @@ using System.IO;
 using CsvHelper.Configuration;
 using System.Threading.Tasks;
 using System.Globalization;
+using System.Threading;
 
 namespace CsvHelper.Tests.Mocks
 {
@@ -47,7 +48,7 @@ namespace CsvHelper.Tests.Mocks
 			return rows.Dequeue();
 		}
 
-		public Task<string[]> ReadAsync()
+		public Task<string[]> ReadAsync(CancellationToken cancellationToken = default)
 		{
 			context.Row++;
 			return Task.FromResult(rows.Dequeue());

--- a/tests/CsvHelper.Tests/Mocks/SerializerMock.cs
+++ b/tests/CsvHelper.Tests/Mocks/SerializerMock.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using CsvHelper.Configuration;
 
@@ -56,12 +57,12 @@ namespace CsvHelper.Tests.Mocks
 			return new ValueTask();
 		}
 
-		public Task WriteAsync(string[] record)
+		public Task WriteAsync(string[] record, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task WriteLineAsync()
+		public Task WriteLineAsync(CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}


### PR DESCRIPTION
This is a breaking change!

I've added a CancellationToken to all async method (with a default, but still requires recompilation) and it's passed down to `TextWriter.WriteAsync` and `TextReader.ReadAsync`

The actual cancellation is handled in [TextReaderExtensions.cs](https://github.com/zivillian/CsvHelper/blob/c246d571e85ccb6d168dd3579bd2abe6b0f0cf5d/src/CsvHelper/TextReaderExtensions.cs)

fixes #1359