### PR TITLE
Fix build break on .NET Framework

### DIFF
--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -14,7 +14,6 @@ using CsvHelper.Expressions;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Configuration;
 
 namespace CsvHelper
 {


### PR DESCRIPTION
Introduced by 9d0ed68

| Severity | Code | Description | Project | File | Line |
| --- | --- | --- | --- | --- | --- |
| Error | CS0104 | 'ConfigurationException' is an ambiguous reference between 'CsvHelper.Configuration.ConfigurationException' and 'System.Configuration.ConfigurationException' | CsvHelper (net45), CsvHelper (net47) | CsvHelper\src\CsvHelper\CsvReader.cs | 91 |

https://github.com/JoshClose/CsvHelper/blob/9848510ed0fc0980bda687882c5ea123b7d7d3ce/src/CsvHelper/CsvReader.cs#L91
