### PR TITLE
Interpolate exception message in ClassMap$1.cs

### DIFF
--- a/src/CsvHelper/Configuration/ClassMap`1.cs
+++ b/src/CsvHelper/Configuration/ClassMap`1.cs
@@ -31,7 +31,7 @@ namespace CsvHelper.Configuration
 			var stack = ReflectionHelper.GetMembers(expression);
 			if (stack.Count == 0)
 			{
-				throw new InvalidOperationException("No members were found in expression '{expression}'.");
+				throw new InvalidOperationException($"No members were found in expression '{expression}'.");
 			}
 
 			ClassMap currentClassMap = this;


### PR DESCRIPTION
The exception message string was not interpolated leading to a less helpful, literal message of "No members were found in expression '{expression}'."