### PR TITLE
Added support for type converter factories to allow easier support for generic types

### DIFF
--- a/src/CsvHelper/TypeConversion/ITypeConverterFactory.cs
+++ b/src/CsvHelper/TypeConversion/ITypeConverterFactory.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CsvHelper.TypeConversion
+{
+	/// <summary>
+	/// Produces <see cref="ITypeConverter"/> for the specified <see cref="System.Type"/>
+	/// </summary>
+	public interface ITypeConverterFactory
+	{
+		/// <summary>
+		/// Checks whether the type is handled by this <see cref="ITypeConverterFactory"/>.
+		/// </summary>
+		/// <param name="type"><see cref="System.Type"/> to be checked</param>
+		/// <returns>Whether the type is handled by this <see cref="ITypeConverterFactory"/></returns>
+		bool Handles(Type type);
+
+		/// <summary>
+		/// Produces <see cref="ITypeConverter"/> for the specified <see cref="System.Type"/>.
+		/// </summary>
+		/// <param name="type"><see cref="System.Type"/> we want <see cref="ITypeConverter"/> for</param>
+		/// <param name="typeConverterCache"><see cref="TypeConverterCache"/> that is used for retrieving already exising type converters that are used to build the new one</param>
+		/// <returns>Created <see cref="ITypeConverter"/> for the specified <see cref="System.Type"/></returns>
+		ITypeConverter CreateTypeConverter(Type type, TypeConverterCache typeConverterCache);
+	}
+}

--- a/src/CsvHelper/TypeConversion/NullableConverterFactory.cs
+++ b/src/CsvHelper/TypeConversion/NullableConverterFactory.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CsvHelper.TypeConversion
+{
+	internal class NullableConverterFactory : ITypeConverterFactory
+	{
+		public ITypeConverter CreateTypeConverter(Type type, TypeConverterCache typeConverterCache)
+		{
+			return new NullableConverter(type, typeConverterCache);
+		}
+
+		public bool Handles(Type type)
+		{
+			return (type.IsGenericType && type.GetGenericTypeDefinition().Equals(typeof(Nullable<>)));
+		}
+	}
+}

