### PR TITLE
Upgraded System.ValueTuple to 4.5.0

### DIFF
--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -54,7 +54,7 @@
 		<PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
 		<PackageReference Include="System.Buffers" Version="4.5.1" />
 		<PackageReference Include="System.Memory" Version="4.5.4" />
-		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
+		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
 	<!-- .NET 4.7 -->

--- a/tests/CsvHelper.Tests/CsvHelper.Tests.csproj
+++ b/tests/CsvHelper.Tests/CsvHelper.Tests.csproj
@@ -37,7 +37,7 @@
 		<PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
 		<PackageReference Include="System.Buffers" Version="4.5.1" />
 		<PackageReference Include="System.Memory" Version="4.5.4" />
-		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
+		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
 	<!-- .NET 4.7 -->


### PR DESCRIPTION
The dependency on the older version of System.ValueTuple causes dependency clashes with packages that rely on the newer version of that package.  This PR aims to reduce those clashes.

Very similar to #1323 , but this PR does not also upgrade Newtonsoft.

I don't believe this causes any breaking changes, but if you feel it does, please feel free to close.

Thanks for your consideration.