### PR TITLE
Fix 26 to 27 migration doc

### DIFF
--- a/docs/change-log/index.html
+++ b/docs/change-log/index.html
@@ -119,7 +119,7 @@
 <li>Added <code>IParserConfiguration.DetectDelimiter</code>.</li>
 <li>Added <code>IParserConfiguration.DetectDelimiterValues</code>.</li>
 <li>Added <code>IWriter.WriteRecordsAsync&lt;T&gt;(IAsyncEnumerable&lt;T&gt; records, CancellationToken cancellationToken = default)</code>.</li>
-<li>Removed <code>\t</code> from <code>CsvConfiguration.WhiteSpaceCharacters</code> as a default.</li>
+<li>Removed <code>\t</code> from <code>CsvConfiguration.WhiteSpaceChars</code> as a default.</li>
 </ul>
 <h3 id="section-7">26.1.0</h3>
 <h4 id="features-2">Features</h4>

--- a/docs/migration/v27/index.html
+++ b/docs/migration/v27/index.html
@@ -75,7 +75,7 @@
 				<div class="column">
 					<div class="content">
 						<h1 id="migrating-from-version-26-to-27">Migrating from version 26 to 27</h1>
-<h2 id="csvconfiugration.whitespacecharacters">CsvConfiugration.WhiteSpaceCharacters</h2>
+<h2 id="csvconfiguration.whitespacechars">CsvConfiguration.WhiteSpaceChars</h2>
 <ul>
 <li>Removed <code>\t</code> from the array of default characters.</li>
 </ul>
@@ -83,7 +83,7 @@
 whitespace characters.</p>
 <pre><code class="language-cs">var config = new CsvConfiguration(CultureInfo.InvariantCulture)
 {
-	WhiteSpaceCharacters = new[] { ' ', '\t' },
+	WhiteSpaceChars = new[] { ' ', '\t' },
 };
 </code></pre>
 <h2 id="iparserconfiguration">IParserConfiguration</h2>

--- a/src/CsvHelper.Website/input/change-log/index.md
+++ b/src/CsvHelper.Website/input/change-log/index.md
@@ -57,7 +57,7 @@
 - Added `IParserConfiguration.DetectDelimiter`.
 - Added `IParserConfiguration.DetectDelimiterValues`.
 - Added `IWriter.WriteRecordsAsync<T>(IAsyncEnumerable<T> records, CancellationToken cancellationToken = default)`.
-- Removed `\t` from `CsvConfiguration.WhiteSpaceCharacters` as a default.
+- Removed `\t` from `CsvConfiguration.WhiteSpaceChars` as a default.
 
 ### 26.1.0
 

--- a/src/CsvHelper.Website/input/migration/v27/index.md
+++ b/src/CsvHelper.Website/input/migration/v27/index.md
@@ -1,6 +1,6 @@
 ﻿# Migrating from version 26 to 27
 
-## CsvConfiugration.WhiteSpaceCharacters
+## CsvConfiguration.WhiteSpaceChars
 
 - Removed `\t` from the array of default characters.
 
@@ -10,7 +10,7 @@ whitespace characters.
 ```cs
 var config = new CsvConfiguration(CultureInfo.InvariantCulture)
 {
-	WhiteSpaceCharacters = new[] { ' ', '\t' },
+	WhiteSpaceChars = new[] { ' ', '\t' },
 };
 ```
 


### PR DESCRIPTION
Fixed two small issues in the 26 to 27 migration documentation:

* Fixed a typo: `CsvConfiugration` -> `CsvConfiguration`
* Used the correct propertyname: `WhiteSpaceCharacters` -> `WhiteSpaceChars`. See [here](https://github.com/JoshClose/CsvHelper/blob/9137bde39ccfe1423981bfa8883cc18f24a26412/src/CsvHelper/Configuration/CsvConfiguration.cs#L159) for the code.