### PR TITLE
fix: make TypeConverterOptionsCache thread safe

### DIFF
--- a/tests/CsvHelper.Tests/TypeConversion/TypeConverterOptionsTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/TypeConverterOptionsTests.cs
@@ -2,10 +2,13 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
+
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CsvHelper.Tests.TypeConversion
@@ -78,6 +81,17 @@ namespace CsvHelper.Tests.TypeConversion
 				Assert.IsNull(records[0].Id);
 				Assert.IsNull(records[0].Name);
 			}
+		}
+
+		[TestMethod]
+		public void MultiThreadGetOptionCall()
+		{
+			var optionsCache = new TypeConverterOptionsCache();
+
+			List<TypeConverterOptions> converterOptions = Enumerable.Repeat(typeof(int), 16)
+				.AsParallel()
+				.Select(type => optionsCache.GetOptions(type))
+				.ToList();
 		}
 
 		private class Test


### PR DESCRIPTION
Fix #1552
That issues s about multy thread access to cache, it was easy confirmed by the test I added. The best fix for this case is wrapping with lock.  We do not need to use ConcurrentDictionary because it's very rare situation when we need to procces more that one thread. ConcurrentDictionary is overhead and worse for perfomance, i even made a bench some years ago for single thread writing:

https://github.com/InRedikaWB/DictionaryBenchmark
![image](https://user-images.githubusercontent.com/22368203/95677129-0d576f80-0bcc-11eb-969f-8e562a89ab2f.png)
