### PR TITLE
Reduce double dictionary lookup in CsvReader.ParseNamedIndexes()

### DIFF
--- a/src/CsvHelper/Configuration/ClassMapCollection.cs
+++ b/src/CsvHelper/Configuration/ClassMapCollection.cs
@@ -35,9 +35,9 @@ namespace CsvHelper.Configuration
 				var currentType = type;
 				while (true)
 				{
-					if (data.ContainsKey(currentType))
+					if (data.TryGetValue(currentType, out var map))
 					{
-						return data[currentType];
+						return map;
 					}
 
 					currentType = currentType.GetTypeInfo().BaseType;
@@ -80,14 +80,7 @@ namespace CsvHelper.Configuration
 
 			var type = GetGenericCsvClassMapType(map.GetType()).GetGenericArguments().First();
 
-			if (data.ContainsKey(type))
-			{
-				data[type] = map;
-			}
-			else
-			{
-				data.Add(type, map);
-			}
+			data[type] = map;
 		}
 
 		/// <summary>

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -1235,9 +1235,9 @@ namespace CsvHelper
 
 			// Caching the named index speeds up mappings that use ConvertUsing tremendously.
 			var nameKey = string.Join("_", names) + index;
-			if (namedIndexCache.ContainsKey(nameKey))
+			if (namedIndexCache.TryGetValue(nameKey, out var cache))
 			{
-				(var cachedName, var cachedIndex) = namedIndexCache[nameKey];
+				(var cachedName, var cachedIndex) = cache;
 				return namedIndexes[cachedName][cachedIndex];
 			}
 
@@ -1367,9 +1367,9 @@ namespace CsvHelper
 			{
 				var args = new PrepareHeaderForMatchArgs(headerRecord[i], i);
 				var name = prepareHeaderForMatch(args);
-				if (namedIndexes.ContainsKey(name))
+				if (namedIndexes.TryGetValue(name, out var index))
 				{
-					namedIndexes[name].Add(i);
+					index.Add(i);
 				}
 				else
 				{

--- a/src/CsvHelper/TypeConversion/EnumConverter.cs
+++ b/src/CsvHelper/TypeConversion/EnumConverter.cs
@@ -80,9 +80,9 @@ namespace CsvHelper.TypeConversion
 				var dict = ignoreCase
 					? enumNamesByAttributeNamesIgnoreCase
 					: enumNamesByAttributeNames;
-				if (dict.ContainsKey(text))
+				if (dict.TryGetValue(text, out var name))
 				{
-					return Enum.Parse(type, dict[text]);
+					return Enum.Parse(type, name);
 				}
 			}
 
@@ -110,9 +110,9 @@ namespace CsvHelper.TypeConversion
 		/// <inheritdoc/>
 		public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
 		{
-			if (value != null && attributeNamesByEnumValues.ContainsKey(value))
+			if (value != null && attributeNamesByEnumValues.TryGetValue(value, out var name))
 			{
-				return attributeNamesByEnumValues[value];
+				return name;
 			}
 
 			return base.ConvertToString(value, row, memberMapData);


### PR DESCRIPTION
Each dictionary lookup requires hash calculation and iteration over bucket and match of item. Puropse of existence `TryGetValue` in Dictionary class is to reduce double lookup to improve performance.