### PR TITLE
Fix culture-sensitive tests

### DIFF
--- a/tests/CsvHelper.Tests/Culture/TypeConverterOptionsFactoryTests.cs
+++ b/tests/CsvHelper.Tests/Culture/TypeConverterOptionsFactoryTests.cs
@@ -205,7 +205,7 @@ namespace CsvHelper.Tests.Culture
 				Map(m => m.Number);
 				Map(m => m.NumberOverridenInMap)
 					.TypeConverterOption.NumberStyles(NumberStyles.AllowThousands | NumberStyles.AllowCurrencySymbol)
-					.TypeConverterOption.Format("N");
+					.TypeConverterOption.Format("N2");
 			}
 		}
 	}

--- a/tests/CsvHelper.Tests/LocalCultureTests.cs
+++ b/tests/CsvHelper.Tests/LocalCultureTests.cs
@@ -45,7 +45,7 @@ namespace CsvHelper.Tests
 				new TestRecordWithDecimal
 				{
 					DecimalColumn = 12.0m,
-					DateTimeColumn = new DateTime( 2010, 11, 11 )
+					DateTimeColumn = new DateTime( 2003, 1, 4, 15, 9, 26 )
 				}
 			};
 
@@ -57,7 +57,7 @@ namespace CsvHelper.Tests
 			var csvFile = writer.ToString();
 
 			const string expected = "DecimalColumn;DateTimeColumn\r\n" +
-									"12,0;11.11.2010 0:00:00\r\n";
+									"12,0;04.01.2003 15:09:26\r\n";
 
 			Assert.AreEqual(expected, csvFile);
 		}

--- a/tests/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/TypeConverterOptionsFactoryTests.cs
@@ -191,7 +191,7 @@ namespace CsvHelper.Tests.TypeConversion
 				Map(m => m.Number);
 				Map(m => m.NumberOverridenInMap)
 					.TypeConverterOption.NumberStyles(NumberStyles.AllowThousands | NumberStyles.AllowCurrencySymbol)
-					.TypeConverterOption.Format("N");
+					.TypeConverterOption.Format("N2");
 			}
 		}
 	}


### PR DESCRIPTION
Linux and macOS use the International Components for Unicode (ICU) libraries for globalization functionality. This is also true for [.NET 5 when running on Windows 10 May 2019 Update or later][1].

ICU and [National Language Support (NLS)][2] (which is used in .NET Core 1.0 - 3.1 and .NET Framework 4 and later on Windows) have slightly different behaviors.

This commit adresses these discrepancies by:

* Using explicit `N2` format instead of `N` to ensure two decimals formatting in `CsvHelper.Tests.Culture.TypeConverterOptionsFactoryTests.WriteRecordsAppliedWhenMappedTest` and `CsvHelper.Tests.TypeConversion.TypeConverterOptionsFactoryTests.WriteRecordsAppliedWhenMappedTest`.
* Choosing a date which formats the same with ICU and NLS under the `uk-UA` culture. The previous date (`new DateTime( 2010, 11, 11 )`) formats as `11.11.2010 00:00:00` with ICU and `11.11.2010 0:00:00` with NLS. Note: `00` for midnight vs `0`.

[1]: https://docs.microsoft.com/en-us/dotnet/core/compatibility/globalization/5.0/icu-globalization-api
[2]: https://docs.microsoft.com/en-us/windows/win32/intl/national-language-support