### PR TITLE
Enumerable safety

### DIFF
--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -1063,8 +1063,9 @@ namespace CsvHelper
 		/// <returns>An <see cref="IEnumerable{T}" /> of records.</returns>
 		public virtual IEnumerable<T> GetRecords<T>()
 		{
-			// Don't need to check if it's been read
-			// since we're doing the reading ourselves.
+			if (context.HasBeenRead) throw new ReaderException(context, "Reading has already started (maybe GetRecords enumeration was called twice).");
+
+			// Check
 
 			if (context.ReaderConfiguration.HasHeaderRecord && context.HeaderRecord == null)
 			{
@@ -1140,8 +1141,7 @@ namespace CsvHelper
 		/// <returns>An <see cref="IEnumerable{Object}" /> of records.</returns>
 		public virtual IEnumerable<object> GetRecords(Type type)
 		{
-			// Don't need to check if it's been read
-			// since we're doing the reading ourselves.
+			if (context.HasBeenRead) throw new ReaderException(context, "Reading has already started (maybe GetRecords enumeration was called twice).");
 
 			if (context.ReaderConfiguration.HasHeaderRecord && context.HeaderRecord == null)
 			{
@@ -1197,8 +1197,7 @@ namespace CsvHelper
 		/// <returns>An <see cref="IEnumerable{T}"/> of records.</returns>
 		public virtual IEnumerable<T> EnumerateRecords<T>(T record)
 		{
-			// Don't need to check if it's been read
-			// since we're doing the reading ourselves.
+			if (context.HasBeenRead) throw new ReaderException(context, "Reading has already started (maybe GetRecords enumeration was called twice).");
 
 			if (context.ReaderConfiguration.HasHeaderRecord && context.HeaderRecord == null)
 			{
@@ -1251,8 +1250,7 @@ namespace CsvHelper
 		/// <returns>An <see cref="IAsyncEnumerable{T}" /> of records.</returns>
 		public virtual async IAsyncEnumerable<T> GetRecordsAsync<T>()
 		{
-			// Don't need to check if it's been read
-			// since we're doing the reading ourselves.
+			if (context.HasBeenRead) throw new ReaderException(context, "Reading has already started (maybe GetRecords enumeration was called twice).");
 
 			if (context.ReaderConfiguration.HasHeaderRecord && context.HeaderRecord == null)
 			{
@@ -1328,8 +1326,7 @@ namespace CsvHelper
 		/// <returns>An <see cref="IAsyncEnumerable{Object}" /> of records.</returns>
 		public virtual async IAsyncEnumerable<object> GetRecordsAsync(Type type)
 		{
-			// Don't need to check if it's been read
-			// since we're doing the reading ourselves.
+			if (context.HasBeenRead) throw new ReaderException(context, "Reading has already started (maybe GetRecords enumeration was called twice).");
 
 			if (context.ReaderConfiguration.HasHeaderRecord && context.HeaderRecord == null)
 			{
@@ -1385,8 +1382,7 @@ namespace CsvHelper
 		/// <returns>An <see cref="IAsyncEnumerable{T}"/> of records.</returns>
 		public virtual async IAsyncEnumerable<T> EnumerateRecordsAsync<T>(T record)
 		{
-			// Don't need to check if it's been read
-			// since we're doing the reading ourselves.
+			if (context.HasBeenRead) throw new ReaderException(context, "Reading has already started (maybe GetRecords enumeration was called twice).");
 
 			if (context.ReaderConfiguration.HasHeaderRecord && context.HeaderRecord == null)
 			{

--- a/tests/CsvHelper.Tests/CsvReaderTests.cs
+++ b/tests/CsvHelper.Tests/CsvReaderTests.cs
@@ -708,7 +708,7 @@ namespace CsvHelper.Tests
 				csvReader.Configuration.RegisterClassMap<TestRecordMap>();
 				var records = csvReader.GetRecords<TestRecord>();
 				Assert.AreEqual(2, records.Count());
-				Assert.AreEqual(0, records.Count());
+				Assert.ThrowsException<ReaderException>(() => records.Count());
 			}
 		}
 

--- a/tests/CsvHelper.Tests/Reading/MultipleGetRecordsTests.cs
+++ b/tests/CsvHelper.Tests/Reading/MultipleGetRecordsTests.cs
@@ -2,6 +2,8 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
+using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -9,6 +11,22 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CsvHelper.Tests.Reading
 {
+	internal static class Enumerable
+	{
+		internal static IEnumerable<T> Generate<T>(Func<T> generator)
+		{
+			while (true)
+				yield return generator();
+		}
+
+		internal static IEnumerable<T> GenerateWhile<T>(Func<bool> checker, Func<T> generator)
+		{
+			while (checker())
+				yield return generator();
+		}
+
+	}
+
 	[TestClass]
 	public class MultipleGetRecordsTests
 	{
@@ -26,14 +44,14 @@ namespace CsvHelper.Tests.Reading
 				writer.Flush();
 				stream.Position = 0;
 
-				var records = csv.GetRecords<Test>().ToList();
+				var records = Enumerable.GenerateWhile(csv.Read, csv.GetRecord<Test>).ToList();
 
 				var position = stream.Position;
 				writer.WriteLine("2,two");
 				writer.Flush();
 				stream.Position = position;
 
-				records = csv.GetRecords<Test>().ToList();
+				records = Enumerable.GenerateWhile(csv.Read, csv.GetRecord<Test>).ToList();
 
 				Assert.AreEqual(1, records.Count);
 				Assert.AreEqual(2, records[0].Id);

--- a/tests/CsvHelper.Tests/Reading/MultipleGetRecordsTests.cs
+++ b/tests/CsvHelper.Tests/Reading/MultipleGetRecordsTests.cs
@@ -35,10 +35,6 @@ namespace CsvHelper.Tests.Reading
 
 				records = csv.GetRecords<Test>().ToList();
 
-				writer.WriteLine("2,two");
-				writer.Flush();
-				stream.Position = position;
-
 				Assert.AreEqual(1, records.Count);
 				Assert.AreEqual(2, records[0].Id);
 				Assert.AreEqual("two", records[0].Name);


### PR DESCRIPTION
To avoid errors like https://github.com/JoshClose/CsvHelper/issues/1582 it should not be allowed to call GetRecords more than once. This patch will use HasBeenRead from context for this.

I had to change one test (`Blah`) that made explicit use multiple calls by adding records on the fly to the input stream. I think advanced use cases like this should really do their own enumeration as in most use cases multiple calls to the enumerator will result in wrong results (maybe unnoticed, compare #1582).