### PR TITLE
Fixed conditional compilation

### DIFF
--- a/src/CsvHelper/IWriter.cs
+++ b/src/CsvHelper/IWriter.cs
@@ -14,7 +14,7 @@ namespace CsvHelper
 	/// Defines methods used to write to a CSV file.
 	/// </summary>
 	public interface IWriter : IWriterRow, IDisposable
-#if NET47 || NETSTANDARD2_1
+#if NET47 || NETSTANDARD
 		, IAsyncDisposable
 #endif
 	{

--- a/tests/CsvHelper.Tests/Async/ReadingTests.cs
+++ b/tests/CsvHelper.Tests/Async/ReadingTests.cs
@@ -44,7 +44,7 @@ namespace CsvHelper.Tests.Async
 			}
 		}
 
-#if NETCOREAPP2_1
+#if NET472 || NETCOREAPP2_1 || NETCOREAPP3_1
 		[TestMethod]
 		public async Task GetRecordsTest()
 		{


### PR DESCRIPTION
1. Since IAsyncDisposable is available not only in .NET Standard 2.1, but also in 2.0 (from package Microsoft.Bcl.AsyncInterfaces, which is already referenced in CsvHelper), NETSTANDARD2_1 in IWriter.cs has been replaced by NETSTANDARD (the same condition as it was for CsvHelper.DisposeAsync()).
2. Test GetRecordsTest() wasn't included in test collections for .NET 4.7.2 and .NET Core 3.1 because of wrong conditional symbols.