### PR TITLE
Fixes #2081

### DIFF
--- a/src/CsvHelper/TypeConversion/CollectionConverterFactory.cs
+++ b/src/CsvHelper/TypeConversion/CollectionConverterFactory.cs
@@ -118,48 +118,51 @@ namespace CsvHelper.TypeConversion
 			}
 
 			var isGenericType = type.GetTypeInfo().IsGenericType;
-			var genericTypeDefinition = type.GetGenericTypeDefinition();
-
-			if (isGenericType && genericTypeDefinition == typeof(Dictionary<,>))
+			if (isGenericType)
 			{
-				typeConverter = new IDictionaryGenericConverter();
-				return true;
-			}
+				var genericTypeDefinition = type.GetGenericTypeDefinition();
 
-			if (isGenericType && genericTypeDefinition == typeof(IDictionary<,>))
-			{
-				typeConverter = new IDictionaryGenericConverter();
-				return true;
-			}
+				if (genericTypeDefinition == typeof(Dictionary<,>))
+				{
+					typeConverter = new IDictionaryGenericConverter();
+					return true;
+				}
 
-			if (isGenericType && genericTypeDefinition == typeof(List<>))
-			{
-				typeConverter = new CollectionGenericConverter();
-				return true;
-			}
+				if (genericTypeDefinition == typeof(IDictionary<,>))
+				{
+					typeConverter = new IDictionaryGenericConverter();
+					return true;
+				}
 
-			if (isGenericType && genericTypeDefinition == typeof(Collection<>))
-			{
-				typeConverter = new CollectionGenericConverter();
-				return true;
-			}
+				if (genericTypeDefinition == typeof(List<>))
+				{
+					typeConverter = new CollectionGenericConverter();
+					return true;
+				}
 
-			if (isGenericType && genericTypeDefinition == typeof(IList<>))
-			{
-				typeConverter = new IEnumerableGenericConverter();
-				return true;
-			}
+				if (genericTypeDefinition == typeof(Collection<>))
+				{
+					typeConverter = new CollectionGenericConverter();
+					return true;
+				}
 
-			if (isGenericType && genericTypeDefinition == typeof(ICollection<>))
-			{
-				typeConverter = new IEnumerableGenericConverter();
-				return true;
-			}
+				if (genericTypeDefinition == typeof(IList<>))
+				{
+					typeConverter = new IEnumerableGenericConverter();
+					return true;
+				}
 
-			if (isGenericType && genericTypeDefinition == typeof(IEnumerable<>))
-			{
-				typeConverter = new IEnumerableGenericConverter();
-				return true;
+				if (genericTypeDefinition == typeof(ICollection<>))
+				{
+					typeConverter = new IEnumerableGenericConverter();
+					return true;
+				}
+
+				if (genericTypeDefinition == typeof(IEnumerable<>))
+				{
+					typeConverter = new IEnumerableGenericConverter();
+					return true;
+				}
 			}
 
 			// A specific IEnumerable converter doesn't exist.


### PR DESCRIPTION
Fixes #2081 Fixes #2069
Fixes "This Operation is only valid on generic types." error caused by calling type.GetGenericTypeDefinition on non generic types.
