### PR TITLE
Fix broken link

### DIFF
--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -245,7 +245,7 @@ use attributes instead of changing the header matching.</p>
 	public string Name { get; set; }
 }
 </code></pre>
-<p><a href="/CsvHelper/api/CsvHelper.Configuration.Attributes">There are many other attributes you can use also.</a></p>
+<p><a href="/CsvHelper/examples/configuration/attributes/">There are many other attributes you can use also.</a></p>
 <p>What if we don't have control over the class we want to map to so we can't add attributes to it?
 In this case, we can use a fluent <code>ClassMap</code> to do the mapping.</p>
 <pre><code class="language-cs">public class FooMap : ClassMap&lt;Foo&gt;

--- a/src/CsvHelper.Website/input/getting-started/index.md
+++ b/src/CsvHelper.Website/input/getting-started/index.md
@@ -160,7 +160,7 @@ public class Foo
 }
 ```
 
-[There are many other attributes you can use also.](~/api/CsvHelper.Configuration.Attributes)
+[There are many other attributes you can use also.](~/examples/configuration/attributes)
 
 What if we don't have control over the class we want to map to so we can't add attributes to it?
 In this case, we can use a fluent `ClassMap` to do the mapping.


### PR DESCRIPTION
Link currently sends to [https://joshclose.github.io/CsvHelper/api/CsvHelper.Configuration.Attributes](https://joshclose.github.io/CsvHelper/api/CsvHelper.Configuration.Attributes) instead of to [https://joshclose.github.io/CsvHelper/examples/configuration/attributes/](https://joshclose.github.io/CsvHelper/examples/configuration/attributes/)