### PR TITLE
initial prove of concept less string allocations

### DIFF
--- a/src/CsvHelper/Configuration/ConfigurationFunctions.cs
+++ b/src/CsvHelper/Configuration/ConfigurationFunctions.cs
@@ -109,14 +109,6 @@ namespace CsvHelper.Configuration
 		}
 
 		/// <summary>
-		/// Returns <c>false</c>.
-		/// </summary>
-		public static bool ShouldSkipRecord(ShouldSkipRecordArgs args)
-		{
-			return false;
-		}
-
-		/// <summary>
 		/// Returns the <see name="PrepareHeaderForMatchArgs.Header"/> as given.
 		/// </summary>
 		public static string PrepareHeaderForMatch(PrepareHeaderForMatchArgs args)

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -144,7 +144,7 @@ namespace CsvHelper.Configuration
 		public ShouldQuote ShouldQuote { get; set; } = ConfigurationFunctions.ShouldQuote;
 
 		/// <inheritdoc/>
-		public virtual ShouldSkipRecord ShouldSkipRecord { get; set; } = ConfigurationFunctions.ShouldSkipRecord;
+		public virtual ShouldSkipRecord ShouldSkipRecord { get; set; }
 
 		/// <inheritdoc/>
 		public virtual ShouldUseConstructorParameters ShouldUseConstructorParameters { get; set; } = ConfigurationFunctions.ShouldUseConstructorParameters;

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -242,7 +242,7 @@ namespace CsvHelper
 			{
 				hasMoreRecords = parser.Read();
 			}
-			while (hasMoreRecords && shouldSkipRecord(new ShouldSkipRecordArgs(parser.Record)));
+			while (hasMoreRecords && (shouldSkipRecord?.Invoke(new ShouldSkipRecordArgs(parser.Record)) ?? false));
 
 			currentIndex = -1;
 			hasBeenRead = true;
@@ -274,7 +274,7 @@ namespace CsvHelper
 			{
 				hasMoreRecords = await parser.ReadAsync();
 			}
-			while (hasMoreRecords && shouldSkipRecord(new ShouldSkipRecordArgs(parser.Record)));
+			while (hasMoreRecords && (shouldSkipRecord?.Invoke(new ShouldSkipRecordArgs(parser.Record)) ?? false));
 
 			currentIndex = -1;
 			hasBeenRead = true;
@@ -354,6 +354,30 @@ namespace CsvHelper
 
 			var field = parser[index];
 
+			return field;
+		}
+
+		public virtual ReadOnlySpan<char> GetFieldSpan(int index)
+		{
+			CheckHasBeenRead();
+
+			// Set the current index being used so we
+			// have more information if an error occurs
+			// when reading records.
+			currentIndex = index;
+
+			if (index >= parser.Count || index < 0)
+			{
+				if (ignoreBlankLines)
+				{
+					var args = new MissingFieldFoundArgs(null, index, context);
+					missingFieldFound?.Invoke(args);
+				}
+
+				return default;
+			}
+
+			var field = parser.GetFieldSpan(index);
 			return field;
 		}
 

--- a/src/CsvHelper/Expressions/RecordHydrator.cs
+++ b/src/CsvHelper/Expressions/RecordHydrator.cs
@@ -87,7 +87,6 @@ namespace CsvHelper.Expressions
 					continue;
 				}
 
-				var memberTypeParameter = Expression.Parameter(memberMap.Data.Member.MemberType(), "member");
 				var memberAccess = Expression.MakeMemberAccess(recordTypeParameter, memberMap.Data.Member);
 				var memberAssignment = Expression.Assign(memberAccess, fieldExpression);
 				memberAssignments.Add(memberAssignment);
@@ -104,8 +103,6 @@ namespace CsvHelper.Expressions
 				expressionManager.CreateMemberAssignmentsForMapping(referenceMap.Data.Mapping, referenceAssignments);
 
 				var referenceBody = expressionManager.CreateInstanceAndAssignMembers(referenceMap.Data.Member.MemberType(), referenceAssignments);
-
-				var memberTypeParameter = Expression.Parameter(referenceMap.Data.Member.MemberType(), "referenceMember");
 				var memberAccess = Expression.MakeMemberAccess(recordTypeParameter, referenceMap.Data.Member);
 				var memberAssignment = Expression.Assign(memberAccess, referenceBody);
 				memberAssignments.Add(memberAssignment);

--- a/src/CsvHelper/IParser.cs
+++ b/src/CsvHelper/IParser.cs
@@ -37,6 +37,8 @@ namespace CsvHelper
 		/// <returns>The field.</returns>
 		string this[int index] { get; }
 
+		ReadOnlySpan<char> GetFieldSpan(int index);
+
 		/// <summary>
 		/// Gets the record for the current row. Note:
 		/// It is much more efficient to only get the fields you need. If

--- a/src/CsvHelper/IReaderRow.cs
+++ b/src/CsvHelper/IReaderRow.cs
@@ -74,6 +74,8 @@ namespace CsvHelper
 		/// <returns>The raw field.</returns>
 		string GetField(int index);
 