--- a/src/CsvHelper/TypeConversion/NullableConverterFactory.cs
+++ b/src/CsvHelper/TypeConversion/NullableConverterFactory.cs
@@ -4,13 +4,27 @@ using System.Linq;
 
 namespace CsvHelper.TypeConversion
 {
-	internal class NullableConverterFactory : ITypeConverterFactory
+	/// <summary>
+	/// Converter factory for nullable types
+	/// </summary>
+	public class NullableConverterFactory : ITypeConverterFactory
 	{
+		/// <summary>
+		/// Produces <see cref="ITypeConverter"/> for the specified <see cref="System.Type"/>.
+		/// </summary>
+		/// <param name="type"><see cref="System.Type"/> we want <see cref="ITypeConverter"/> for</param>
+		/// <param name="typeConverterCache"><see cref="TypeConverterCache"/> that is used for retrieving already exising type converters that are used to build the new one</param>
+		/// <returns>Created <see cref="ITypeConverter"/> for the specified <see cref="System.Type"/></returns>
 		public ITypeConverter CreateTypeConverter(Type type, TypeConverterCache typeConverterCache)
 		{
 			return new NullableConverter(type, typeConverterCache);
 		}
 
+		/// <summary>
+		/// Checks whether the type is handled by <see cref="NullableConverterFactory"/>.
+		/// </summary>
+		/// <param name="type"><see cref="System.Type"/> to be checked</param>
+		/// <returns>Whether the type is handled by <see cref="NullableConverterFactory"/></returns>
 		public bool Handles(Type type)
 		{
 			return (type.IsGenericType && type.GetGenericTypeDefinition().Equals(typeof(Nullable<>)));

--- a/src/CsvHelper/TypeConversion/TypeConverterCache.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterCache.cs
@@ -18,6 +18,7 @@ namespace CsvHelper.TypeConversion
 	public class TypeConverterCache
 	{
 		private readonly Dictionary<Type, ITypeConverter> typeConverters = new Dictionary<Type, ITypeConverter>();
+		private readonly List<ITypeConverterFactory> generalTypeConverters = new List<ITypeConverterFactory>();
 
 		/// <summary>
 		/// Initializes the <see cref="TypeConverterCache" /> class.
@@ -25,6 +26,15 @@ namespace CsvHelper.TypeConversion
 		public TypeConverterCache()
 		{
 			CreateDefaultConverters();
+		}
+
+		/// <summary>
+		/// Adds the <see cref="ITypeConverterFactory"/>. Factories are queried in order of being added and first factory that handles the type is used for creating the <see cref="ITypeConverter"/>.
+		/// </summary>
+		/// <param name="typeConverterFactory">Type converter factory</param>
+		public void AddTypeConverter(ITypeConverterFactory typeConverterFactory)
+		{
+			generalTypeConverters.Add(typeConverterFactory);
 		}
 
 		/// <summary>
@@ -85,6 +95,19 @@ namespace CsvHelper.TypeConversion
 			RemoveConverter(typeof(T));
 		}
 
+		private ITypeConverter CheckFactoriesForTypeConverter(Type type)
+		{
+			foreach (ITypeConverterFactory typeConv in generalTypeConverters)
+			{
+				if (typeConv.Handles(type))
+				{
+					return typeConv.CreateTypeConverter(type, this);
+				}
+			}
+
+			return null;
+		}
+
 		/// <summary>
 		/// Gets the converter for the given <see cref="System.Type"/>.
 		/// </summary>
@@ -100,6 +123,18 @@ namespace CsvHelper.TypeConversion
 			if (typeConverters.TryGetValue(type, out ITypeConverter typeConverter))
 			{
 				return typeConverter;
+			}
+
+			if (generalTypeConverters.Count > 0)
+			{
+				ITypeConverter factoryCreatedTypeConverter = CheckFactoriesForTypeConverter(type);
+
+				if (factoryCreatedTypeConverter != null)
+				{
+					AddConverter(type, factoryCreatedTypeConverter);
+
+					return factoryCreatedTypeConverter;
+				}
 			}
 
 			if (typeof(Enum).IsAssignableFrom(type))

--- a/src/CsvHelper/TypeConversion/TypeConverterCache.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterCache.cs
@@ -32,7 +32,7 @@ namespace CsvHelper.TypeConversion
 		/// Adds the <see cref="ITypeConverterFactory"/>. Factories are queried in order of being added and first factory that handles the type is used for creating the <see cref="ITypeConverter"/>.
 		/// </summary>
 		/// <param name="typeConverterFactory">Type converter factory</param>
-		public void AddTypeConverter(ITypeConverterFactory typeConverterFactory)
+		public void AddTypeConverterFactory(ITypeConverterFactory typeConverterFactory)
 		{
 			generalTypeConverters.Add(typeConverterFactory);
 		}


### PR DESCRIPTION
Feature : 
             - by registering ITypeConverterFactory instance on TypeConverterCache using AddTypeConverterFactory you can add in one go handling of a whole group of types
             - using this would allow to make handling of Nullable<> and other generic types in TypeConverterCache.GetConverter more principled
             - I use it for mass handling of types that are wrapped in my Maybe<T> type and my IValueType<T>
             - provided as example is NullableConverterFactory
             - factories are evaluated in order they were registered in, so if two factories handle the same type, only the the one registered first will be used

Negatives : 
             - even when not using the feature TypeConverterCache allocates additionally one empty List - this could be solved by initializing the list only when necessary, if that would turn out to be an issue (memory would still increase by the one pointer)
            - even when not using the feature TypeConverterCache.GetConverter needs to perform one check on the List.Count - this can be changed only to null-check or bool-check, but cannot be eliminated.