### PR TITLE
Empty CSV file passed to CsvDataReader

### DIFF
--- a/src/CsvHelper/CsvDataReader.cs
+++ b/src/CsvHelper/CsvDataReader.cs
@@ -84,7 +84,7 @@ namespace CsvHelper
 		{
 			get
 			{
-				return csv.Context.Record.Length;
+				return csv.Context.Record?.Length ?? 0;
 			}
 		}
 

--- a/tests/CsvHelper.Tests/DataTableTests/CsvDataReaderTests.cs
+++ b/tests/CsvHelper.Tests/DataTableTests/CsvDataReaderTests.cs
@@ -2,15 +2,14 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
-using CsvHelper.Tests.Mocks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using CsvHelper.Tests.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CsvHelper.Tests.DataTableTests
 {
@@ -271,6 +270,20 @@ namespace CsvHelper.Tests.DataTableTests
 						dr.GetOrdinal("Foo");
 					});
 				}
+			}
+		}
+
+		[TestMethod]
+		public void DataTableLoadEmptyTest()
+		{
+			var s = "";
+			using (var reader = new StringReader(s.ToString()))
+			using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
+			{
+				csv.Configuration.HasHeaderRecord = false;
+
+				var dataReader = new CsvDataReader(csv);
+				Assert.AreEqual(0, dataReader.FieldCount);
 			}
 		}
 	}


### PR DESCRIPTION
- `CsvHelper.CsvDataReader.get_FieldCount()` is throwing `System.NullReferenceException` if you try to read from an empty file.
- Fixes #1508