### PR TITLE
Enable ignoring CultureInfo.TextInfo.ListSeparator

### DIFF
--- a/src/CsvHelper/Configuration/ConfigurationFunctions.cs
+++ b/src/CsvHelper/Configuration/ConfigurationFunctions.cs
@@ -245,7 +245,7 @@ namespace CsvHelper.Configuration
 			).ToList();
 
 			string? newDelimiter = null;
-			if (delimiters.Any(x => x.Delimiter == config.CultureInfo.TextInfo.ListSeparator) && lineDelimiterCounts.Count > 1)
+			if (!config.IgnoreCultureListSeparator && delimiters.Any(x => x.Delimiter == config.CultureInfo.TextInfo.ListSeparator) && lineDelimiterCounts.Count > 1)
 			{
 				// The culture's separator is on every line. Assume this is the delimiter.
 				newDelimiter = config.CultureInfo.TextInfo.ListSeparator;

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -55,6 +55,12 @@ namespace CsvHelper.Configuration
 		/// <inheritdoc/>
 		public virtual string[] DetectDelimiterValues { get; set; } = new[] { ",", ";", "|", "\t" };
 
+		/// <summary>
+		/// When true, if <see cref="TextInfo.ListSeparator"/> of the <see cref="CultureInfo"/> is present on all lines, it will be used.
+		/// Consider setting this value to false if your data includes the <see cref="TextInfo.ListSeparator"/> as data rather than as delimiters.
+		/// </summary>
+		public bool IgnoreCultureListSeparator { get; set; }
+
 		/// <inheritdoc/>
 		public virtual bool DetectColumnCountChanges { get; set; }
 

--- a/src/CsvHelper/Configuration/IParserConfiguration.cs
+++ b/src/CsvHelper/Configuration/IParserConfiguration.cs
@@ -144,6 +144,13 @@ namespace CsvHelper.Configuration
 		string[] DetectDelimiterValues { get; }
 
 		/// <summary>
+		/// When true, <see cref="TextInfo.ListSeparator"/> of the <see cref="CultureInfo"/> is not weighted as a delimiter.
+		/// Consider setting this value to true if your data includes the <see cref="TextInfo.ListSeparator"/> as data rather than as delimiters.
+		/// </summary>
+		bool IgnoreCultureListSeparator { get; } 
+
+
+		/// <summary>
 		/// The character used to escape characters.
 		/// Default is '"'.
 		/// </summary>

--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -8,8 +8,8 @@
 
 		<!-- Build -->
 		<AssemblyName>CsvHelper</AssemblyName>
-		<TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net47;net45</TargetFrameworks>
-		<!--<TargetFrameworks>net60</TargetFrameworks>-->
+		<!--<TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net47;net45</TargetFrameworks>-->
+		<TargetFrameworks>net60</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>CsvHelper</RootNamespace>
 		<DefaultLanguage>en-US</DefaultLanguage>

--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -8,8 +8,8 @@
 
 		<!-- Build -->
 		<AssemblyName>CsvHelper</AssemblyName>
-		<!--<TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net47;net45</TargetFrameworks>-->
-		<TargetFrameworks>net60</TargetFrameworks>
+		<TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net47;net45</TargetFrameworks>
+		<!--<TargetFrameworks>net60</TargetFrameworks>-->
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>CsvHelper</RootNamespace>
 		<DefaultLanguage>en-US</DefaultLanguage>

--- a/tests/CsvHelper.Tests/Parsing/DetectDelimiterTests.cs
+++ b/tests/CsvHelper.Tests/Parsing/DetectDelimiterTests.cs
@@ -180,6 +180,23 @@ namespace CsvHelper.Tests.Parsing
 			Assert.Equal(CultureInfo.InvariantCulture.TextInfo.ListSeparator, ConfigurationFunctions.GetDelimiter(new Delegates.GetDelimiterArgs(s.ToString(), config)));
 		}
 
+		/// <summary>
+		/// Ensure <see cref="IParserConfiguration.IgnoreCultureListSeparator"/> is respected by <see cref="ConfigurationFunctions.GetDelimiter(Delegates.GetDelimiterArgs)"/>
+		/// </summary>
+		[Fact]
+		public void GetDelimiter_CulturesSeparatorOccursLessButIsOnEveryLine_CanBeIgnored()
+		{
+			var s = new StringBuilder();
+			s.Append("1;2,3;4\r\n");
+			s.Append("5;6,7;8\r\n");
+			s.Append("9;10,11;12\r\n");
+			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				IgnoreCultureListSeparator = true
+			};
+			Assert.NotEqual(CultureInfo.InvariantCulture.TextInfo.ListSeparator, ConfigurationFunctions.GetDelimiter(new Delegates.GetDelimiterArgs(s.ToString(), config)));
+		}
+
 		[Fact]
 		public void GetDelimiter_CulturesSeparatorOccursLessAndIsOnFirstLine_CulturesSeparatorIsNotDetected()
 		{


### PR DESCRIPTION
Enable ignoring CultureInfo.TextInfo.ListSeparator in favor of highest frequency delimiter.

I have a use case where pipe delimited files are being delivered with fields that contain commas in every row. Nice edge case ;-)

To deal with this use case:

- Extended `IParserConfiguration` and `CsvConfiguration` to include a `bool IgnoreCultureListSeparator`
- Extended `ConfigurationFunctions` to ignore the `CultureListSeparator` check if `IgnoreCultureListSeparator` is true
- Create a corresponding test `GetDelimiter_CulturesSeparatorOccursLessButIsOnEveryLine_CanBeIgnored`

Default behaviors remain the same; all tests pass.