### PR TITLE
added benchmark project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ artifacts/
 
 *.user
 *.psess
+BenchmarkDotNet.Artifacts/

--- a/CsvHelper.sln
+++ b/CsvHelper.sln
@@ -16,6 +16,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsvHelper.Tests", "tests\Cs
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "build\_build.csproj", "{B0E9C5E1-8A40-4BF7-AF08-6A6E179446A5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsvHelper.Benchmarks", "performance\CsvHelper.Benchmarks\CsvHelper.Benchmarks.csproj", "{C380C182-BC37-4E95-AF03-E7F250B41BCA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsvHelper.Performance", "performance\CsvHelper.Performance\CsvHelper.Performance.csproj", "{DDB99F59-2E48-4133-858D-B42F812D4C78}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +84,46 @@ Global
 		{B0E9C5E1-8A40-4BF7-AF08-6A6E179446A5}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{B0E9C5E1-8A40-4BF7-AF08-6A6E179446A5}.Release|x64.ActiveCfg = Release|Any CPU
 		{B0E9C5E1-8A40-4BF7-AF08-6A6E179446A5}.Release|x86.ActiveCfg = Release|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Debug|ARM.Build.0 = Debug|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Debug|x64.Build.0 = Debug|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Debug|x86.Build.0 = Debug|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Release|ARM.ActiveCfg = Release|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Release|ARM.Build.0 = Release|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Release|x64.ActiveCfg = Release|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Release|x64.Build.0 = Release|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Release|x86.ActiveCfg = Release|Any CPU
+		{C380C182-BC37-4E95-AF03-E7F250B41BCA}.Release|x86.Build.0 = Release|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Debug|ARM.Build.0 = Debug|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Debug|x64.Build.0 = Debug|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Debug|x86.Build.0 = Debug|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Release|ARM.ActiveCfg = Release|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Release|ARM.Build.0 = Release|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Release|x64.ActiveCfg = Release|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Release|x64.Build.0 = Release|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Release|x86.ActiveCfg = Release|Any CPU
+		{DDB99F59-2E48-4133-858D-B42F812D4C78}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/performance/CsvHelper.Benchmarks/CsvHelper.Benchmarks.csproj
+++ b/performance/CsvHelper.Benchmarks/CsvHelper.Benchmarks.csproj
@@ -2,8 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\CsvHelper\CsvHelper.csproj" />

--- a/performance/CsvHelper.Benchmarks/CsvWriterBenches.cs
+++ b/performance/CsvHelper.Benchmarks/CsvWriterBenches.cs
@@ -1,0 +1,47 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace CsvHelper.Benchmarks
+{
+
+	[MemoryDiagnoser]
+	public class CsvWriterBenches
+	{
+
+		public class Foo
+		{
+			public int Id { get; set; }
+			public string Name { get; set; }
+		}
+
+		List<Foo> records;
+
+		[GlobalSetup]
+		public void GlobalSetup()
+		{
+			records = new List<Foo>();
+			for (int i = 0; i < 1000; i++)
+			{
+				records.Add(new Foo { Id = i, Name = $"I am {i}" });
+			}
+		}
+
+		[Benchmark]
+		public void WriteCsv()
+		{
+			using (var memoryStream = new MemoryStream())
+			using (var textWriter = new StreamWriter(memoryStream))
+			using (var csv = new CsvWriter(textWriter, CultureInfo.InvariantCulture))
+			{
+				csv.WriteRecords(records);
+			}
+
+		}
+
+
+	}
+}

--- a/performance/CsvHelper.Benchmarks/Program.cs
+++ b/performance/CsvHelper.Benchmarks/Program.cs
@@ -1,0 +1,11 @@
+﻿using BenchmarkDotNet.Running;
+namespace CsvHelper.Benchmarks
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+			var summary = BenchmarkRunner.Run<CsvWriterBenches>();
+		}
+    }
+}

--- a/performance/CsvHelper.Performance/Program.cs
+++ b/performance/CsvHelper.Performance/Program.cs
@@ -6,6 +6,7 @@ using CsvHelper.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -41,7 +42,7 @@ namespace CsvHelper.Performance
 
 			using (var stream = File.Create(GetFilePath()))
 			using (var writer = new StreamWriter(stream))
-			using (var csv = new CsvWriter(writer))
+			using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
 			{
 				for (var column = 1; column <= columns; column++)
 				{
@@ -71,7 +72,7 @@ namespace CsvHelper.Performance
 
 			using (var stream = File.Create(GetFilePath()))
 			using (var writer = new StreamWriter(stream))
-			using (var csv = new CsvWriter(writer))
+			using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
 			{
 				var records = new List<Columns50>();
 				for (var i = 0; i < rows; i++)
@@ -147,7 +148,7 @@ namespace CsvHelper.Performance
 
 			using (var stream = File.OpenRead(GetFilePath()))
 			using (var reader = new StreamReader(stream))
-			using (var parser = new CsvParser(reader))
+			using (var parser = new CsvParser(reader, CultureInfo.InvariantCulture))
 			{
 				string[] row;
 				while ((row = parser.Read()) != null)
@@ -167,7 +168,7 @@ namespace CsvHelper.Performance
 
 			using (var stream = File.OpenRead(GetFilePath()))
 			using (var reader = new StreamReader(stream))
-			using (var csv = new CsvReader(reader))
+			using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
 			{
 				// Read header.
 				csv.Read();
@@ -193,7 +194,7 @@ namespace CsvHelper.Performance
 
 			using (var stream = File.OpenRead(GetFilePath()))
 			using (var reader = new StreamReader(stream))
-			using (var csv = new CsvReader(reader))
+			using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
 			{
 				var records = csv.GetRecords<Columns50>();
 				foreach (var record in records)
@@ -213,7 +214,7 @@ namespace CsvHelper.Performance
 
 			using (var stream = File.OpenRead(GetFilePath()))
 			using (var reader = new StreamReader(stream))
-			using (var csv = new CsvReader(reader))
+			using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
 			{
 				while (await csv.ReadAsync())
 				{


### PR DESCRIPTION
Hi I was looking at #1048 

I've got a couple of ideas, but I thought the first step should be to start measuring where we are.
So I've added performance back in and added a benchmarking project.


One quick thing I've noticed is that there is one ObjectRecordWriter allocated per writing row.
While there is caching in GetWriteDelegate in RecordWriter, perhaps that would be better to be cached in RecordWriterFactory for example?








