### PR TITLE
Getfield should throw errors on missing fields (as long as not suppressed)

### DIFF
--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -329,11 +329,7 @@ namespace CsvHelper
 
 			if (index >= context.Record.Length || index < 0)
 			{
-				if (context.ReaderConfiguration.IgnoreBlankLines)
-				{
-					context.ReaderConfiguration.MissingFieldFound?.Invoke(null, index, context);
-				}
-
+				context.ReaderConfiguration.MissingFieldFound?.Invoke(null, index, context);
 				return default;
 			}
 
@@ -546,10 +542,7 @@ namespace CsvHelper
 			if (index >= context.Record.Length || index < 0)
 			{
 				context.CurrentIndex = index;
-				if (context.ReaderConfiguration.IgnoreBlankLines)
-				{
-					context.ReaderConfiguration.MissingFieldFound?.Invoke(null, index, context);
-				}
+				context.ReaderConfiguration.MissingFieldFound?.Invoke(null, index, context);
 
 				return default;
 			}

--- a/tests/CsvHelper.Tests/CsvReaderTests.cs
+++ b/tests/CsvHelper.Tests/CsvReaderTests.cs
@@ -239,10 +239,10 @@ namespace CsvHelper.Tests
 			var data = new Queue<string[]>();
 			data.Enqueue(new[] { "One", "Two" });
 			data.Enqueue(new[] { "1", "2" });
-			data.Enqueue(null);
 			var parserMock = new ParserMock(data);
 
 			var reader = new CsvReader(parserMock);
+			reader.Configuration.IgnoreBlankLines = false;
 			reader.Read();
 
 			try

--- a/tests/CsvHelper.Tests/CsvReaderTests.cs
+++ b/tests/CsvHelper.Tests/CsvReaderTests.cs
@@ -863,6 +863,7 @@ namespace CsvHelper.Tests
 			{
 				csv.Configuration.Delimiter = ",";
 				csv.Configuration.IgnoreBlankLines = false;
+				csv.Configuration.MissingFieldFound = null;
 				csv.Configuration.RegisterClassMap<SimpleMap>();
 
 				writer.WriteLine("Id,Name");

--- a/tests/CsvHelper.Tests/Exceptions/ExceptionMessageTests.cs
+++ b/tests/CsvHelper.Tests/Exceptions/ExceptionMessageTests.cs
@@ -23,6 +23,7 @@ namespace CsvHelper.Tests.Exceptions
 			};
 
 			var reader = new CsvReader( parser );
+			reader.Configuration.IgnoreBlankLines = false;
 			reader.Read();
 			reader.Read();
 			try

--- a/tests/CsvHelper.Tests/Reading/NullableValuesInEmptyColumnsInputTests.cs
+++ b/tests/CsvHelper.Tests/Reading/NullableValuesInEmptyColumnsInputTests.cs
@@ -23,6 +23,7 @@ namespace CsvHelper.Tests.Reading
 			using (var csv = new CsvReader(parser))
 			{
 				csv.Configuration.IgnoreBlankLines = false;
+				csv.Configuration.MissingFieldFound = null;
 				csv.Configuration.TypeConverterOptionsCache.GetOptions<int?>().NullValues.Add(string.Empty);
 
 				// Read header row, assert header row columns:
@@ -60,6 +61,7 @@ namespace CsvHelper.Tests.Reading
 			using (var csv = new CsvReader(parser))
 			{
 				csv.Configuration.IgnoreBlankLines = false;
+				csv.Configuration.MissingFieldFound = null;
 				csv.Configuration.TypeConverterOptionsCache.GetOptions<int?>().NullValues.Add(string.Empty);
 
 				// Read header row, assert header row columns:
@@ -122,6 +124,7 @@ namespace CsvHelper.Tests.Reading
 			using (var csv = new CsvReader(parser))
 			{
 				csv.Configuration.IgnoreBlankLines = false;
+				csv.Configuration.MissingFieldFound = null;
 				csv.Configuration.TypeConverterOptionsCache.GetOptions<string>().NullValues.Add(string.Empty); // Read empty fields as nulls instead of `""`.
 
 				// Read header row, assert header row columns:


### PR DESCRIPTION
Previously MissingFieldFound wasn't called in GetField when IgnoreBlankLines was set to false.
I think it's at least misleading / some configuration settings produce unexpected results.

The goal of this PR is to get clear behavior:

Always throw exception if GetField is called on non-existing field unless suppressed via MissingFieldFound.
IgnoreBlankLines should only skip those rows while reading.