### PR TITLE
Fix remaining nullable warnings

### DIFF
--- a/src/CsvHelper/Configuration/ClassMapCollection.cs
+++ b/src/CsvHelper/Configuration/ClassMapCollection.cs
@@ -4,6 +4,7 @@
 // https://github.com/JoshClose/CsvHelper
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 
@@ -114,12 +115,14 @@ namespace CsvHelper.Configuration
 		/// <returns>The type that is CsvClassMap{}.</returns>
 		private Type GetGenericCsvClassMapType(Type type)
 		{
+			Debug.Assert(typeof(ClassMap).IsAssignableFrom(type));
+
 			if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(ClassMap<>))
 			{
 				return type;
 			}
 
-			return GetGenericCsvClassMapType(type.GetTypeInfo().BaseType);
+			return GetGenericCsvClassMapType(type.GetTypeInfo().BaseType!);
 		}
 
 		/// <summary>
@@ -150,6 +153,9 @@ namespace CsvHelper.Configuration
 
 					if (parameterMap.Data.Names.Count == 0)
 					{
+						Debug.Assert(parameterMap.Data.Parameter.Name != null, $"{nameof(ParameterInfo)}.{nameof(ParameterInfo.Name)} should not be null unless it has come from" +
+							$" {nameof(MethodInfo)}.{nameof(MethodInfo.ReturnParameter)}, which we are not expecting to have been used");
+
 						parameterMap.Data.Names.Add(parameterMap.Data.Parameter.Name);
 					}
 				}

--- a/src/CsvHelper/Configuration/ConfigurationFunctions.cs
+++ b/src/CsvHelper/Configuration/ConfigurationFunctions.cs
@@ -33,7 +33,7 @@ namespace CsvHelper.Configuration
 				errorMessage.AppendLine($"Header with name '{string.Join("' or '", invalidHeader.Names)}'[{invalidHeader.Index}] was not found.");
 			}
 
