### PR TITLE
Pass configuration in the CsvReader constructor

### DIFF
--- a/src/CsvHelper.Website/input/examples/configuration/class-maps/mapping-by-index/index.md
+++ b/src/CsvHelper.Website/input/examples/configuration/class-maps/mapping-by-index/index.md
@@ -17,7 +17,7 @@ void Main()
         HasHeaderRecord = false,
     };
     using (var reader = new StreamReader("path\\to\\file.csv"))
-    using (var csv = new CsvReader(reader, ))
+    using (var csv = new CsvReader(reader, config))
     {
         csv.Context.RegisterClassMap<FooMap>();
         var records = csv.GetRecords<Foo>();


### PR DESCRIPTION
issue #2016 

CsvConfiguration parameter was not passed in the CsvReader constructor in [mapping by index](https://joshclose.github.io/CsvHelper/examples/configuration/class-maps/mapping-by-index/) docs example.