### PR TITLE
allow inherited prefix headers

### DIFF
--- a/src/CsvHelper/Configuration/MemberReferenceMapData.cs
+++ b/src/CsvHelper/Configuration/MemberReferenceMapData.cs
@@ -26,6 +26,11 @@ namespace CsvHelper.Configuration
 				{
 					memberMap.Data.Names.Prefix = value;
 				}
+
+				foreach( var memberRef in Mapping.ReferenceMaps )
+				{
+					memberRef.Data.Prefix = memberRef.Data.Prefix == null ? value : string.Concat(value, memberRef.Data.Prefix);
+				}
 			}
 		}
 

--- a/tests/CsvHelper.Tests/AttributeMapping/HeaderPrefixTests.cs
+++ b/tests/CsvHelper.Tests/AttributeMapping/HeaderPrefixTests.cs
@@ -43,6 +43,21 @@ namespace CsvHelper.Tests.AttributeMapping
 			}
 		}
 
+		[TestMethod]
+		public void InheritedHeaderPrefixTest()
+		{
+			using (var reader = new StringReader("Id,D.B.Name,D.C.Name\r\n1,b,c"))
+			using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
+			{
+				csv.Configuration.Delimiter = ",";
+				var records = csv.GetRecords<ADefaultInherited>().ToList();
+
+				Assert.AreEqual(1, records[0].Id);
+				Assert.AreEqual("b", records[0].D.B.Name);
+				Assert.AreEqual("c", records[0].D.C.Name);
+			}
+		}
+
 		private class ADefault
 		{
 			public int Id { get; set; }
@@ -73,6 +88,24 @@ namespace CsvHelper.Tests.AttributeMapping
 		private class C
 		{
 			public string Name { get; set; }
+		}
+
+		private class D
+		{
+			[HeaderPrefixAttribute]
+			public B B { get; set; }
+
+			[HeaderPrefixAttribute]
+			public C C { get; set; }
+		}
+
+		private class ADefaultInherited
+		{
+			public int Id { get; set; }
+
+			[HeaderPrefixAttribute]
+			public D D { get; set; }
+
 		}
 	}
 }


### PR DESCRIPTION
For complex object graph or an object with multiple properties referencing a same type, it may be useful to nest header prefix.
```
class A
  [HeaderPrefix("B1")]
  public B B
  [HeaderPrefix("B2")]
  public B B
  [HeaderPrefix("B3")]
  public B B

class B
   [HeaderPrefix("Name")]
   public C C

class C
  public int ID {get; set;}
```

So that the csv header is set to B1.Name.ID, B2.Name.ID, B3.Name.ID respectively.