+		ReadOnlySpan<char> GetFieldSpan(int index);
+
 		/// <summary>
 		/// Gets the raw field at position (column) name.
 		/// </summary>

--- a/src/CsvHelper/ObjectCreator.cs
+++ b/src/CsvHelper/ObjectCreator.cs
@@ -58,6 +58,11 @@ namespace CsvHelper
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private static Type[] GetArgTypes(object[] args)
 		{
+			if (args.Length == 0)
+			{
+				return Type.EmptyTypes;
+			}
+
 			var argTypes = new Type[args.Length];
 			for (var i = 0; i < args.Length; i++)
 			{

--- a/src/CsvHelper/TypeConversion/ISpanTypeConverter.cs
+++ b/src/CsvHelper/TypeConversion/ISpanTypeConverter.cs
@@ -1,0 +1,21 @@
+﻿// Copyright 2009-2021 Josh Close
+// This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
+// See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
+// https://github.com/JoshClose/CsvHelper
+using CsvHelper.Configuration;
+using System;
+
+namespace CsvHelper.TypeConversion
+{
+	public interface ISpanTypeConverter
+	{
+		/// <summary>
+		/// Converts the ReadOnlySpan to an object.
+		/// </summary>
+		/// <param name="text">The ReadOnlySpan to convert to an object.</param>
+		/// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+		/// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+		/// <returns>The object created from the string.</returns>
+		object ConvertFromSpan(ReadOnlySpan<char> text, IReaderRow row, MemberMapData memberMapData);
+	}
+}

--- a/src/CsvHelper/TypeConversion/Int32Converter.cs
+++ b/src/CsvHelper/TypeConversion/Int32Converter.cs
@@ -11,6 +11,9 @@ namespace CsvHelper.TypeConversion
 	/// Converts an <see cref="int"/> to and from a <see cref="string"/>.
 	/// </summary>
 	public class Int32Converter : DefaultTypeConverter
+#if !NET45 && !NETSTANDARD2_0
+		, ISpanTypeConverter
+#endif
 	{
 		/// <summary>
 		/// Converts the string to an object.
@@ -30,5 +33,19 @@ namespace CsvHelper.TypeConversion
 
 			return base.ConvertFromString(text, row, memberMapData);
 		}
+
+#if !NET45 && !NETSTANDARD2_0
+		public object ConvertFromSpan(System.ReadOnlySpan<char> text, IReaderRow row, MemberMapData memberMapData)
+		{
+			var numberStyle = memberMapData.TypeConverterOptions.NumberStyles ?? NumberStyles.Integer;
+
+			if (int.TryParse(text, numberStyle, memberMapData.TypeConverterOptions.CultureInfo, out var i))
+			{
+				return i;
+			}
+
+			return ConvertFromString(text.ToString(), row, memberMapData);
+		}
+#endif
 	}
 }

--- a/tests/CsvHelper.Tests/Configuration/ClassMapBuilderTests.cs
+++ b/tests/CsvHelper.Tests/Configuration/ClassMapBuilderTests.cs
@@ -315,6 +315,11 @@ namespace CsvHelper.Tests.Configuration
 			{
 				throw new NotImplementedException();
 			}
+
+			public ReadOnlySpan<char> GetFieldSpan(int index)
+			{
+				throw new NotImplementedException();
+			}
 		}
 
 		private class FakeClass

--- a/tests/CsvHelper.Tests/Mocks/ParserMock.cs
+++ b/tests/CsvHelper.Tests/Mocks/ParserMock.cs
@@ -91,6 +91,11 @@ namespace CsvHelper.Tests.Mocks
 			return GetEnumerator();
 		}
 
+		public ReadOnlySpan<char> GetFieldSpan(int index)
+		{
+			throw new NotImplementedException();
+		}
+
 		#endregion Mock Methods
 	}
 }

--- a/tests/CsvHelper.Tests/Mocks/ReaderRowMock.cs
+++ b/tests/CsvHelper.Tests/Mocks/ReaderRowMock.cs
@@ -218,5 +218,10 @@ namespace CsvHelper.Tests.Mocks
 		{
 			throw new NotImplementedException();
 		}
+
+		public ReadOnlySpan<char> GetFieldSpan(int index)
+		{
+			throw new NotImplementedException();
+		}
 	}
 }


### PR DESCRIPTION
fixed #1825 

I used the benchmark project to generate a file with 1000000 records and then actually run the benchmark to read them with

```csharp
using (var parser = new CsvReader(reader, config))
{
    foreach (var item in parser.GetRecords<Program.Columns50>())
    {
    
    }
}
```

| Method | Mean | Error | StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |branch|
| ------- | --------:| ---------:| ---------:| -------------:| ------:| ------:| ----------:|----------:|
| Parse | 7.599 s | 0.1678 s | 0.4759 s | 1176000.0000 | - | - | 4.58 GB | master
| Parse | 4.746 s | 0.0875 s | 0.1622 s | 338000.0000 | - | - | 1.32 GB | pr

\+ 40% speed 
-100% string allocations when reading records
-100% type[] allocation with default ctor

if the general design is accepted i will implement more type converters and come up with a way to check wether a row should be skipped without allocating  


