### PR TITLE
Test and fix for #1954

### DIFF
--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -380,6 +380,7 @@ namespace CsvHelper
 							var result = ReadSpaces(ref c);
 							if (result == ReadLineResult.Incomplete)
 							{
+								fieldStartPosition = bufferPosition;	// Transport info that we are at start of field to next call (#1954).
 								return result;
 							}
 						}

--- a/tests/CsvHelper.Tests/CsvReaderTests.cs
+++ b/tests/CsvHelper.Tests/CsvReaderTests.cs
@@ -57,7 +57,7 @@ namespace CsvHelper.Tests
 			{
 				"1",
 				"blah",
-				DateTime.Now.ToString(),
+				DateTime.Now.ToString("O"),
 				"true",
 				"c",
 				"",

--- a/tests/CsvHelper.Tests/Issues/Issue1954.cs
+++ b/tests/CsvHelper.Tests/Issues/Issue1954.cs
@@ -66,6 +66,90 @@ namespace CsvHelper.Tests.Issues {
 			}
 		}
 
+		[Fact]
+		public void Test3() {
+			var data = @"field1, field2, field3
+1, 2, ""test""
+3, 4,    ""TEST""";
+
+			var opts = new CsvConfiguration(CultureInfo.InvariantCulture) {
+				Delimiter = ",",
+				TrimOptions = TrimOptions.Trim,
+				BufferSize = 44
+			};
+
+			using (var sr = new StringReader(data))
+			using (var csv = new CsvReader(sr, opts)) {
+				var records = csv.GetRecords<Row>().ToArray();
+
+				Assert.Equal(2, records.Length);
+
+				Assert.Equal(1, records[0].Field1);
+				Assert.Equal(2, records[0].Field2);
+				Assert.Equal("test", records[0].Field3);
+
+				Assert.Equal(3, records[1].Field1);
+				Assert.Equal(4, records[1].Field2);
+				Assert.Equal("TEST", records[1].Field3);
+			}
+		}
+
+		[Fact]
+		public void Test4() {
+			var data = @"field1, field2, field3
+1, 2, ""test""
+3, 4,""TEST""";
+
+			var opts = new CsvConfiguration(CultureInfo.InvariantCulture) {
+				Delimiter = ",",
+				TrimOptions = TrimOptions.Trim,
+				BufferSize = 44
+			};
+
+			using (var sr = new StringReader(data))
+			using (var csv = new CsvReader(sr, opts)) {
+				var records = csv.GetRecords<Row>().ToArray();
+
+				Assert.Equal(2, records.Length);
+
+				Assert.Equal(1, records[0].Field1);
+				Assert.Equal(2, records[0].Field2);
+				Assert.Equal("test", records[0].Field3);
+
+				Assert.Equal(3, records[1].Field1);
+				Assert.Equal(4, records[1].Field2);
+				Assert.Equal("TEST", records[1].Field3);
+			}
+		}
+
+		[Fact]
+		public void Test5() {
+			var data = @"field1, field2, field3
+1, 2, ""test""
+3, 4, TEST";
+
+			var opts = new CsvConfiguration(CultureInfo.InvariantCulture) {
+				Delimiter = ",",
+				TrimOptions = TrimOptions.Trim,
+				BufferSize = 44
+			};
+
+			using (var sr = new StringReader(data))
+			using (var csv = new CsvReader(sr, opts)) {
+				var records = csv.GetRecords<Row>().ToArray();
+
+				Assert.Equal(2, records.Length);
+
+				Assert.Equal(1, records[0].Field1);
+				Assert.Equal(2, records[0].Field2);
+				Assert.Equal("test", records[0].Field3);
+
+				Assert.Equal(3, records[1].Field1);
+				Assert.Equal(4, records[1].Field2);
+				Assert.Equal("TEST", records[1].Field3);
+			}
+		}
+
 		private class Row {
 			[Name("field1")] public int Field1 { get; set; }
 			[Name("field2")] public int Field2 { get; set; }

--- a/tests/CsvHelper.Tests/Issues/Issue1954.cs
+++ b/tests/CsvHelper.Tests/Issues/Issue1954.cs
@@ -1,0 +1,75 @@
+﻿using CsvHelper.Configuration;
+using CsvHelper.Configuration.Attributes;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+
+namespace CsvHelper.Tests.Issues {
+
+	public class Issue1954 {
+
+		[Fact]
+		public void Test1() {
+			var data = @"field1, field2, field3
+1, 2, ""test""
+3, 4, ""TEST""";
+
+			var opts = new CsvConfiguration(CultureInfo.InvariantCulture) {
+				Delimiter = ",",
+				TrimOptions = TrimOptions.Trim,
+				BufferSize = 44
+			};
+
+			using (var sr = new StringReader(data))
+			using (var csv = new CsvReader(sr, opts)) {
+				var records = csv.GetRecords<Row>().ToArray();
+
+				Assert.Equal(2, records.Length);
+
+				Assert.Equal(1, records[0].Field1);
+				Assert.Equal(2, records[0].Field2);
+				Assert.Equal("test", records[0].Field3);
+
+				Assert.Equal(3, records[1].Field1);
+				Assert.Equal(4, records[1].Field2);
+				Assert.Equal("TEST", records[1].Field3);
+			}
+		}
+
+		[Fact]
+		public void Test2() {
+			var data = @"field1, field2, field3
+1, 2, ""test""
+3, 4, ""TEST""";
+
+			var opts = new CsvConfiguration(CultureInfo.InvariantCulture) {
+				Delimiter = ",",
+				TrimOptions = TrimOptions.Trim,
+				BufferSize = 45
+			};
+
+			using (var sr = new StringReader(data))
+			using (var csv = new CsvReader(sr, opts)) {
+				var records = csv.GetRecords<Row>().ToArray();
+
+				Assert.Equal(2, records.Length);
+
+				Assert.Equal(1, records[0].Field1);
+				Assert.Equal(2, records[0].Field2);
+				Assert.Equal("test", records[0].Field3);
+
+				Assert.Equal(3, records[1].Field1);
+				Assert.Equal(4, records[1].Field2);
+				Assert.Equal("TEST", records[1].Field3);
+			}
+		}
+
+		private class Row {
+			[Name("field1")] public int Field1 { get; set; }
+			[Name("field2")] public int Field2 { get; set; }
+			[Name("field3")] public string Field3 { get; set; }
+		}
+	}
+}

--- a/tests/CsvHelper.Tests/Mappings/ConstructorParameter/CultureInfoAttributeTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/ConstructorParameter/CultureInfoAttributeTests.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace CsvHelper.Tests.Mappings.ConstructorParameter
 {
@@ -82,16 +83,22 @@ namespace CsvHelper.Tests.Mappings.ConstructorParameter
 				new Foo(1, AMOUNT),
 			};
 
-			using (var writer = new StringWriter())
-			using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
-			{
-				csv.WriteRecords(records);
+			var prevCulture = Thread.CurrentThread.CurrentCulture;
+			try {
+				Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+				using (var writer = new StringWriter())
+				using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
+				{
+					csv.WriteRecords(records);
 
-				var expected = new StringBuilder();
-				expected.Append("Id,Amount\r\n");
-				expected.Append($"1,{AMOUNT}\r\n");
+					var expected = new StringBuilder();
+					expected.Append("Id,Amount\r\n");
+					expected.Append($"1,{AMOUNT}\r\n");
 
-				Assert.Equal(expected.ToString(), writer.ToString());
+					Assert.Equal(expected.ToString(), writer.ToString());
+				}
+			} finally {
+				Thread.CurrentThread.CurrentCulture = prevCulture;
 			}
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/ConstructorParameter/CultureInfoMapTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/ConstructorParameter/CultureInfoMapTests.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace CsvHelper.Tests.Mappings.ConstructorParameter
 {
@@ -111,18 +112,24 @@ namespace CsvHelper.Tests.Mappings.ConstructorParameter
 				new Foo(1, AMOUNT),
 			};
 
-			using (var writer = new StringWriter())
-			using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
-			{
-				csv.Context.RegisterClassMap<FooMap>();
+			var prevCulture = Thread.CurrentThread.CurrentCulture;
+			try {
+				Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+				using (var writer = new StringWriter())
+				using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
+				{
+					csv.Context.RegisterClassMap<FooMap>();
 
-				csv.WriteRecords(records);
+					csv.WriteRecords(records);
 
-				var expected = new StringBuilder();
-				expected.Append("Id,Amount\r\n");
-				expected.Append($"1,{AMOUNT}\r\n");
+					var expected = new StringBuilder();
+					expected.Append("Id,Amount\r\n");
+					expected.Append($"1,{AMOUNT}\r\n");
 
-				Assert.Equal(expected.ToString(), writer.ToString());
+					Assert.Equal(expected.ToString(), writer.ToString());
+			}
+			} finally {
+				Thread.CurrentThread.CurrentCulture = prevCulture;
 			}
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/ConstructorParameter/DateTimeStylesAttributeTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/ConstructorParameter/DateTimeStylesAttributeTests.cs
@@ -20,7 +20,7 @@ namespace CsvHelper.Tests.Mappings.ConstructorParameter
     public class DateTimeStylesAttributeTests
 	{
 		private const string DATE = "12/25/2020";
-		private readonly DateTimeOffset date = DateTimeOffset.Parse(DATE);
+		private readonly DateTimeOffset date = DateTimeOffset.Parse(DATE, CultureInfo.InvariantCulture);
 
 		[Fact]
 		public void AutoMap_WithCultureInfoAttributes_ConfiguresParameterMaps()

--- a/tests/CsvHelper.Tests/Mappings/ConstructorParameter/DateTimeStylesMapTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/ConstructorParameter/DateTimeStylesMapTests.cs
@@ -19,7 +19,7 @@ namespace CsvHelper.Tests.Mappings.ConstructorParameter
     public class DateTimeStylesMapTests
 	{
 		private const string DATE = "12/25/2020";
-		private readonly DateTimeOffset date = DateTimeOffset.Parse(DATE);
+		private readonly DateTimeOffset date = DateTimeOffset.Parse(DATE, CultureInfo.InvariantCulture);
 
 		[Fact]
 		public void Parameter_WithName_CreatesParameterMaps()

--- a/tests/CsvHelper.Tests/Writing/MultipleFieldsFromOnePropertyTests.cs
+++ b/tests/CsvHelper.Tests/Writing/MultipleFieldsFromOnePropertyTests.cs
@@ -26,7 +26,7 @@ namespace CsvHelper.Tests.Writing
 			{
 				var records = new List<Test>
 				{
-					new Test { Dob = DateTime.Parse( "9/6/2017" ) }
+					new Test { Dob = DateTime.Parse("9/6/2017", new CultureInfo("en-US")) }
 				};
 				csv.Context.RegisterClassMap<TestMap>();
 				csv.WriteRecords(records);
@@ -57,7 +57,7 @@ namespace CsvHelper.Tests.Writing
 				csv.Context.RegisterClassMap<TestMap>();
 				var records = csv.GetRecords<Test>().ToList();
 
-				Assert.Equal(DateTime.Parse("9/8/2017"), records[0].Dob);
+				Assert.Equal(DateTime.Parse("9/8/2017", CultureInfo.InvariantCulture), records[0].Dob);
 			}
 		}
 


### PR DESCRIPTION
Although I have only a superficial understanding of how the parser works, I think I found the reason for issue #1954: The information on whether the parser is at the begin of a field is not preserved throughout multiple calls to `ReadLine` in this case. Therefore, if the buffer is re-filled and `ReadLine` is called again, it does not know any more that between the begin of the field and the current position were only white spaces.

I believe that moving the `fieldStartPosition` to the buffer position at the last whitespace that was skipped will transport this information to the next invocation. This PR adds this fix and provides a test case for the issue.