### PR TITLE
Update WhiteSpaceChars summary

### DIFF
--- a/src/CsvHelper/Configuration/IParserConfiguration.cs
+++ b/src/CsvHelper/Configuration/IParserConfiguration.cs
@@ -148,7 +148,7 @@ namespace CsvHelper.Configuration
 		/// <summary>
 		/// Characters considered whitespace.
 		/// Used when trimming fields.
-		/// Default is [' ', '\t'].
+		/// Default is [' '].
 		/// </summary>
 		char[] WhiteSpaceChars { get; }
 


### PR DESCRIPTION
[\t was removed from WhiteSpaceChars](https://github.com/JoshClose/CsvHelper/commit/72cad999ee043814e67e42b1c3095e7f648d943a), so the property's summary should be updated to remove the same.