### PR TITLE
Fix parsing issue with blank CR-lines

### DIFF
--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -294,7 +294,8 @@ namespace CsvHelper
 			{
 				if (c == '\r' || c == '\n')
 				{
-					ReadLineEnding();
+					var offset = ReadLineEnding();
+					fieldReader.SetBufferPosition(offset);
 					fieldReader.SetFieldStart();
 					return;
 				}
@@ -329,7 +330,8 @@ namespace CsvHelper
 			{
 				if (c == '\r' || c == '\n')
 				{
-					await ReadLineEndingAsync().ConfigureAwait(false);
+					var offset = await ReadLineEndingAsync().ConfigureAwait(false);
+					fieldReader.SetBufferPosition(offset);
 					fieldReader.SetFieldStart();
 					return;
 				}

--- a/src/CsvHelper/CsvParser.tt
+++ b/src/CsvHelper/CsvParser.tt
@@ -227,7 +227,8 @@ namespace CsvHelper
 			{
 				if (c == '\r' || c == '\n')
 				{
-					<#= Await(isAsync) #>ReadLineEnding<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>;
+					var offset = <#= Await(isAsync) #>ReadLineEnding<#= AsyncPostfix(isAsync) #>()<#= ConfigureAwait(isAsync) #>;
+					fieldReader.SetBufferPosition(offset);
 					fieldReader.SetFieldStart();
 					return;
 				}

--- a/tests/CsvHelper.Tests/Parsing/CrTests.cs
+++ b/tests/CsvHelper.Tests/Parsing/CrTests.cs
@@ -26,6 +26,19 @@ namespace CsvHelper.Tests.Parsing
 		}
 
 		[TestMethod]
+		public void SingleFieldAndSingleRowAndRowStartsWithCRTest()
+		{
+			var s = new StringBuilder();
+			s.Append("\r1\r");
+			using (var reader = new StringReader(s.ToString()))
+			using (var parser = new CsvParser(reader, CultureInfo.InvariantCulture))
+			{
+				var row = parser.Read();
+				Assert.AreEqual("1", row[0]);
+			}
+		}
+
+		[TestMethod]
 		public void SingleFieldAndSingleRowAndFieldIsQuotedTest()
 		{
 			var s = new StringBuilder();
@@ -168,6 +181,62 @@ namespace CsvHelper.Tests.Parsing
 			using (var parser = new CsvParser(reader, CultureInfo.InvariantCulture))
 			{
 				parser.Configuration.Delimiter = ",";
+				var row = parser.Read();
+				Assert.AreEqual("1", row[0]);
+				Assert.AreEqual("2", row[1]);
+
+				row = parser.Read();
+				Assert.AreEqual("3", row[0]);
+				Assert.AreEqual("4", row[1]);
+			}
+		}
+		
+		[TestMethod]
+		public void MultipleFieldsAndSingleRowAndRowStartsWithCRTest()
+		{
+			var s = new StringBuilder();
+			s.Append("\r1,2\r");
+			using (var reader = new StringReader(s.ToString()))
+			using (var parser = new CsvParser(reader, CultureInfo.InvariantCulture))
+			{
+				parser.Configuration.Delimiter = ",";
+
+				var row = parser.Read();
+				Assert.AreEqual("1", row[0]);
+				Assert.AreEqual("2", row[1]);
+			}
+		}
+
+		[TestMethod]
+		public void MultipleBlankLinesWithOnlyCRTest()
+		{
+			var s = new StringBuilder();
+			s.Append("\r\r");
+			using (var reader = new StringReader(s.ToString()))
+			using (var parser = new CsvParser(reader, CultureInfo.InvariantCulture))
+			{
+				parser.Configuration.IgnoreBlankLines = false;
+
+				var row = parser.Read();
+				Assert.AreEqual(0, row.Length);
+				row = parser.Read();
+				Assert.AreEqual(0, row.Length);
+				row = parser.Read();
+				Assert.IsNull(row);
+			}
+		}
+
+		[TestMethod]
+		public void MultipleFieldsAndMultipleRowsAndRowStartsWithCRTest()
+		{
+			var s = new StringBuilder();
+			s.Append("1,2\r");
+			s.Append("\r3,4\r");
+			using (var reader = new StringReader(s.ToString()))
+			using (var parser = new CsvParser(reader, CultureInfo.InvariantCulture))
+			{
+				parser.Configuration.Delimiter = ",";
+
 				var row = parser.Read();
 				Assert.AreEqual("1", row[0]);
 				Assert.AreEqual("2", row[1]);


### PR DESCRIPTION
When reading a blank CR-line, the buffer position has to be set back by one character. The method `ReadLineEnding` correctly returns `-1` but the value is just ignored. Instead, we want to set the buffer position one back by passing the return value of `ReadLineEnding` to `fieldReader.SetBufferPosition`. The already existing call to `fieldReader.SetFieldStart()` is still correct since we adjust the buffer position right before.  
I believe this fix doesn't have any side effects but I haven't been around the internals for very long so I hope that's correct.  
I have added four tests to validate the behaviour and they all pass along with all the others.

I'm used to very different coding conventions but I think I managed to follow your style. Also I hope the location of the tests is fine.

If you need me to change anything, just let me know :)  
I've also enabled "Allow edits by maintainers".

Fixes #1522