### PR TITLE
IAsyncEnumerable support in CsvWriter

### DIFF
--- a/src/CsvHelper/IWriter.cs
+++ b/src/CsvHelper/IWriter.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.IO;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace CsvHelper
 {
@@ -65,5 +66,18 @@ namespace CsvHelper
 		/// <typeparam name="T">Record type.</typeparam>
 		/// <param name="records">The records to write.</param>
 		Task WriteRecordsAsync<T>(IEnumerable<T> records);
+
+#if NET47 || NETSTANDARD
+		/// <summary>
+		/// Writes the list of records to the CSV file.
+		/// </summary>
+		/// <typeparam name="T">Record type.</typeparam>
+		/// <param name="records">The records to write.</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <remarks>
+		/// This method uses IAsyncEnumerable as data source, so calls to MoveNextAsync() during enumeration are non-blocking
+		/// </remarks>
+		Task WriteRecordsAsync<T>(IAsyncEnumerable<T> records, CancellationToken cancellationToken = default);
+#endif
 	}
 }

--- a/tests/CsvHelper.Tests/Async/WritingTests.cs
+++ b/tests/CsvHelper.Tests/Async/WritingTests.cs
@@ -2,11 +2,15 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
+
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CsvHelper.Tests.Async
@@ -76,11 +80,68 @@ namespace CsvHelper.Tests.Async
 			}
 		}
 
+#if NET472 || NETCOREAPP2_1 || NETCOREAPP3_1
+		[TestMethod]
+		public async Task WriteRecordsAsyncEnumerableTest()
+		{
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
+			{
+				csv.Configuration.Delimiter = ",";
+                     
+				await csv.WriteRecordsAsync(GetRecords());
+
+				writer.Flush();
+				stream.Position = 0;
+
+				var expected = new StringBuilder();
+				expected.AppendLine("Id,Name");
+				expected.AppendLine("1,one");
+				expected.AppendLine("2,two");
+
+				Assert.AreEqual(expected.ToString(), reader.ReadToEnd());
+			}
+		}
+
+		[TestMethod]
+		public async Task WriteRecordsAsyncEnumerableCancelledTest()
+		{
+			using (var stream = new MemoryStream())
+			using (var writer = new StreamWriter(stream))
+			using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
+			{
+				csv.Configuration.Delimiter = ",";
+
+				var cts = new CancellationTokenSource();
+				cts.Cancel();
+
+				var exception = await Assert.ThrowsExceptionAsync<WriterException>(() => csv.WriteRecordsAsync(GetRecords(), cts.Token));
+
+				Assert.IsTrue(exception.InnerException is OperationCanceledException);
+			}
+		}
+#endif  // NET472 || NETCOREAPP2_1 || NETCOREAPP3_1
+
 		private class Simple
 		{
 			public int Id { get; set; }
 
 			public string Name { get; set; }
 		}
+
+#if NET472 || NETCOREAPP2_1 || NETCOREAPP3_1
+		private async IAsyncEnumerable<Simple> GetRecords([EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+
+			yield return new Simple { Id = 1, Name = "one" };
+
+			await Task.CompletedTask;
+
+			yield return new Simple { Id = 2, Name = "two" };
+		}
+#endif
 	}
 }

--- a/tests/CsvHelper.Tests/CsvHelper.Tests.csproj
+++ b/tests/CsvHelper.Tests/CsvHelper.Tests.csproj
@@ -4,6 +4,7 @@
 		<TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net472;net452</TargetFrameworks>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>CsvHelper.snk</AssemblyOriginatorKeyFile>
+		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Added method `WriteRecordsAsync<T>(IAsyncEnumerable<T> records, CancellationToken cancellationToken = default)` to CsvWriter class. Unlike existing `WriteRecordsAsync<T>(IEnumerable<T> records)`, this new method uses "await foreach" for non-blocking enumeration.
Covered with tests.

Also, some refactoring is made in CsvWriter (common functionality moved to private methods). If it's undesirable, I can revert this refactoring.

closes #1515 