-			if (args.Context.Reader.HeaderRecord != null)
+			if (args.Context.Reader?.HeaderRecord != null)
 			{
 				foreach (var header in args.Context.Reader.HeaderRecord)
 				{
@@ -163,7 +163,7 @@ namespace CsvHelper.Configuration
 		/// <param name="args">The args.</param>
 		public static string GetDynamicPropertyName(GetDynamicPropertyNameArgs args)
 		{
-			if (args.Context.Reader.HeaderRecord == null)
+			if (args.Context.Reader?.HeaderRecord == null)
 			{
 				return $"Field{args.FieldIndex + 1}";
 			}

--- a/src/CsvHelper/Configuration/IReaderConfiguration.cs
+++ b/src/CsvHelper/Configuration/IReaderConfiguration.cs
@@ -92,7 +92,7 @@ namespace CsvHelper.Configuration
 		/// <summary>
 		/// Gets a callback that will return the prefix for a reference header.
 		/// </summary>
-		ReferenceHeaderPrefix ReferenceHeaderPrefix { get; }
+		ReferenceHeaderPrefix? ReferenceHeaderPrefix { get; }
 
 		/// <summary>
 		/// Gets a value indicating whether changes in the column

--- a/src/CsvHelper/Configuration/IWriterConfiguration.cs
+++ b/src/CsvHelper/Configuration/IWriterConfiguration.cs
@@ -127,7 +127,7 @@ namespace CsvHelper.Configuration
 		/// <summary>
 		/// Gets a callback that will return the prefix for a reference header.
 		/// </summary>
-		ReferenceHeaderPrefix ReferenceHeaderPrefix { get; }
+		ReferenceHeaderPrefix? ReferenceHeaderPrefix { get; }
 
 		/// <summary>
 		/// Gets the member types that are used when auto mapping.
@@ -151,7 +151,7 @@ namespace CsvHelper.Configuration
 		/// which will preserve the order the object properties
 		/// were created with.
 		/// </summary>
-		IComparer<string> DynamicPropertySort { get; }
+		IComparer<string>? DynamicPropertySort { get; }
 
 		/// <summary>
 		/// A value indicating if exception messages contain raw CSV data.

--- a/src/CsvHelper/Configuration/MemberMap.cs
+++ b/src/CsvHelper/Configuration/MemberMap.cs
@@ -28,6 +28,18 @@ namespace CsvHelper.Configuration
 		public virtual MemberMapTypeConverterOption TypeConverterOption { get; protected set; }
 
 		/// <summary>
+		/// Creates a new <see cref="MemberMap"/> instance using the specified <see cref="MemberMapData"/>
+		/// and optionally, a <see cref="MemberMapTypeConverterOption"/> instance.
+		/// If <paramref name="typeConverterOption"/> is not specified or is <see langword="null"/>,
+		/// a new instance will be created.
+		/// </summary>
+		protected MemberMap(MemberMapData data, MemberMapTypeConverterOption? typeConverterOption = null)
+		{
+			Data = data;
+			TypeConverterOption = typeConverterOption ?? new MemberMapTypeConverterOption(this);
+		}
+
+		/// <summary>
 		/// Creates an instance of <see cref="MemberMap"/> using the given Type and <see cref="MemberInfo"/>.
 		/// </summary>
 		/// <param name="classType">Type of the class the member being mapped belongs to.</param>

--- a/src/CsvHelper/Configuration/MemberMapCollection.cs
+++ b/src/CsvHelper/Configuration/MemberMapCollection.cs
@@ -221,8 +221,8 @@ namespace CsvHelper.Configuration
 			   m.Data.Member != null &&
 			   m.Data.Member.Name == member.Name &&
 			   (
-				   m.Data.Member.DeclaringType.IsAssignableFrom(member.DeclaringType) ||
-				   member.DeclaringType.IsAssignableFrom(m.Data.Member.DeclaringType)
+				   m.Data.Member.DeclaringType?.IsAssignableFrom(member.DeclaringType) == true ||
+				   member.DeclaringType?.IsAssignableFrom(m.Data.Member.DeclaringType) == true
 			   )
 			);
 

--- a/src/CsvHelper/Configuration/MemberMapComparer.cs
+++ b/src/CsvHelper/Configuration/MemberMapComparer.cs
@@ -57,7 +57,7 @@ namespace CsvHelper.Configuration
 		/// <param name="x">The first object to compare.
 		///                 </param><param name="y">The second object to compare.
 		///                 </param>
-		public virtual int Compare( MemberMap x, MemberMap y )
+		public virtual int Compare( MemberMap? x, MemberMap? y )
 		{
 			if( x == null )
 			{

--- a/src/CsvHelper/Configuration/MemberMapData.cs
+++ b/src/CsvHelper/Configuration/MemberMapData.cs
@@ -132,23 +132,23 @@ namespace CsvHelper.Configuration
 		/// Gets or sets the expression used to convert data in the
 		/// row to the member.
 		/// </summary>
-		public virtual Expression ReadingConvertExpression { get; set; }
+		public virtual Expression? ReadingConvertExpression { get; set; }
 
 		/// <summary>
 		/// Gets or sets the expression to be used to convert the object
 		/// to a field.
 		/// </summary>
-		public virtual Expression WritingConvertExpression { get; set; }
+		public virtual Expression? WritingConvertExpression { get; set; }
 
 		/// <summary>
 		/// Gets or sets the expression use to validate a field.
 		/// </summary>
-		public virtual Expression ValidateExpression { get; set; }
+		public virtual Expression? ValidateExpression { get; set; }
 
 		/// <summary>
 		/// Gets or sets the expression used to get the validation message when validation fails.
 		/// </summary>
-		public virtual Expression ValidateMessageExpression { get; set; }
+		public virtual Expression? ValidateMessageExpression { get; set; }
 
 		/// <summary>
 		/// Gets or sets a value indicating if a field is optional.

--- a/src/CsvHelper/Configuration/MemberMap`1.cs
+++ b/src/CsvHelper/Configuration/MemberMap`1.cs
@@ -18,11 +18,8 @@ namespace CsvHelper.Configuration
 		/// <summary>
 		/// Creates a new <see cref="MemberMap"/> instance using the specified member.
 		/// </summary>
-		public MemberMap(MemberInfo? member)
+		public MemberMap(MemberInfo? member) : base(new MemberMapData(member))
 		{
-			TypeConverterOption = new MemberMapTypeConverterOption(this);
-
-			Data = new MemberMapData(member);
 		}
 
 		/// <summary>
@@ -146,7 +143,7 @@ namespace CsvHelper.Configuration
 		/// what other mapping configurations are specified.
 		/// </summary>
 		/// <param name="constantValue">The constant value.</param>
-		public virtual MemberMap<TClass, TMember> Constant(TMember? constantValue)
+		public virtual MemberMap<TClass, TMember> Constant(TMember constantValue)
 		{
 			Data.Constant = constantValue;
 			Data.IsConstantSet = true;

--- a/src/CsvHelper/Configuration/MemberNameCollection.cs
+++ b/src/CsvHelper/Configuration/MemberNameCollection.cs
@@ -29,7 +29,7 @@ namespace CsvHelper.Configuration
 		/// <summary>
 		/// Gets the prefix to use for each name.
 		/// </summary>
-		public string Prefix { get; set; }
+		public string? Prefix { get; set; }
 
 		/// <summary>
 		/// Gets the raw list of names without

--- a/src/CsvHelper/Configuration/MemberReferenceMapCollection.cs
+++ b/src/CsvHelper/Configuration/MemberReferenceMapCollection.cs
@@ -153,8 +153,8 @@ namespace CsvHelper.Configuration
 				m.Data.Member == member ||
 				m.Data.Member.Name == member.Name &&
 				(
-					m.Data.Member.DeclaringType.IsAssignableFrom(member.DeclaringType) ||
-					member.DeclaringType.IsAssignableFrom(m.Data.Member.DeclaringType)
+					m.Data.Member.DeclaringType?.IsAssignableFrom(member.DeclaringType) == true ||
+					member.DeclaringType?.IsAssignableFrom(m.Data.Member.DeclaringType) == true
 				)
 			);
 

--- a/src/CsvHelper/Configuration/MemberReferenceMapData.cs
+++ b/src/CsvHelper/Configuration/MemberReferenceMapData.cs
@@ -11,12 +11,12 @@ namespace CsvHelper.Configuration
 	/// </summary>
 	public class MemberReferenceMapData
 	{
-		private string prefix;
+		private string? prefix;
 
 		/// <summary>
 		/// Gets or sets the header prefix to use.
 		/// </summary>
-		public virtual string Prefix
+		public virtual string? Prefix
 		{
 			get { return prefix; }
 			set

--- a/src/CsvHelper/Configuration/ParameterMap.cs
+++ b/src/CsvHelper/Configuration/ParameterMap.cs
@@ -30,12 +30,12 @@ namespace CsvHelper.Configuration
 		/// <summary>
 		/// Gets or sets the map for a constructor type.
 		/// </summary>
-		public virtual ClassMap ConstructorTypeMap { get; set; }
+		public virtual ClassMap? ConstructorTypeMap { get; set; }
 
 		/// <summary>
 		/// Gets or sets the map for a reference type.
 		/// </summary>
-		public virtual ParameterReferenceMap ReferenceMap { get; set; }
+		public virtual ParameterReferenceMap? ReferenceMap { get; set; }
 
 		/// <summary>
 		/// Creates an instance of <see cref="ParameterMap"/> using

--- a/src/CsvHelper/Configuration/ParameterMapData.cs
+++ b/src/CsvHelper/Configuration/ParameterMapData.cs
@@ -55,7 +55,7 @@ namespace CsvHelper.Configuration
 		/// <summary>
 		/// Gets or sets the type converter.
 		/// </summary>
-		public virtual ITypeConverter TypeConverter { get; set; }
+		public virtual ITypeConverter? TypeConverter { get; set; }
 
 		/// <summary>
 		/// Gets or sets the type converter options.

--- a/src/CsvHelper/Configuration/ParameterReferenceMap.cs
+++ b/src/CsvHelper/Configuration/ParameterReferenceMap.cs
@@ -40,7 +40,7 @@ namespace CsvHelper.Configuration
 		/// <param name="prefix">The prefix to be prepended to headers of each reference parameter.</param>
 		/// <param name="inherit">Inherit parent prefixes.</param>
 		/// <returns>The current <see cref="ParameterReferenceMap" /></returns>
-		public ParameterReferenceMap Prefix(string prefix = null, bool inherit = false)
+		public ParameterReferenceMap Prefix(string? prefix = null, bool inherit = false)
 		{
 			if (string.IsNullOrEmpty(prefix))
 			{

--- a/src/CsvHelper/Configuration/ParameterReferenceMapData.cs
+++ b/src/CsvHelper/Configuration/ParameterReferenceMapData.cs
@@ -13,12 +13,12 @@ namespace CsvHelper.Configuration
 	[DebuggerDisplay( "Prefix = {Prefix}, Parameter = {Parameter}" )]
 	public class ParameterReferenceMapData
 	{
-		private string prefix;
+		private string? prefix;
 
 		/// <summary>
 		/// Gets or sets the header prefix to use.
 		/// </summary>
-		public virtual string Prefix
+		public virtual string? Prefix
 		{
 			get { return prefix; }
 			set

--- a/src/CsvHelper/CsvContext.cs
+++ b/src/CsvHelper/CsvContext.cs
@@ -35,17 +35,17 @@ namespace CsvHelper
 		/// <summary>
 		/// Gets the parser.
 		/// </summary>
-		public IParser Parser { get; private set; }
+		public IParser? Parser { get; private set; }
 
 		/// <summary>
 		/// Gets the reader.
 		/// </summary>
-		public IReader Reader { get; internal set; }
+		public IReader? Reader { get; internal set; }
 
 		/// <summary>
 		/// Gets the writer.
 		/// </summary>
-		public IWriter Writer { get; internal set; }
+		public IWriter? Writer { get; internal set; }
 
 		/// <summary>
 		/// Gets the configuration.

--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -15,8 +15,9 @@
 		<DefaultLanguage>en-US</DefaultLanguage>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-        <!--<Nullable>enable</Nullable>
-        <WarningsAsErrors>nullable</WarningsAsErrors>-->
+		<Nullable>enable</Nullable>
+		<!-- This breaks .NET Framework and Standard builds due to not recognizing nullable attributes -->
+		<!--<WarningsAsErrors>nullable</WarningsAsErrors>-->
 
 		<!-- Sign -->
 		<SignAssembly>true</SignAssembly>

--- a/src/CsvHelper/CsvHelperException.cs
+++ b/src/CsvHelper/CsvHelperException.cs
@@ -15,12 +15,12 @@ namespace CsvHelper
 	public class CsvHelperException : Exception
 	{
 		[NonSerialized]
-		private readonly CsvContext context;
+		private readonly CsvContext? context;
 
 		/// <summary>
 		/// Gets the context.
 		/// </summary>
-		public CsvContext Context => context;
+		public CsvContext? Context => context;
 
 		/// <summary>
 		/// Initializes a new instance of the CsvHelperException class.

--- a/src/CsvHelper/CsvReader.cs
+++ b/src/CsvHelper/CsvReader.cs
@@ -14,7 +14,6 @@ using CsvHelper.Expressions;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Configuration;
 
 namespace CsvHelper
 {
@@ -148,12 +147,13 @@ namespace CsvHelper
 				throw new InvalidOperationException($"The header must be read before it can be validated.");
 			}
 
-			if (context.Maps[type] == null)
+			var map = context.Maps[type];
+
+			if (map == null)
 			{
-				context.Maps.Add(context.AutoMap(type));
+				context.Maps.Add(map = context.AutoMap(type));
 			}
 
-			var map = context.Maps[type];
 			var invalidHeaders = new List<InvalidHeader>();
 			ValidateHeader(map, invalidHeaders);
 
@@ -427,7 +427,7 @@ namespace CsvHelper
 
 			reusableMemberMapData.Index = index;
 			reusableMemberMapData.TypeConverter = converter;
-			if (!typeConverterOptionsCache.TryGetValue(type, out TypeConverterOptions typeConverterOptions))
+			if (!typeConverterOptionsCache.TryGetValue(type, out TypeConverterOptions? typeConverterOptions))
 			{
 				typeConverterOptions = TypeConverterOptions.Merge(new TypeConverterOptions { CultureInfo = cultureInfo }, context.TypeConverterOptionsCache.GetOptions(type));
 				typeConverterOptionsCache.Add(type, typeConverterOptions);
@@ -498,7 +498,7 @@ namespace CsvHelper
 				return default;
 			}
 
-			return (T)GetField(typeof(T), index, converter);
+			return (T?)GetField(typeof(T), index, converter);
 		}
 
 		/// <inheritdoc/>
@@ -743,7 +743,7 @@ namespace CsvHelper
 				}
 			}
 
-			T record;
+			T? record;
 			try
 			{
 				record = recordManager.Value.Create<T>();
@@ -803,7 +803,7 @@ namespace CsvHelper
 				}
 			}
 
-			object record;
+			object? record;
 			try
 			{
 				record = recordManager.Value.Create(type);
@@ -1125,7 +1125,7 @@ namespace CsvHelper
 			while (await ReadAsync().ConfigureAwait(false))
 			{
 				cancellationToken.ThrowIfCancellationRequested();
-				object record;
+				object? record;
 				try
 				{
 					record = recordManager.Value.Create(type);
@@ -1260,7 +1260,7 @@ namespace CsvHelper
 			}
 
 			// Check all possible names for this field.
-			string name = null;
+			string? name = null;
 			var i = 0;
 			foreach (var n in names)
 			{
@@ -1368,7 +1368,7 @@ namespace CsvHelper
 
 			// Free unmanaged resources (unmanaged objects) and override finalizer
 			// Set large fields to null
-			context = null;
+			context = null!;
 
 			disposed = true;
 		}

--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -44,7 +44,7 @@ namespace CsvHelper
 		private readonly char comment;
 		private readonly bool hasHeaderRecord;
 		private readonly bool includePrivateMembers;
-		private readonly IComparer<string> dynamicPropertySort;
+		private readonly IComparer<string>? dynamicPropertySort;
 		private readonly string delimiter;
 		private readonly bool leaveOpen;
 		private readonly string newLine;
@@ -65,10 +65,10 @@ namespace CsvHelper
 		private char[] buffer;
 		private int bufferSize;
 		private int bufferPosition;
-		private Type fieldType;
+		private Type? fieldType;
 
 		/// <inheritdoc/>
-		public virtual string[] HeaderRecord { get; private set; }
+		public virtual string[]? HeaderRecord { get; private set; }
 
 		/// <inheritdoc/>
 		public virtual int Row => row;
@@ -133,7 +133,7 @@ namespace CsvHelper
 		}
 
 		/// <inheritdoc/>
-		public virtual void WriteConvertedField(string field, Type fieldType)
+		public virtual void WriteConvertedField(string? field, Type fieldType)
 		{
 			this.fieldType = fieldType;
 
@@ -146,7 +146,7 @@ namespace CsvHelper
 		}
 
 		/// <inheritdoc/>
-		public virtual void WriteField(string field)
+		public virtual void WriteField(string? field)
 		{
 			if (field != null && (trimOptions & TrimOptions.Trim) == TrimOptions.Trim)
 			{
@@ -162,7 +162,7 @@ namespace CsvHelper
 		}
 
 		/// <inheritdoc/>
-		public virtual void WriteField(string field, bool shouldQuote)
+		public virtual void WriteField(string? field, bool shouldQuote)
 		{
 			if (mode == CsvMode.RFC4180)
 			{
@@ -215,7 +215,7 @@ namespace CsvHelper
 		{
 			var type = field == null ? typeof(string) : field.GetType();
 			reusableMemberMapData.TypeConverter = converter;
-			if (!typeConverterOptionsCache.TryGetValue(type, out TypeConverterOptions typeConverterOptions))
+			if (!typeConverterOptionsCache.TryGetValue(type, out TypeConverterOptions? typeConverterOptions))
 			{
 				typeConverterOptions = TypeConverterOptions.Merge(new TypeConverterOptions { CultureInfo = cultureInfo }, context.TypeConverterOptionsCache.GetOptions(type));
 				typeConverterOptionsCache.Add(type, typeConverterOptions);
@@ -261,13 +261,15 @@ namespace CsvHelper
 				return;
 			}
 
-			if (context.Maps[type] == null)
+			var map = context.Maps[type];
+
+			if (map == null)
 			{
-				context.Maps.Add(context.AutoMap(type));
+				context.Maps.Add(map = context.AutoMap(type));
 			}
 
 			var members = new MemberMapCollection();
-			members.AddMembers(context.Maps[type]);
+			members.AddMembers(map);
 
 			var headerRecord = new List<string>();
 
@@ -289,7 +291,7 @@ namespace CsvHelper
 					{
 						var header = member.Data.Names.FirstOrDefault();
 						WriteField(header);
-						headerRecord.Add(header);
+						headerRecord.Add(header ?? "");
 					}
 				}
 			}
@@ -583,7 +585,7 @@ namespace CsvHelper
 		public virtual Type GetTypeForRecord<T>(T record)
 		{
 			var type = typeof(T);
-			if (type == typeof(object))
+			if (type == typeof(object) && record != null)
 			{
 				type = record.GetType();
 			}
@@ -598,7 +600,7 @@ namespace CsvHelper
 		/// <returns>The sanitized field.</returns>
 		/// <exception cref="WriterException">Thrown when an injection character is found in the field.</exception>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		protected virtual string SanitizeForInjection(string field)
+		protected virtual string? SanitizeForInjection(string? field)
 		{
 			if (string.IsNullOrEmpty(field))
 			{
@@ -663,7 +665,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <param name="value">The value to write.</param>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		protected void WriteToBuffer(string value)
+		protected void WriteToBuffer(string? value)
 		{
 			var length = value?.Length ?? 0;
 
@@ -721,7 +723,7 @@ namespace CsvHelper
 			// Free unmanaged resources (unmanaged objects) and override finalizer
 			// Set large fields to null
 
-			buffer = null;
+			buffer = null!;
 
 			disposed = true;
 		}
@@ -757,7 +759,7 @@ namespace CsvHelper
 			// Free unmanaged resources (unmanaged objects) and override finalizer
 			// Set large fields to null
 
-			buffer = null;
+			buffer = null!;
 
 			disposed = true;
 		}

--- a/src/CsvHelper/Delegates/ShouldQuote.cs
+++ b/src/CsvHelper/Delegates/ShouldQuote.cs
@@ -23,7 +23,7 @@ namespace CsvHelper
 		/// <summary>
 		/// The field.
 		/// </summary>
-		public readonly string Field;
+		public readonly string? Field;
 
 		/// <summary>
 		/// The field type.
@@ -41,7 +41,7 @@ namespace CsvHelper
 		/// <param name="field">The field.</param>
 		/// <param name="fieldType">The field type.</param>
 		/// <param name="row">The row.</param>
-		public ShouldQuoteArgs(string field, Type fieldType, IWriterRow row)
+		public ShouldQuoteArgs(string? field, Type fieldType, IWriterRow row)
 		{
 			Field = field;
 			FieldType = fieldType;

--- a/src/CsvHelper/Expressions/DynamicRecordCreator.cs
+++ b/src/CsvHelper/Expressions/DynamicRecordCreator.cs
@@ -33,14 +33,14 @@ namespace CsvHelper.Expressions
 		protected virtual dynamic CreateDynamicRecord()
 		{
 			var obj = new ExpandoObject();
-			var dict = obj as IDictionary<string, object>;
+			var dict = obj as IDictionary<string, object?>;
 			if (Reader.HeaderRecord != null)
 			{
 				for (var i = 0; i < Reader.HeaderRecord.Length; i++)
 				{
 					var args = new GetDynamicPropertyNameArgs(i, Reader.Context);
 					var propertyName = Reader.Configuration.GetDynamicPropertyName(args);
-					Reader.TryGetField(i, out string field);
+					Reader.TryGetField(i, out string? field);
 					dict.Add(propertyName, field);
 				}
 			}

--- a/src/CsvHelper/Expressions/ExpandoObjectRecordWriter.cs
+++ b/src/CsvHelper/Expressions/ExpandoObjectRecordWriter.cs
@@ -4,6 +4,7 @@
 // https://github.com/JoshClose/CsvHelper
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 
 namespace CsvHelper.Expressions
@@ -29,6 +30,11 @@ namespace CsvHelper.Expressions
 		{
 			Action<T> action = r =>
 			{
+				if (!(r is ExpandoObject))
+				{
+					throw new ArgumentException($"Value is not an {nameof(ExpandoObject)}", nameof(record));
+				}
+
 				var dict = ((IDictionary<string, object>)r).AsEnumerable();
 
 				if (Writer.Configuration.DynamicPropertySort != null)

--- a/src/CsvHelper/Expressions/ObjectRecordCreator.cs
+++ b/src/CsvHelper/Expressions/ObjectRecordCreator.cs
@@ -27,12 +27,12 @@ namespace CsvHelper.Expressions
 		/// <param name="recordType">The record type.</param>
 		protected override Delegate CreateCreateRecordDelegate(Type recordType)
 		{
-			if (Reader.Context.Maps[recordType] == null)
-			{
-				Reader.Context.Maps.Add(Reader.Context.AutoMap(recordType));
-			}
-
 			var map = Reader.Context.Maps[recordType];
+
+			if (map == null)
+			{
+				Reader.Context.Maps.Add(map = Reader.Context.AutoMap(recordType));
+			}
 
 			Expression body;
 

--- a/src/CsvHelper/Expressions/PrimitiveRecordWriter.cs
+++ b/src/CsvHelper/Expressions/PrimitiveRecordWriter.cs
@@ -5,6 +5,7 @@
 using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
 using System;
+using System.Diagnostics;
 using System.Linq.Expressions;
 
 namespace CsvHelper.Expressions
@@ -37,6 +38,7 @@ namespace CsvHelper.Expressions
 			var typeConverter = Writer.Context.TypeConverterCache.GetConverter(type);
 			var typeConverterExpression = Expression.Constant(typeConverter);
 			var method = typeof(ITypeConverter).GetMethod(nameof(ITypeConverter.ConvertToString));
+			Debug.Assert(method != null, $"Missing method {nameof(ITypeConverter.ConvertToString)} on {nameof(ITypeConverter)}");
 
 			var memberMapData = new MemberMapData(null)
 			{

--- a/src/CsvHelper/Expressions/RecordCreator.cs
+++ b/src/CsvHelper/Expressions/RecordCreator.cs
@@ -88,7 +88,7 @@ namespace CsvHelper.Expressions
 		/// <param name="recordType">The record type.</param>
 		protected virtual Delegate GetCreateRecordDelegate(Type recordType)
 		{
-			if (!createRecordFuncs.TryGetValue(recordType, out Delegate func))
+			if (!createRecordFuncs.TryGetValue(recordType, out Delegate? func))
 			{
 				createRecordFuncs[recordType] = func = CreateCreateRecordDelegate(recordType);
 			}

--- a/src/CsvHelper/Expressions/RecordHydrator.cs
+++ b/src/CsvHelper/Expressions/RecordHydrator.cs
@@ -60,7 +60,7 @@ namespace CsvHelper.Expressions
 		{
 			var recordType = typeof(T);
 
-			if (!hydrateRecordActions.TryGetValue(recordType, out Delegate action))
+			if (!hydrateRecordActions.TryGetValue(recordType, out Delegate? action))
 			{
 				hydrateRecordActions[recordType] = action = CreateHydrateRecordAction<T>();
 			}
@@ -76,12 +76,12 @@ namespace CsvHelper.Expressions
 		{
 			var recordType = typeof(T);
 
-			if (reader.Context.Maps[recordType] == null)
-			{
-				reader.Context.Maps.Add(reader.Context.AutoMap(recordType));
-			}
-
 			var mapping = reader.Context.Maps[recordType];
+
+			if (mapping == null)
+			{
+				reader.Context.Maps.Add(mapping = reader.Context.AutoMap(recordType));
+			}
 
 			var recordTypeParameter = Expression.Parameter(recordType, "record");
 			var memberAssignments = new List<Expression>();

--- a/src/CsvHelper/Expressions/RecordManager.cs
+++ b/src/CsvHelper/Expressions/RecordManager.cs
@@ -3,6 +3,7 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CsvHelper.Expressions
 {
@@ -11,10 +12,9 @@ namespace CsvHelper.Expressions
 	/// </summary>
 	public class RecordManager
 	{
-		private readonly CsvReader reader;
-		private readonly RecordCreatorFactory recordCreatorFactory;
-		private readonly RecordHydrator recordHydrator;
-		private readonly RecordWriterFactory recordWriterFactory;
+		private readonly RecordCreatorFactory? recordCreatorFactory;
+		private readonly RecordHydrator? recordHydrator;
+		private readonly RecordWriterFactory? recordWriterFactory;
 
 		/// <summary>
 		/// Initializes a new instance using the given reader.
@@ -22,7 +22,6 @@ namespace CsvHelper.Expressions
 		/// <param name="reader"></param>
 		public RecordManager(CsvReader reader)
 		{
-			this.reader = reader;
 			recordCreatorFactory = ObjectResolver.Current.Resolve<RecordCreatorFactory>(reader);
 			recordHydrator = ObjectResolver.Current.Resolve<RecordHydrator>(reader);
 		}
@@ -42,6 +41,7 @@ namespace CsvHelper.Expressions
 		/// <typeparam name="T">The type of record to create.</typeparam>
 		public T Create<T>()
 		{
+			CheckHaveCreator();
 			var recordCreator = recordCreatorFactory.MakeRecordCreator(typeof(T));
 			return recordCreator.Create<T>();
 		}
@@ -52,6 +52,7 @@ namespace CsvHelper.Expressions
 		/// <param name="recordType">The type of record to create.</param>
 		public object? Create(Type recordType)
 		{
+			CheckHaveCreator();
 			var recordCreator = recordCreatorFactory.MakeRecordCreator(recordType);
 			return recordCreator.Create(recordType);
 		}
@@ -63,6 +64,7 @@ namespace CsvHelper.Expressions
 		/// <param name="record">The record to hydrate.</param>
 		public void Hydrate<T>(T record)
 		{
+			CheckHaveHydrator();
 			recordHydrator.Hydrate(record);
 		}
 
@@ -73,8 +75,57 @@ namespace CsvHelper.Expressions
 		/// <param name="record">The record.</param>
 		public void Write<T>(T record)
 		{
+			CheckHaveWriter();
 			var recordWriter = recordWriterFactory.MakeRecordWriter(record);
 			recordWriter.Write(record);
+		}
+
+		[MemberNotNull(nameof(recordCreatorFactory))]
+		private void CheckHaveCreator()
+		{
+			if (recordCreatorFactory == null)
+			{
+				ThrowNoCreator();
+			}
+		}
+
+		[DoesNotReturn]
+		private static void ThrowNoCreator()
+		{
+			throw new InvalidOperationException($"Do not have a {nameof(RecordCreatorFactory)} instance. This is a method intended " +
+					$"to be called by a {nameof(RecordManager)} initialized with a {nameof(CsvReader)}");
+		}
+
+		[MemberNotNull(nameof(recordHydrator))]
+		private void CheckHaveHydrator()
+		{
+			if (recordHydrator == null)
+			{
+				ThrowNoHydrator();
+			}
+		}
+
+		[DoesNotReturn]
+		private static void ThrowNoHydrator()
+		{
+			throw new InvalidOperationException($"Do not have a {nameof(RecordHydrator)} instance. This is a method intended " +
+					$"to be called by a {nameof(RecordManager)} initialized with a {nameof(CsvReader)}");
+		}
+
+		[MemberNotNull(nameof(recordWriterFactory))]
+		private void CheckHaveWriter()
+		{
+			if (recordWriterFactory == null)
+			{
+				ThrowNoWriter();
+			}
+		}
+
+		[DoesNotReturn]
+		private static void ThrowNoWriter()
+		{
+			throw new InvalidOperationException($"Do not have a {nameof(RecordWriterFactory)} instance. This is a method intended " +
+					$"to be called by a {nameof(RecordManager)} initialized with a {nameof(CsvWriter)}");
 		}
 	}
 }

--- a/src/CsvHelper/Expressions/RecordWriter.cs
+++ b/src/CsvHelper/Expressions/RecordWriter.cs
@@ -4,6 +4,7 @@
 // https://github.com/JoshClose/CsvHelper
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 
@@ -70,7 +71,11 @@ namespace CsvHelper.Expressions
 		{
 			var type = typeof(T);
 			var typeKeyName = type.AssemblyQualifiedName;
-			if (type == typeof(object))
+
+			Debug.Assert(!type.IsGenericParameter && typeKeyName != null,
+				$"{nameof(Type.AssemblyQualifiedName)} should only be null if the type represents a generic parameter, which it should not here");
+
+			if (type == typeof(object) && record != null)
 			{
 				type = record.GetType();
 				typeKeyName += $"|{type.AssemblyQualifiedName}";
@@ -78,7 +83,7 @@ namespace CsvHelper.Expressions
 
 			int typeKey = typeKeyName.GetHashCode();
 
-			if (!typeActions.TryGetValue(typeKey, out Delegate action))
+			if (!typeActions.TryGetValue(typeKey, out Delegate? action))
 			{
 				typeActions[typeKey] = action = CreateWriteDelegate(record);
 			}
@@ -101,9 +106,9 @@ namespace CsvHelper.Expressions
 		/// </summary>
 		/// <param name="delegates">The delegates to combine.</param>
 		/// <returns>A multicast delegate combined from the given delegates.</returns>
-		protected virtual Action<T> CombineDelegates<T>(IEnumerable<Action<T>> delegates)
+		protected virtual Action<T>? CombineDelegates<T>(IEnumerable<Action<T>> delegates)
 		{
-			return (Action<T>)delegates.Aggregate<Delegate, Delegate>(null, Delegate.Combine);
+			return (Action<T>?)delegates.Aggregate<Delegate?, Delegate?>(null, Delegate.Combine);
 		}
 	}
 }

--- a/src/CsvHelper/IReader.cs
+++ b/src/CsvHelper/IReader.cs
@@ -63,7 +63,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <param name="type">The <see cref="Type"/> of the record.</param>
 		/// <returns>An <see cref="IEnumerable{Object}" /> of records.</returns>
-		IEnumerable<object> GetRecords(Type type);
+		IEnumerable<object?> GetRecords(Type type);
 
 		/// <summary>
 		/// Enumerates the records hydrating the given record instance with row data.
@@ -107,7 +107,7 @@ namespace CsvHelper
 		/// <param name="type">The <see cref="Type"/> of the record.</param>
 		/// <param name="cancellationToken">The cancellation token to stop the writing.</param>
 		/// <returns>An <see cref="IAsyncEnumerable{Object}" /> of records.</returns>
-		IAsyncEnumerable<object> GetRecordsAsync(Type type, CancellationToken cancellationToken = default(CancellationToken));
+		IAsyncEnumerable<object?> GetRecordsAsync(Type type, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
 		/// Enumerates the records hydrating the given record instance with row data.

--- a/src/CsvHelper/IWriterRow.cs
+++ b/src/CsvHelper/IWriterRow.cs
@@ -16,7 +16,7 @@ namespace CsvHelper
 		/// <summary>
 		/// The header record.
 		/// </summary>
-		string[] HeaderRecord { get; }
+		string[]? HeaderRecord { get; }
 
 		/// <summary>
 		/// The current row.
@@ -48,7 +48,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <param name="field">The converted field to write.</param>
 		/// <param name="fieldType">The type of the field before it was converted into a string.</param>
-		void WriteConvertedField(string field, Type fieldType);
+		void WriteConvertedField(string? field, Type fieldType);
 
 		/// <summary>
 		/// Writes the field to the CSV file. The field
@@ -58,7 +58,7 @@ namespace CsvHelper
 		/// to complete writing of the current record.
 		/// </summary>
 		/// <param name="field">The field to write.</param>
-		void WriteField(string field);
+		void WriteField(string? field);
 
 		/// <summary>
 		/// Writes the field to the CSV file. This will
@@ -72,7 +72,7 @@ namespace CsvHelper
 		/// </summary>
 		/// <param name="field">The field to write.</param>
 		/// <param name="shouldQuote">True to quote the field, otherwise false.</param>
-		void WriteField(string field, bool shouldQuote);
+		void WriteField(string? field, bool shouldQuote);
 
 		/// <summary>
 		/// Writes the field to the CSV file.

--- a/src/CsvHelper/NullableAttributes.cs
+++ b/src/CsvHelper/NullableAttributes.cs
@@ -1,0 +1,59 @@
+﻿#if NET45 || NET47 || NETSTANDARD2_0
+namespace System.Diagnostics.CodeAnalysis
+{
+	[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+	internal sealed class NotNullWhenAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified return value condition.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter will not be null.
+		/// </param>
+		public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+		/// <summary>Gets the return value condition.</summary>
+		public bool ReturnValue { get; }
+	}
+
+	[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+	internal sealed class MaybeNullWhenAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified return value condition.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter may be null.
+		/// </param>
+		public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+		/// <summary>Gets the return value condition.</summary>
+		public bool ReturnValue { get; }
+	}
+
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+	internal sealed class NotNullAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+	internal sealed class DoesNotReturnAttribute : Attribute { }
+}
+#endif
+#if NET45 || NET47 || NETSTANDARD2_0 || NETSTANDARD2_1
+namespace System.Diagnostics.CodeAnalysis
+{
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+	internal sealed class MemberNotNullAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with a field or property member.</summary>
+		/// <param name="member">
+		/// The field or property member that is promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+		/// <summary>Initializes the attribute with the list of field and property members.</summary>
+		/// <param name="members">
+		/// The list of field and property members that are promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute(params string[] members) => Members = members;
+
+		/// <summary>Gets field or property member names.</summary>
+		public string[] Members { get; }
+	}
+}
+#endif

--- a/src/CsvHelper/ReflectionExtensions.cs
+++ b/src/CsvHelper/ReflectionExtensions.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CsvHelper
 {
@@ -21,16 +22,14 @@ namespace CsvHelper
 		/// <param name="member">The member to get the type from.</param>
 		/// <returns>The type.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Type MemberType(this MemberInfo member)
+		public static Type MemberType([NotNull] this MemberInfo? member)
 		{
-			var property = member as PropertyInfo;
-			if (property != null)
+			if (member is PropertyInfo property)
 			{
 				return property.PropertyType;
 			}
 
-			var field = member as FieldInfo;
-			if (field != null)
+			if (member is FieldInfo field)
 			{
 				return field.FieldType;
 			}

--- a/src/CsvHelper/TypeConversion/BooleanConverter.cs
+++ b/src/CsvHelper/TypeConversion/BooleanConverter.cs
@@ -36,7 +36,7 @@ namespace CsvHelper.TypeConversion
 			var t = (text ?? string.Empty).Trim();
 			foreach (var trueValue in memberMapData.TypeConverterOptions.BooleanTrueValues)
 			{
-				if (memberMapData.TypeConverterOptions.CultureInfo.CompareInfo.Compare(trueValue, t, CompareOptions.IgnoreCase) == 0)
+				if (memberMapData.TypeConverterOptions.CultureInfo?.CompareInfo.Compare(trueValue, t, CompareOptions.IgnoreCase) == 0)
 				{
 					return true;
 				}
@@ -44,7 +44,7 @@ namespace CsvHelper.TypeConversion
 
 			foreach (var falseValue in memberMapData.TypeConverterOptions.BooleanFalseValues)
 			{
-				if (memberMapData.TypeConverterOptions.CultureInfo.CompareInfo.Compare(falseValue, t, CompareOptions.IgnoreCase) == 0)
+				if (memberMapData.TypeConverterOptions.CultureInfo?.CompareInfo.Compare(falseValue, t, CompareOptions.IgnoreCase) == 0)
 				{
 					return false;
 				}

--- a/src/CsvHelper/TypeConversion/CollectionGenericConverter.cs
+++ b/src/CsvHelper/TypeConversion/CollectionGenericConverter.cs
@@ -32,16 +32,19 @@ namespace CsvHelper.TypeConversion
 			if (memberMapData.IsNameSet || row.Configuration.HasHeaderRecord && !memberMapData.IsIndexSet)
 			{
 				// Use the name.
-				var nameIndex = 0;
-				while (true)
+				foreach (string name in memberMapData.Names)
 				{
-					if (!row.TryGetField(type, memberMapData.Names.FirstOrDefault(), nameIndex, out var field))
+					var nameIndex = 0;
+					while (true)
 					{
-						break;
-					}
+						if (!row.TryGetField(type, name, nameIndex, out var field))
+						{
+							break;
+						}
 
-					list.Add(field);
-					nameIndex++;
+						list.Add(field);
+						nameIndex++;
+					}
 				}
 			}
 			else

--- a/src/CsvHelper/TypeConversion/DateOnlyConverter.cs
+++ b/src/CsvHelper/TypeConversion/DateOnlyConverter.cs
@@ -28,7 +28,7 @@ namespace CsvHelper.TypeConversion
 				return base.ConvertFromString(null, row, memberMapData);
 			}
 
-			var formatProvider = (IFormatProvider)memberMapData.TypeConverterOptions.CultureInfo.GetFormat(typeof(DateTimeFormatInfo)) ?? memberMapData.TypeConverterOptions.CultureInfo;
+			var formatProvider = (IFormatProvider?)memberMapData.TypeConverterOptions.CultureInfo?.GetFormat(typeof(DateTimeFormatInfo)) ?? memberMapData.TypeConverterOptions.CultureInfo;
 			var dateTimeStyle = memberMapData.TypeConverterOptions.DateTimeStyle ?? DateTimeStyles.None;
 
 			return memberMapData.TypeConverterOptions.Formats == null || memberMapData.TypeConverterOptions.Formats.Length == 0

--- a/src/CsvHelper/TypeConversion/DateTimeConverter.cs
+++ b/src/CsvHelper/TypeConversion/DateTimeConverter.cs
@@ -27,7 +27,7 @@ namespace CsvHelper.TypeConversion
 				return base.ConvertFromString(null, row, memberMapData);
 			}
 
-			var formatProvider = (IFormatProvider)memberMapData.TypeConverterOptions.CultureInfo.GetFormat(typeof(DateTimeFormatInfo)) ?? memberMapData.TypeConverterOptions.CultureInfo;
+			var formatProvider = (IFormatProvider?)memberMapData.TypeConverterOptions.CultureInfo?.GetFormat(typeof(DateTimeFormatInfo)) ?? memberMapData.TypeConverterOptions.CultureInfo;
 			var dateTimeStyle = memberMapData.TypeConverterOptions.DateTimeStyle ?? DateTimeStyles.None;
 
 			DateTime dateTime;

--- a/src/CsvHelper/TypeConversion/DateTimeOffsetConverter.cs
+++ b/src/CsvHelper/TypeConversion/DateTimeOffsetConverter.cs
@@ -27,7 +27,7 @@ namespace CsvHelper.TypeConversion
 				return base.ConvertFromString(null, row, memberMapData);
 			}
 
-			var formatProvider = (IFormatProvider)memberMapData.TypeConverterOptions.CultureInfo.GetFormat(typeof(DateTimeFormatInfo)) ?? memberMapData.TypeConverterOptions.CultureInfo;
+			var formatProvider = (IFormatProvider?)memberMapData.TypeConverterOptions.CultureInfo?.GetFormat(typeof(DateTimeFormatInfo)) ?? memberMapData.TypeConverterOptions.CultureInfo;
 			var dateTimeStyle = memberMapData.TypeConverterOptions.DateTimeStyle ?? DateTimeStyles.None;
 
 			DateTimeOffset dateTimeOffset;

--- a/src/CsvHelper/TypeConversion/DefaultTypeConverter.cs
+++ b/src/CsvHelper/TypeConversion/DefaultTypeConverter.cs
@@ -56,7 +56,7 @@ namespace CsvHelper.TypeConversion
                 return formattable.ToString(format, memberMapData.TypeConverterOptions.CultureInfo);
             }
 
-            return value?.ToString() ?? string.Empty;
+            return value.ToString() ?? string.Empty;
         }
     }
 }

--- a/src/CsvHelper/TypeConversion/IDictionaryConverter.cs
+++ b/src/CsvHelper/TypeConversion/IDictionaryConverter.cs
@@ -2,6 +2,7 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using CsvHelper.Configuration;
@@ -45,7 +46,12 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
 		{
-			var dictionary = new Dictionary<string, string>();
+			if (row.HeaderRecord == null)
+			{
+				throw new InvalidOperationException($"Cannot convert string to IDictionary. {nameof(row)}.{nameof(row.HeaderRecord)} is null");
+			}
+
+			var dictionary = new Dictionary<string, string?>();
 
 			var indexEnd = memberMapData.IndexEnd < memberMapData.Index
 				? row.Parser.Count - 1
@@ -53,7 +59,7 @@ namespace CsvHelper.TypeConversion
 
 			for (var i = memberMapData.Index; i <= indexEnd; i++)
 			{
-				if (row.TryGetField(i, out string field))
+				if (row.TryGetField(i, out string? field))
 				{
 					dictionary.Add(row.HeaderRecord[i], field);
 				}

--- a/src/CsvHelper/TypeConversion/IDictionaryGenericConverter.cs
+++ b/src/CsvHelper/TypeConversion/IDictionaryGenericConverter.cs
@@ -2,6 +2,7 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using CsvHelper.Configuration;
@@ -22,6 +23,11 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
 		{
+			if (row.HeaderRecord == null)
+			{
+				throw new InvalidOperationException($"Cannot convert string to IDictionary. {nameof(row)}.{nameof(row.HeaderRecord)} is null");
+			}
+
 			var keyType = memberMapData.Member.MemberType().GetGenericArguments()[0];
 			var valueType = memberMapData.Member.MemberType().GetGenericArguments()[1];
 			var dictionaryType = typeof(Dictionary<,>);

--- a/src/CsvHelper/TypeConversion/IEnumerableConverter.cs
+++ b/src/CsvHelper/TypeConversion/IEnumerableConverter.cs
@@ -46,21 +46,24 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
 		{
-			var list = new List<string>();
+			var list = new List<string?>();
 
 			if (memberMapData.IsNameSet || row.Configuration.HasHeaderRecord && !memberMapData.IsIndexSet)
 			{
 				// Use the name.
-				var nameIndex = 0;
-				while (true)
+				foreach (string name in memberMapData.Names)
 				{
-					if (!row.TryGetField(memberMapData.Names.FirstOrDefault(), nameIndex, out string field))
+					var nameIndex = 0;
+					while (true)
 					{
-						break;
-					}
+						if (!row.TryGetField(name, nameIndex, out string? field))
+						{
+							break;
+						}
 
-					list.Add(field);
-					nameIndex++;
+						list.Add(field);
+						nameIndex++;
+					}
 				}
 			}
 			else
@@ -72,7 +75,7 @@ namespace CsvHelper.TypeConversion
 
 				for (var i = memberMapData.Index; i <= indexEnd; i++)
 				{
-					if (row.TryGetField(i, out string field))
+					if (row.TryGetField(i, out string? field))
 					{
 						list.Add(field);
 					}

--- a/src/CsvHelper/TypeConversion/IEnumerableGenericConverter.cs
+++ b/src/CsvHelper/TypeConversion/IEnumerableGenericConverter.cs
@@ -32,16 +32,19 @@ namespace CsvHelper.TypeConversion
 			if (memberMapData.IsNameSet || row.Configuration.HasHeaderRecord && !memberMapData.IsIndexSet)
 			{
 				// Use the name.
-				var nameIndex = 0;
-				while (true)
+				foreach (string name in memberMapData.Names)
 				{
-					if (!row.TryGetField(type, memberMapData.Names.FirstOrDefault(), nameIndex, out var field))
+					var nameIndex = 0;
+					while (true)
 					{
-						break;
-					}
+						if (!row.TryGetField(type, name, nameIndex, out var field))
+						{
+							break;
+						}
 
-					list.Add(field);
-					nameIndex++;
+						list.Add(field);
+						nameIndex++;
+					}
 				}
 			}
 			else

--- a/src/CsvHelper/TypeConversion/NullableConverter.cs
+++ b/src/CsvHelper/TypeConversion/NullableConverter.cs
@@ -45,12 +45,7 @@ namespace CsvHelper.TypeConversion
 		public NullableConverter(Type type, TypeConverterCache typeConverterFactory)
 		{
 			NullableType = type;
-			UnderlyingType = Nullable.GetUnderlyingType(type);
-			if (UnderlyingType == null)
-			{
-				throw new ArgumentException("type is not a nullable type.");
-			}
-
+			UnderlyingType = Nullable.GetUnderlyingType(type) ?? throw new ArgumentException("type is not a nullable type.", nameof(type));
 			UnderlyingTypeConverter = typeConverterFactory.GetConverter(UnderlyingType);
 		}
 

--- a/src/CsvHelper/TypeConversion/TimeOnlyConverter.cs
+++ b/src/CsvHelper/TypeConversion/TimeOnlyConverter.cs
@@ -28,7 +28,7 @@ namespace CsvHelper.TypeConversion
 				return base.ConvertFromString(null, row, memberMapData);
 			}
 
-			var formatProvider = (IFormatProvider)memberMapData.TypeConverterOptions.CultureInfo.GetFormat(typeof(DateTimeFormatInfo)) ?? memberMapData.TypeConverterOptions.CultureInfo;
+			var formatProvider = (IFormatProvider?)memberMapData.TypeConverterOptions.CultureInfo?.GetFormat(typeof(DateTimeFormatInfo)) ?? memberMapData.TypeConverterOptions.CultureInfo;
 			var dateTimeStyle = memberMapData.TypeConverterOptions.DateTimeStyle ?? DateTimeStyles.None;
 
 			return memberMapData.TypeConverterOptions.Formats == null || memberMapData.TypeConverterOptions.Formats.Length == 0

--- a/src/CsvHelper/TypeConversion/TimeSpanConverter.cs
+++ b/src/CsvHelper/TypeConversion/TimeSpanConverter.cs
@@ -22,7 +22,7 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
 		{
-			var formatProvider = (IFormatProvider)memberMapData.TypeConverterOptions.CultureInfo;
+			var formatProvider = (IFormatProvider?)memberMapData.TypeConverterOptions.CultureInfo;
 
 			var timeSpanStyle = memberMapData.TypeConverterOptions.TimeSpanStyle ?? TimeSpanStyles.None;
 			if (memberMapData.TypeConverterOptions.Formats != null && TimeSpan.TryParseExact(text, memberMapData.TypeConverterOptions.Formats, formatProvider, timeSpanStyle, out var span))

--- a/src/CsvHelper/TypeConversion/TypeConverterCache.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterCache.cs
@@ -151,7 +151,7 @@ namespace CsvHelper.TypeConversion
 				throw new ArgumentNullException(nameof(type));
 			}
 
-			if (typeConverters.TryGetValue(type, out ITypeConverter typeConverter))
+			if (typeConverters.TryGetValue(type, out ITypeConverter? typeConverter))
 			{
 				return typeConverter;
 			}

--- a/src/CsvHelper/TypeConversion/TypeConverterException.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterException.cs
@@ -16,12 +16,12 @@ namespace CsvHelper.TypeConversion
 		/// <summary>
 		/// The text used in ConvertFromString.
 		/// </summary>
-		public string Text { get; private set; }
+		public string? Text { get; private set; }
 
 		/// <summary>
 		/// The value used in ConvertToString.
 		/// </summary>
-		public object Value { get; private set; }
+		public object? Value { get; private set; }
 
 		/// <summary>
 		/// The type converter.
@@ -40,7 +40,7 @@ namespace CsvHelper.TypeConversion
 		/// <param name="memberMapData">The member map data.</param>
 		/// <param name="text">The text.</param>
 		/// <param name="context">The reading context.</param>
-		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, string text, CsvContext context) : base(context)
+		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, string? text, CsvContext context) : base(context)
 		{
 			TypeConverter = typeConverter;
 			MemberMapData = memberMapData;
@@ -54,7 +54,7 @@ namespace CsvHelper.TypeConversion
 		/// <param name="memberMapData">The member map data.</param>
 		/// <param name="value">The value.</param>
 		/// <param name="context">The writing context.</param>
-		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, object value, CsvContext context) : base(context)
+		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, object? value, CsvContext context) : base(context)
 		{
 			TypeConverter = typeConverter;
 			MemberMapData = memberMapData;
@@ -70,7 +70,7 @@ namespace CsvHelper.TypeConversion
 		/// <param name="text">The text.</param>
 		/// <param name="context">The reading context.</param>
 		/// <param name="message">The message that describes the error.</param>
-		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, string text, CsvContext context, string message) : base(context, message)
+		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, string? text, CsvContext context, string message) : base(context, message)
 		{
 			TypeConverter = typeConverter;
 			MemberMapData = memberMapData;
@@ -86,7 +86,7 @@ namespace CsvHelper.TypeConversion
 		/// <param name="value">The value.</param>
 		/// <param name="context">The writing context.</param>
 		/// <param name="message">The message that describes the error.</param>
-		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, object value, CsvContext context, string message) : base(context, message)
+		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, object? value, CsvContext context, string message) : base(context, message)
 		{
 			TypeConverter = typeConverter;
 			MemberMapData = memberMapData;
@@ -104,7 +104,7 @@ namespace CsvHelper.TypeConversion
 		/// <param name="context">The reading context.</param>
 		/// <param name="message">The error message that explains the reason for the exception.</param>
 		/// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
-		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, string text, CsvContext context, string message, Exception innerException) : base(context, message, innerException)
+		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, string? text, CsvContext context, string message, Exception innerException) : base(context, message, innerException)
 		{
 			TypeConverter = typeConverter;
 			MemberMapData = memberMapData;
@@ -122,7 +122,7 @@ namespace CsvHelper.TypeConversion
 		/// <param name="context">The writing context.</param>
 		/// <param name="message">The error message that explains the reason for the exception.</param>
 		/// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
-		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, object value, CsvContext context, string message, Exception innerException) : base(context, message, innerException)
+		public TypeConverterException(ITypeConverter typeConverter, MemberMapData memberMapData, object? value, CsvContext context, string message, Exception innerException) : base(context, message, innerException)
 		{
 			TypeConverter = typeConverter;
 			MemberMapData = memberMapData;

--- a/src/CsvHelper/TypeConversion/TypeConverterOptions.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterOptions.cs
@@ -21,7 +21,7 @@ namespace CsvHelper.TypeConversion
 		/// <summary>
 		/// Gets or sets the culture info.
 		/// </summary>
-		public CultureInfo CultureInfo { get; set; }
+		public CultureInfo? CultureInfo { get; set; }
 
 		/// <summary>
 		/// Gets or sets the date time style.
@@ -41,7 +41,7 @@ namespace CsvHelper.TypeConversion
 		/// <summary>
 		/// Gets or sets the string format.
 		/// </summary>
-		public string[] Formats { get; set; }
+		public string[]? Formats { get; set; }
 
 		/// <summary>
 		/// Gets or sets the <see cref="UriKind"/>.
@@ -71,21 +71,25 @@ namespace CsvHelper.TypeConversion
 		public List<string> NullValues { get; } = new List<string>(defaultNullValues);
 
 		/// <summary>
-		/// Merges TypeConverterOptions by applying the values of sources in order on to each other.
-		/// The first object is the source object.
+		/// Merges <see cref="TypeConverterOptions"/> by applying the values of <paramref name="sources"/>
+		/// in order on to <paramref name="options"/>.
 		/// </summary>
+		/// <param name="options">The <see cref="TypeConverterOptions"/> value to mutate</param>
 		/// <param name="sources">The sources that will be applied.</param>
-		/// <returns>The updated source object.</returns>
-		public static TypeConverterOptions? Merge(params TypeConverterOptions[] sources)
+		/// <returns>The mutated <paramref name="options"/> object.</returns>
+		public static TypeConverterOptions Merge(TypeConverterOptions options, params TypeConverterOptions[] sources)
 		{
-			if (sources == null || sources.Length == 0)
+			if (options is null)
 			{
-				return null;
+				throw new ArgumentNullException(nameof(options));
 			}
 
-			var options = sources[0];
+			if (sources is null)
+			{
+				throw new ArgumentNullException(nameof(sources));
+			}
 
-			for (var i = 1; i < sources.Length; i++)
+			for (var i = 0; i < sources.Length; i++)
 			{
 				var source = sources[i];
 

--- a/tests/CsvHelper.Tests/DataTableTests/CsvDataReaderTests.cs
+++ b/tests/CsvHelper.Tests/DataTableTests/CsvDataReaderTests.cs
@@ -278,6 +278,27 @@ namespace CsvHelper.Tests.DataTableTests
 		}
 
 		[Fact]
+		public void GetOrdinalNoHeaderTest_ThrowsReaderException()
+		{
+			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				HasHeaderRecord = false,
+			};
+			var s = new StringBuilder();
+			s.AppendLine("1,one");
+			s.AppendLine("2,two");
+			using (var reader = new StringReader(s.ToString()))
+			using (var csv = new CsvReader(reader, config))
+			{
+				var dataReader = new CsvDataReader(csv);
+
+				dataReader.Read();
+
+				Assert.Throws<ReaderException>(() => dataReader.GetOrdinal("Id"));
+			}
+		}
+
+		[Fact]
 		public void DataTableLoadEmptyTest()
 		{
 			var config = new CsvConfiguration(CultureInfo.InvariantCulture)

--- a/tests/CsvHelper.Tests/TypeConversion/ArrayConverterTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/ArrayConverterTests.cs
@@ -148,6 +148,31 @@ namespace CsvHelper.Tests.TypeConversion
 		}
 
 		[Fact]
+		public void FullReadWithMultiNameHeaderListItemsScattered()
+		{
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
+			{
+				writer.WriteLine("Before,List1,A,List2,B,List2,After");
+				writer.WriteLine("1,2,3,4,5,6,7");
+				writer.Flush();
+				stream.Position = 0;
+
+				csv.Context.RegisterClassMap<TestMultipleNamedMap>();
+				var records = csv.GetRecords<Test>().ToList();
+
+				var list = Assert.Single(records).List.ToList();
+
+				Assert.Equal(3, list.Count);
+				Assert.Equal(2, list[0]);
+				Assert.Equal(4, list[1]);
+				Assert.Equal(6, list[2]);
+			}
+		}
+
+		[Fact]
 		public void GetRecords_NullValuesAttributeWithIndex_UsesCustomNullValue()
 		{
 			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
@@ -194,6 +219,16 @@ namespace CsvHelper.Tests.TypeConversion
 			{
 				Map(m => m.Before).Name("Before");
 				Map(m => m.List).Name("List");
+				Map(m => m.After).Name("After");
+			}
+		}
+
+		private sealed class TestMultipleNamedMap : ClassMap<Test>
+		{
+			public TestMultipleNamedMap()
+			{
+				Map(m => m.Before).Name("Before");
+				Map(m => m.List).Name("List1", "List2");
 				Map(m => m.After).Name("After");
 			}
 		}

--- a/tests/CsvHelper.Tests/TypeConversion/IEnumerableConverterTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/IEnumerableConverterTests.cs
@@ -145,6 +145,31 @@ namespace CsvHelper.Tests.TypeConversion
 		}
 
 		[Fact]
+		public void FullReadWithMultiNameHeaderListItemsScattered()
+		{
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
+			{
+				writer.WriteLine("Before,List1,A,List2,B,List2,After");
+				writer.WriteLine("1,2,3,4,5,6,7");
+				writer.Flush();
+				stream.Position = 0;
+
+				csv.Context.RegisterClassMap<TestMultipleNamedMap>();
+				var records = csv.GetRecords<Test>().ToList();
+
+				var list = Assert.Single(records).List.Cast<string>().ToList();
+
+				Assert.Equal(3, list.Count);
+				Assert.Equal("2", list[0]);
+				Assert.Equal("4", list[1]);
+				Assert.Equal("6", list[2]);
+			}
+		}
+
+		[Fact]
 		public void FullWriteNoHeaderTest()
 		{
 			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
@@ -244,6 +269,16 @@ namespace CsvHelper.Tests.TypeConversion
 			{
 				Map(m => m.Before).Name("Before");
 				Map(m => m.List).Name("List");
+				Map(m => m.After).Name("After");
+			}
+		}
+
+		private sealed class TestMultipleNamedMap : ClassMap<Test>
+		{
+			public TestMultipleNamedMap()
+			{
+				Map(m => m.Before).Name("Before");
+				Map(m => m.List).Name("List1", "List2");
 				Map(m => m.After).Name("After");
 			}
 		}

--- a/tests/CsvHelper.Tests/TypeConversion/IEnumerableGenericConverterTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/IEnumerableGenericConverterTests.cs
@@ -149,6 +149,31 @@ namespace CsvHelper.Tests.TypeConversion
 		}
 
 		[Fact]
+		public void FullReadWithMultiNameHeaderListItemsScattered()
+		{
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
+			{
+				writer.WriteLine("Before,List1,A,List2,B,List2,After");
+				writer.WriteLine("1,2,3,4,5,6,7");
+				writer.Flush();
+				stream.Position = 0;
+
+				csv.Context.RegisterClassMap<TestMultipleNamedMap>();
+				var records = csv.GetRecords<Test>().ToList();
+
+				var list = Assert.Single(records).List.ToList();
+
+				Assert.Equal(3, list.Count);
+				Assert.Equal(2, list[0]);
+				Assert.Equal(4, list[1]);
+				Assert.Equal(6, list[2]);
+			}
+		}
+
+		[Fact]
 		public void FullWriteNoHeaderTest()
 		{
 			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
@@ -248,6 +273,16 @@ namespace CsvHelper.Tests.TypeConversion
 			{
 				Map(m => m.Before).Name("Before");
 				Map(m => m.List).Name("List");
+				Map(m => m.After).Name("After");
+			}
+		}
+
+		private sealed class TestMultipleNamedMap : ClassMap<Test>
+		{
+			public TestMultipleNamedMap()
+			{
+				Map(m => m.Before).Name("Before");
+				Map(m => m.List).Name("List1", "List2");
 				Map(m => m.After).Name("After");
 			}
 		}


### PR DESCRIPTION
This PR fixes all remaining nullable warnings using a combination of:

- Annotating members (public included) with `?` or nullable attributes
  - Note, on netfx and netstandard, these attributes don't exist so I have added them in `NullableAttributes.cs` to prevent build failures, but they don't take part in the nullable state analysis
- Throwing explicit exceptions which would otherwise have been implicit `NullReferenceException`s
- Adding asserts to make assumptions explicit, e.g validating reflection, which hopefully would fire during test runs if such assumptions have changed
- Some slight refactors including a few breaking changes:
  - Added protected constructor on `MemberMap` to ensure non-nullable properties are initialised
  - Changed argument signature of `public static TypeConverterOptions.Merge` from `Merge(params TypeConverterOptions[] sources)` to `Merge(TypeConverterOptions options, params TypeConverterOptions[] sources)` (internal callsites unchanged)
  - Array/Collection/IEnumerable converters now make use of all Names set rather than just the first (I consider this a feature :slightly_smiling_face:)

Otherwise I tried to keep functional changes to a minimum, and to follow https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/api-guidelines/nullability.md

Comments welcome