### PR TITLE
Performance optimizations for GetDelimiter and HeaderValidated.

### DIFF
--- a/src/CsvHelper/Configuration/ConfigurationFunctions.cs
+++ b/src/CsvHelper/Configuration/ConfigurationFunctions.cs
@@ -32,21 +32,21 @@ namespace CsvHelper.Configuration
 			var errorMessage = new StringBuilder();
 			foreach (var invalidHeader in args.InvalidHeaders)
 			{
-				errorMessage.AppendLine($"Header with name '{string.Join("' or '", invalidHeader.Names)}'[{invalidHeader.Index}] was not found.");
+				errorMessage.Append("Header with name '").Append(string.Join("' or '", invalidHeader.Names)).Append("'[").Append(invalidHeader.Index).AppendLine("] was not found.");
 			}
 
 			if (args.Context.Reader.HeaderRecord != null)
 			{
 				foreach (var header in args.Context.Reader.HeaderRecord)
 				{
-					errorMessage.AppendLine($"Headers: '{string.Join("', '", args.Context.Reader.HeaderRecord)}'");
+					errorMessage.Append("Headers: '").Append(string.Join("', '", args.Context.Reader.HeaderRecord)).AppendLine("'");
 				}
 			}
 
 			var messagePostfix =
-				$"If you are expecting some headers to be missing and want to ignore this validation, " +
+				"If you are expecting some headers to be missing and want to ignore this validation, " +
 				$"set the configuration {nameof(HeaderValidated)} to null. You can also change the " +
-				$"functionality to do something else, like logging the issue.";
+				"functionality to do something else, like logging the issue.";
 			errorMessage.AppendLine(messagePostfix);
 
 			throw new HeaderValidationException(args.Context, args.InvalidHeaders, errorMessage.ToString());
@@ -148,7 +148,7 @@ namespace CsvHelper.Configuration
 		}
 
 		/// <summary>
-		/// Returns the type's constructor with the most parameters. 
+		/// Returns the type's constructor with the most parameters.
 		/// If two constructors have the same number of parameters, then
 		/// there is no guarantee which one will be returned. If you have
 		/// that situation, you should probably implement this function yourself.

--- a/src/CsvHelper/Configuration/ConfigurationFunctions.cs
+++ b/src/CsvHelper/Configuration/ConfigurationFunctions.cs
@@ -24,7 +24,7 @@ namespace CsvHelper.Configuration
 		/// </summary>
 		public static void HeaderValidated(HeaderValidatedArgs args)
 		{
-			if (args.InvalidHeaders.Count() == 0)
+			if (!args.InvalidHeaders.Any())
 			{
 				return;
 			}
@@ -239,7 +239,7 @@ namespace CsvHelper.Configuration
 			if (lineDelimiterCounts.Count > 1)
 			{
 				// The last line isn't complete and can't be used to reliably detect a delimiter.
-				lineDelimiterCounts.Remove(lineDelimiterCounts.Last());
+				lineDelimiterCounts.RemoveAt(lineDelimiterCounts.Count - 1);
 			}
 
 			var delimiters =
@@ -254,7 +254,7 @@ namespace CsvHelper.Configuration
 					Delimiter = g.Key,
 					Count = sum
 				}
-			).ToList();
+			);
 
 			string? newDelimiter = null;
 			if (delimiters.Any(x => x.Delimiter == config.CultureInfo.TextInfo.ListSeparator) && lineDelimiterCounts.Count > 1)

--- a/src/CsvHelper/Configuration/ConfigurationFunctions.cs
+++ b/src/CsvHelper/Configuration/ConfigurationFunctions.cs
@@ -246,6 +246,7 @@ namespace CsvHelper.Configuration
 
 			var lineCount = lineDelimiterCounts.Count;
 
+			// Select only the delimiters that appear on every line.
 			var delimiters =
 			(
 				from counts in lineDelimiterCounts

--- a/tests/CsvHelper.Tests/Parsing/DetectDelimiterTests.cs
+++ b/tests/CsvHelper.Tests/Parsing/DetectDelimiterTests.cs
@@ -66,6 +66,24 @@ namespace CsvHelper.Tests.Parsing
 				Assert.Equal("|", ConfigurationFunctions.GetDelimiter(new Delegates.GetDelimiterArgs(s.ToString(), config)));
 			}
 		}
+		[Fact]
+		public void GetDelimiter_TextHasPlus_DetectsPlus()
+		{
+			var s = new StringBuilder();
+			s.Append("Id+Name+City\r\n");
+			s.Append("1+one+Irvine\r\n");
+			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				Delimiter = "+",
+			};
+			using (var reader = new StringReader(s.ToString()))
+			using (var parser = new CsvParser(reader, config))
+			{
+				parser.Read();
+
+				Assert.Equal("+", ConfigurationFunctions.GetDelimiter(new Delegates.GetDelimiterArgs(s.ToString(), config)));
+			}
+		}
 
 		[Fact]
 		public void GetDelimiter_TextHasTabs_DetectsTab()


### PR DESCRIPTION
- Optimize `StringBuilder` calls.
- Replace `Regex.Replace` with static instance of `Regex`.
- LINQ cleanup
- Optimize logic for `GetDelimiter` so it skips further processing for a delimiter that is missing on a line.