### PR TITLE
Add null check for WriteRecords

### DIFF
--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -479,6 +479,11 @@ namespace CsvHelper
 				var getRecordType = recordType == typeof(object);
 				foreach (var record in records)
 				{
+					if (record == null)
+					{
+						continue;
+					}
+
 					if (getRecordType)
 					{
 						recordType = record.GetType();


### PR DESCRIPTION
Using Entity Framework Core, I am getting a List<object> which I am passing to WriteRecords. One record is null and WriteRecords throws an object reference  exception. I added a check for null and everything works correctly now.