### PR TITLE
Ensure the ConvertToStringArgs are constructed with the correct generic type

### DIFF
--- a/src/CsvHelper/Expressions/ObjectRecordWriter.cs
+++ b/src/CsvHelper/Expressions/ObjectRecordWriter.cs
@@ -57,7 +57,9 @@ namespace CsvHelper.Expressions
 				if (memberMap.Data.WritingConvertExpression != null)
 				{
 					// The user is providing the expression to do the conversion.
-					var constructor = typeof(ConvertToStringArgs<T>).GetConstructor(new Type[] { typeof(T) });
+					Type convertGenericType = memberMap.Data.WritingConvertExpression.Type.GenericTypeArguments[0];
+
+					var constructor = typeof(ConvertToStringArgs<>).MakeGenericType(convertGenericType).GetConstructor(new Type[] { convertGenericType });
 					var args = Expression.New(constructor, recordParameterConverted);
 					Expression exp = Expression.Invoke(memberMap.Data.WritingConvertExpression, args);
 					exp = Expression.Call(Expression.Constant(Writer), nameof(Writer.WriteField), null, exp);

--- a/tests/CsvHelper.Tests/Issues/Issue2118.cs
+++ b/tests/CsvHelper.Tests/Issues/Issue2118.cs
@@ -1,0 +1,46 @@
+﻿using CsvHelper.Configuration;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Xunit;
+
+namespace CsvHelper.Tests.Issues
+{
+	public class Issue2118
+	{
+		[Fact]
+		public void Issue2118Test()
+		{
+			var records = new List<Foo>
+			{
+				new() { Bar = new HashSet<string> { "foo" } },
+				new() { Bar = new HashSet<string> { "bar" } },
+			};
+
+			string csvString;
+			using (var writer = new StringWriter())
+			using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
+			{
+				csv.Context.RegisterClassMap<FooMap>();
+				csv.WriteRecords(records);
+				csvString = writer.ToString();
+			}
+
+			Assert.Equal("Foo,Bar\r\nTrue,False\r\nFalse,True\r\n", csvString);
+		}
+
+		private class Foo
+		{
+			public HashSet<string> Bar { get; set; }
+		}
+
+		private sealed class FooMap : ClassMap<Foo>
+		{
+			public FooMap()
+			{
+				Map().Index(0).Name("Foo").Convert(x => (x.Value as Foo).Bar.Contains("foo") ? "True" : "False");
+				Map().Index(1).Name("Bar").Convert(x => (x.Value as Foo).Bar.Contains("bar") ? "True" : "False");
+			}
+		}
+	}
+}


### PR DESCRIPTION
When the parameterless `Map()` (returning `MemberMap<object, object>`) is used in combination with `Convert(ConvertToString<TClass>)` then `TClass` is `object` but when writing we invoke the delegate with a `ConvertToStringArgs<T>` where `T` is the type of the record and not `object`. This fails because `TClass` is invariant on the `ConvertToString` delegate (we cannot express it as contravariant, I think because of the generic struct argument). So we need to construct the `ConvertToStringArgs` with the same generic type as that of the `ConvertToString` delegate stored in `WritingConvertExpression`.

fixes #2118 