### PR TITLE
Fix PowerShell build script path in "build.cmd"

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,4 +3,4 @@
 :; exit $?
 
 @ECHO OFF
-powershell -ExecutionPolicy ByPass -NoProfile %0\..\build.ps1 %*
+powershell -ExecutionPolicy ByPass -NoProfile %~dp0build.ps1 %*


### PR DESCRIPTION
The `build.cmd` builds in an invalid path to `build.ps1`.

Suppose this repo has been locally cloned to `A:\CsvHelper`. Running `build.cmd` will run PowerShell with the following command line:

    powershell -ExecutionPolicy ByPass -NoProfile "A:\CsvHelper\build.cmd"\..\build.ps1

The are two problems:

1. `%0`expands to the file name of the running batch, not its path.
2. `build.ps1` is in the same directory as `build.cmd` and not in a parent (ie `..`)

This PR fixes both problems (and uses proper quoting) such that PowerShell gets executed as follows:

    powershell -ExecutionPolicy ByPass -NoProfile A:\CsvHelper\build.ps1
