### PR TITLE
Adds cancelation to async methods

### DIFF
--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using CsvHelper.Expressions;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace CsvHelper
 {
@@ -1000,7 +1001,7 @@ namespace CsvHelper
 
 #if !NET45
 		/// <inheritdoc/>
-		public virtual async IAsyncEnumerable<T> GetRecordsAsync<T>()
+		public virtual async IAsyncEnumerable<T> GetRecordsAsync<T>([EnumeratorCancellation]CancellationToken cancellationToken = default(CancellationToken))
 		{
 			if (disposed)
 			{
@@ -1027,6 +1028,7 @@ namespace CsvHelper
 
 			while (await ReadAsync().ConfigureAwait(false))
 			{
+				cancellationToken.ThrowIfCancellationRequested();
 				T record;
 				try
 				{
@@ -1057,7 +1059,7 @@ namespace CsvHelper
 		}
 
 		/// <inheritdoc/>
-		public virtual IAsyncEnumerable<T> GetRecordsAsync<T>(T anonymousTypeDefinition)
+		public virtual IAsyncEnumerable<T> GetRecordsAsync<T>(T anonymousTypeDefinition, CancellationToken cancellationToken = default)
 		{
 			if (anonymousTypeDefinition == null)
 			{
@@ -1069,11 +1071,11 @@ namespace CsvHelper
 				throw new ArgumentException($"Argument is not an anonymous type.", nameof(anonymousTypeDefinition));
 			}
 
-			return GetRecordsAsync<T>();
+			return GetRecordsAsync<T>(cancellationToken);
 		}
 
 		/// <inheritdoc/>
-		public virtual async IAsyncEnumerable<object> GetRecordsAsync(Type type)
+		public virtual async IAsyncEnumerable<object> GetRecordsAsync(Type type, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			if (disposed)
 			{
@@ -1100,6 +1102,7 @@ namespace CsvHelper
 
 			while (await ReadAsync().ConfigureAwait(false))
 			{
+				cancellationToken.ThrowIfCancellationRequested();
 				object record;
 				try
 				{
@@ -1130,7 +1133,7 @@ namespace CsvHelper
 		}
 
 		/// <inheritdoc/>
-		public virtual async IAsyncEnumerable<T> EnumerateRecordsAsync<T>(T record)
+		public virtual async IAsyncEnumerable<T> EnumerateRecordsAsync<T>(T record, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			if (disposed)
 			{
@@ -1157,6 +1160,7 @@ namespace CsvHelper
 
 			while (await ReadAsync().ConfigureAwait(false))
 			{
+				cancellationToken.ThrowIfCancellationRequested();
 				try
 				{
 					recordManager.Value.Hydrate(record);

--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -18,6 +18,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Buffers;
+using System.Threading;
 
 #pragma warning disable 649
 #pragma warning disable 169
@@ -448,7 +449,7 @@ namespace CsvHelper
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task WriteRecordsAsync(IEnumerable records)
+		public virtual async Task WriteRecordsAsync(IEnumerable records, CancellationToken cancellationToken = default)
 		{
 			// Changes in this method require changes in method WriteRecords<T>(IEnumerable<T> records) also.
 
@@ -456,6 +457,8 @@ namespace CsvHelper
 			{
 				foreach (var record in records)
 				{
+					cancellationToken.ThrowIfCancellationRequested();
+
 					var recordType = record.GetType();
 
 					if (record is IDynamicMetaObjectProvider dynamicObject)
@@ -497,7 +500,7 @@ namespace CsvHelper
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task WriteRecordsAsync<T>(IEnumerable<T> records)
+		public virtual async Task WriteRecordsAsync<T>(IEnumerable<T> records, CancellationToken cancellationToken = default)
 		{
 			// Changes in this method require changes in method WriteRecords(IEnumerable records) also.
 
@@ -519,6 +522,8 @@ namespace CsvHelper
 				var getRecordType = recordType == typeof(object);
 				foreach (var record in records)
 				{
+					cancellationToken.ThrowIfCancellationRequested();
+
 					if (getRecordType)
 					{
 						recordType = record.GetType();

--- a/src/CsvHelper/IReader.cs
+++ b/src/CsvHelper/IReader.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace CsvHelper
 {
@@ -83,8 +84,9 @@ namespace CsvHelper
 		/// should not be used when using this.
 		/// </summary>
 		/// <typeparam name="T">The <see cref="Type"/> of the record.</typeparam>
+		/// <param name="cancellationToken">The cancellation token to stop the writing.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{T}" /> of records.</returns>
-		IAsyncEnumerable<T> GetRecordsAsync<T>();
+		IAsyncEnumerable<T> GetRecordsAsync<T>(CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
 		/// Gets all the records in the CSV file and converts
@@ -93,8 +95,9 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The <see cref="System.Type"/> of the record.</typeparam>
 		/// <param name="anonymousTypeDefinition">The anonymous type definition to use for the records.</param>
+		/// <param name="cancellationToken">The cancellation token to stop the writing.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{T}"/> of records.</returns>
-		IAsyncEnumerable<T> GetRecordsAsync<T>(T anonymousTypeDefinition);
+		IAsyncEnumerable<T> GetRecordsAsync<T>(T anonymousTypeDefinition, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
 		/// Gets all the records in the CSV file and
@@ -102,8 +105,9 @@ namespace CsvHelper
 		/// should not be used when using this.
 		/// </summary>
 		/// <param name="type">The <see cref="Type"/> of the record.</param>
+		/// <param name="cancellationToken">The cancellation token to stop the writing.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{Object}" /> of records.</returns>
-		IAsyncEnumerable<object> GetRecordsAsync(Type type);
+		IAsyncEnumerable<object> GetRecordsAsync(Type type, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
 		/// Enumerates the records hydrating the given record instance with row data.
@@ -114,8 +118,9 @@ namespace CsvHelper
 		/// </summary>
 		/// <typeparam name="T">The type of the record.</typeparam>
 		/// <param name="record">The record to fill each enumeration.</param>
+		/// /// <param name="cancellationToken">The cancellation token to stop the writing.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{T}"/> of records.</returns>
-		IAsyncEnumerable<T> EnumerateRecordsAsync<T>(T record);
+		IAsyncEnumerable<T> EnumerateRecordsAsync<T>(T record, CancellationToken cancellationToken = default(CancellationToken));
 #endif
 	}
 }

--- a/src/CsvHelper/IWriter.cs
+++ b/src/CsvHelper/IWriter.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.IO;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace CsvHelper
 {
@@ -61,13 +62,15 @@ namespace CsvHelper
 		/// Writes the list of records to the CSV file.
 		/// </summary>
 		/// <param name="records">The records to write.</param>
-		Task WriteRecordsAsync(IEnumerable records);
+		/// <param name="cancellationToken">The cancellation token to stop the writing.</param>
+		Task WriteRecordsAsync(IEnumerable records, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Writes the list of records to the CSV file.
 		/// </summary>
 		/// <typeparam name="T">Record type.</typeparam>
 		/// <param name="records">The records to write.</param>
-		Task WriteRecordsAsync<T>(IEnumerable<T> records);
+		/// <param name="cancellationToken">The cancellation token to stop the writing.</param>
+		Task WriteRecordsAsync<T>(IEnumerable<T> records, CancellationToken cancellationToken = default);
 	}
 }

--- a/tests/CsvHelper.Tests/Async/ReadingTests.cs
+++ b/tests/CsvHelper.Tests/Async/ReadingTests.cs
@@ -6,6 +6,8 @@ using CsvHelper.Tests.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Threading;
+using System;
 
 namespace CsvHelper.Tests.Async
 {
@@ -67,6 +69,26 @@ namespace CsvHelper.Tests.Async
 
 				Assert.AreEqual(2, records.Current.Id);
 				Assert.AreEqual("two", records.Current.Name);
+			}
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(OperationCanceledException))]
+		public async Task GetRecordsTestCanceled()
+		{
+			var parser = new ParserMock
+			{
+				new [] { "Id", "Name" },
+				new [] { "1", "one" },
+				new [] { "2", "two" },
+				null
+			};
+			using (var source = new CancellationTokenSource())
+			using (var csv = new CsvReader(parser))
+			{
+				source.Cancel();
+				var records = csv.GetRecordsAsync<Simple>(source.Token).GetAsyncEnumerator();
+				await records.MoveNextAsync();
 			}
 		}
 #endif


### PR DESCRIPTION
Exposed on writer/reader primary calls
Only flows down to the big while loop, as nothing else was interruptible
Adds reader/writer tests.
Added with explicit defaults on the interface to help not break existing.
#1359