### PR TITLE
Make TypeConverterOptionCache thread safe

### DIFF
--- a/src/CsvHelper/TypeConversion/TypeConverterOptionsCache.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterOptionsCache.cs
@@ -3,7 +3,7 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace CsvHelper.TypeConversion
 {
@@ -12,7 +12,7 @@ namespace CsvHelper.TypeConversion
 	/// </summary>
 	public class TypeConverterOptionsCache
 	{
-		private Dictionary<Type, TypeConverterOptions> typeConverterOptions = new Dictionary<Type, TypeConverterOptions>();
+		private ConcurrentDictionary<Type, TypeConverterOptions> typeConverterOptions = new ConcurrentDictionary<Type, TypeConverterOptions>();
 
 		/// <summary>
 		/// Adds the <see cref="TypeConverterOptions"/> for the given <see cref="Type"/>.
@@ -50,7 +50,7 @@ namespace CsvHelper.TypeConversion
 				throw new ArgumentNullException(nameof(type));
 			}
 
-			typeConverterOptions.Remove(type);
+			typeConverterOptions.TryRemove(type, out TypeConverterOptions _);
 		}
 
 		/// <summary>
@@ -74,13 +74,7 @@ namespace CsvHelper.TypeConversion
 				throw new ArgumentNullException();
 			}
 
-			if (!typeConverterOptions.TryGetValue(type, out var options))
-			{
-				options = new TypeConverterOptions();
-				typeConverterOptions.Add(type, options);
-			}
-
-			return options;
+			return typeConverterOptions.GetOrAdd(type, _ => new TypeConverterOptions());
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fix #1320

Currently when using the same CsvConfiguration across multiple threads it is
possible to reach issues in the ThreadConverterOptionsCache#GetOptions method.
This throws an exception and fails the CSV operation. The existing workaround of
using ThreadLocal CsvConfiguration or not sharing CsvConfiguration does not seem
acceptable.

This PR does not add any new test because of how hard it is to test concurrency issues.