### PR TITLE
Allow Microsoft.Bcl.AsyncInterfaces version 6.0.0 as a dependency for net47 and netstandard2.0 targets

### DIFF
--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -60,7 +60,7 @@
 
 	<!-- .NET 4.7 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[5.0.0]" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[5.0.0,6.0.0]" />
 		<PackageReference Include="Microsoft.Bcl.HashCode" Version="[1.1.1]" />
 		<PackageReference Include="Microsoft.CSharp" Version="[4.7.0]" />
 		<PackageReference Include="System.Buffers" Version="[4.5.1]" />

--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -70,7 +70,7 @@
 
 	<!-- .NET Standard 2.0 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[5.0.0]" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[5.0.0,6.0.0]" />
 		<PackageReference Include="Microsoft.Bcl.HashCode" Version="[1.1.1]" />
 		<PackageReference Include="Microsoft.CSharp" Version="[4.7.0]" />
 		<PackageReference Include="System.Buffers" Version="[4.5.1]" />


### PR DESCRIPTION
Fixes #1901 ; all tests pass, no meaningful change in Microsoft.Bcl.AsyncInterfaces 6.0.0 vs 5.0.0 except version number.

Context:
CsvHelper is used in a project targeting `net47`, which consumes a class library that targets `netstandard2.0` and consumes `Microsoft.Extensions.DependencyInjection`. Another consumer of said class library targets `net6.0`. If everything gets updated to .NET 6, then `Microsoft.Extensions.DependencyInjection` can be updated to version `6.0.0`, which requires `Microsoft.Bcl.AsyncInterfaces` version `6.0.0`. This starts causing dependency version warnings when building the final projects.