### PR TITLE
Update CsvWriter.cs

### DIFF
--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -109,7 +109,7 @@ namespace CsvHelper
 			injectionCharacters = configuration.InjectionCharacters;
 			injectionEscapeCharacter = configuration.InjectionEscapeCharacter;
 			leaveOpen = configuration.LeaveOpen;
-			newLineString = configuration.NewLine?.ToString() ?? Environment.NewLine;
+			newLineString = configuration.NewLine?.ToString() ?? "\r\n";
 			quote = configuration.Quote;
 			quoteString = configuration.QuoteString;
 			sanitizeForInjection = configuration.SanitizeForInjection;


### PR DESCRIPTION
Ensure that NewLine=null actually uses \r\n as the newline as documented, instead of using either a single specified character or the platform default - which meant it was impossible to use \r\n as line ending on any platform (such as Linux and the Mac) where this is not the system default.