### PR TITLE
Update IWriterConfiguration.cs

### DIFF
--- a/src/CsvHelper/Configuration/IWriterConfiguration.cs
+++ b/src/CsvHelper/Configuration/IWriterConfiguration.cs
@@ -65,7 +65,8 @@ namespace CsvHelper.Configuration
 
 		/// <summary>
 		/// Gets the newline to use when writing.
-		/// If not set, \r\n will be used.
+		/// If not set, the value of Environment.NewLine will be used.
+		/// There is no way to force the use of \r\n explicitly, only single-character line endings.
 		/// Keep in mind, when reading <see cref="ParserMode.RFC4180"/> will not use this value.
 		/// Only <see cref="ParserMode.Escape"/> will.
 		/// </summary>


### PR DESCRIPTION
Correct the comment on IWriterConfiguration.NewLine to match actual code behaviour.

(Alternative fix: change writer to actually use \r\n when NewLine isn't set, rather than using Environment.NewLine?)