### PR TITLE
Reduce array allocations

### DIFF
--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -185,7 +185,7 @@ namespace CsvHelper
 				}
 				else
 				{
-					var index = GetFieldIndex(parameter.Data.Names.ToArray(), parameter.Data.NameIndex, true);
+					var index = GetFieldIndex(parameter.Data.Names, parameter.Data.NameIndex, true);
 					var isValid = index != -1 || parameter.Data.IsOptional;
 					if (!isValid)
 					{
@@ -1218,6 +1218,11 @@ namespace CsvHelper
 		/// <inheritdoc/>
 		public virtual int GetFieldIndex(string[] names, int index = 0, bool isTryGet = false, bool isOptional = false)
 		{
+			return GetFieldIndex((IEnumerable<string>)names, index, isTryGet, isOptional);
+		}
+
+		internal int GetFieldIndex(IEnumerable<string> names, int index = 0, bool isTryGet = false, bool isOptional = false)
+		{
 			if (names == null)
 			{
 				throw new ArgumentNullException(nameof(names));
@@ -1243,9 +1248,9 @@ namespace CsvHelper
 
 			// Check all possible names for this field.
 			string name = null;
-			for (var i = 0; i < names.Length; i++)
+			int i = 0;
+			foreach (var n in names)
 			{
-				var n = names[i];
 				// Get the list of indexes for this name.
 				var args = new PrepareHeaderForMatchArgs(n, i);
 				var fieldName = prepareHeaderForMatch(args);
@@ -1254,6 +1259,7 @@ namespace CsvHelper
 					name = fieldName;
 					break;
 				}
+				i++;
 			}
 
 			// Check if the index position exists.
@@ -1262,7 +1268,7 @@ namespace CsvHelper
 				// It doesn't exist. The field is missing.
 				if (!isTryGet && !isOptional)
 				{
-					var args = new MissingFieldFoundArgs(names, index, context);
+					var args = new MissingFieldFoundArgs(names as string[] ?? names.ToArray(), index, context);
 					missingFieldFound?.Invoke(args);
 				}
 

--- a/src/CsvHelper/Expressions/ExpressionManager.cs
+++ b/src/CsvHelper/Expressions/ExpressionManager.cs
@@ -104,7 +104,7 @@ namespace CsvHelper.Expressions
 					if (parameterMap.Data.IsNameSet || reader.Configuration.HasHeaderRecord && !parameterMap.Data.IsIndexSet)
 					{
 						// Use name.
-						index = reader.GetFieldIndex(parameterMap.Data.Names.ToArray(), parameterMap.Data.NameIndex, parameterMap.Data.IsOptional);
+						index = reader.GetFieldIndex(parameterMap.Data.Names, parameterMap.Data.NameIndex, parameterMap.Data.IsOptional);
 						if (index == -1)
 						{
 							if (parameterMap.Data.IsDefaultSet || parameterMap.Data.IsOptional)
@@ -228,7 +228,7 @@ namespace CsvHelper.Expressions
 			if (memberMap.Data.IsNameSet || reader.Configuration.HasHeaderRecord && !memberMap.Data.IsIndexSet)
 			{
 				// Use the name.
-				index = reader.GetFieldIndex(memberMap.Data.Names.ToArray(), memberMap.Data.NameIndex, memberMap.Data.IsOptional);
+				index = reader.GetFieldIndex(memberMap.Data.Names, memberMap.Data.NameIndex, memberMap.Data.IsOptional);
 				if (index == -1)
 				{
 					if (memberMap.Data.IsDefaultSet)


### PR DESCRIPTION
The same array is allocated twice. Re-used the first one.