### PR TITLE
Convert using null issue 1595 / 1454

### DIFF
--- a/src/CsvHelper/Expressions/ObjectRecordWriter.cs
+++ b/src/CsvHelper/Expressions/ObjectRecordWriter.cs
@@ -58,7 +58,7 @@ namespace CsvHelper.Expressions
 				{
 					// The user is providing the expression to do the conversion.
 					Expression exp = Expression.Invoke(memberMap.Data.WritingConvertExpression, recordParameterConverted);
-					exp = Expression.Call(Expression.Constant(Writer), nameof(Writer.WriteConvertedField), null, exp);
+					exp = Expression.Call(Expression.Constant(Writer), nameof(Writer.WriteField), null, exp);
 					delegates.Add(Expression.Lambda<Action<T>>(exp, recordParameter).Compile());
 					continue;
 				}

--- a/tests/CsvHelper.Tests/CsvWriterMappingTests.cs
+++ b/tests/CsvHelper.Tests/CsvWriterMappingTests.cs
@@ -154,6 +154,34 @@ namespace CsvHelper.Tests
 			Assert.AreEqual("Constant\r\n", result);
 		}
 
+
+		[TestMethod]
+		public void ConvertUsingNullTest()
+		{
+			string result;
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
+			{
+				var records = new List<MultipleNamesClass>
+				{
+					new MultipleNamesClass { IntColumn = 1, StringColumn = "test" }
+				};
+
+				csv.Configuration.HasHeaderRecord = false;
+				csv.Configuration.Delimiter = ";";
+				csv.Configuration.RegisterClassMap<ConvertUsingNullMap>();
+				csv.WriteRecords(records);
+				writer.Flush();
+				stream.Position = 0;
+
+				result = reader.ReadToEnd();
+			}
+
+			Assert.AreEqual(";test\r\n", result);
+		}
+
 		private class SameNameMultipleTimesClass
 		{
 			public string Name1 { get; set; }
@@ -220,6 +248,15 @@ namespace CsvHelper.Tests
 			public ConvertUsingConstantMap()
 			{
 				Map(m => m.IntColumn).ConvertUsing(m => "Constant");
+			}
+		}
+
+		private sealed class ConvertUsingNullMap : ClassMap<MultipleNamesClass>
+		{
+			public ConvertUsingNullMap()
+			{
+				Map(m => m.IntColumn).ConvertUsing(m => (string)null);
+				Map(m => m.StringColumn).ConvertUsing(m => m.StringColumn);
 			}
 		}
 	}


### PR DESCRIPTION
Should fix issues #1454 and #1595.

`ConvertUsing` now is allowed to return `null` which will result in empty field.