### PR TITLE
Allow CultureInfoAttribute on classes and some other attribute nice-to-haves

### DIFF
--- a/src/CsvHelper.Website/input/examples/configuration/attributes/index.md
+++ b/src/CsvHelper.Website/input/examples/configuration/attributes/index.md
@@ -5,9 +5,9 @@ Most of the configuration done via class maps can also be done using attributes.
 ###### Data
 
 ```
-Identifier,name,IsBool,Constant
-1,one,yes,a
-2,two,no,b
+Identifier||Amount2|IsBool|Constant
+1|1,234|1,234|yes|a
+2|1.234|1.234|no|b
 ```
 
 ###### Example
@@ -15,35 +15,54 @@ Identifier,name,IsBool,Constant
 ```cs
 void Main()
 {
+	CsvConfiguration config = CsvConfiguration.FromType<Foo>();
 	using (var reader = new StreamReader("path\\to\\file.csv"))
-	using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
+	using (var csv = new CsvReader(reader, config))
 	{
-		csv.GetRecords<Foo>().ToList().Dump();
+		List<Foo> records = csv.GetRecords<Foo>().ToList();
+
+		// These all print "True"
+
+		Console.WriteLine(records.Count == 2);
+		Console.WriteLine(records[0].Id == 1);
+		Console.WriteLine(records[0].Amount == 1.234m);
+		Console.WriteLine(records[0].Amount2 == 1234);
+		Console.WriteLine(records[0].IsBool == true);
+		Console.WriteLine(records[0].Constant == "bar");
+		Console.WriteLine(records[0].Optional == null);
+		Console.WriteLine(records[0].Ignored == null);
+
+		Console.WriteLine(records[1].Amount == 1234);
+		Console.WriteLine(records[1].Amount2 == 1.234m);
+
 	}
 }
 
-[Delimiter(",")]
-[CultureInfo("")]  // Set CultureInfo to InvariantCulture
+[Delimiter("|")]
+[CultureInfo("de-DE")]
 public class Foo
 {
 	[Name("Identifier")]
 	public int Id { get; set; }
-	
+
 	[Index(1)]
-	public string Name { get; set; }
+	public decimal Amount { get; set; }
 	
+	[CultureInfo("InvariantCulture")]
+	public decimal Amount2 { get; set; }
+
 	[BooleanTrueValues("yes")]
 	[BooleanFalseValues("no")]
 	public bool IsBool { get; set; }
-	
+
 	[Constant("bar")]
 	public string Constant { get; set; }
-	
+
 	[Optional]
 	public string Optional { get; set; }
-	
+
 	[Ignore]
-	public string Ignored { get; set; }	
+	public string Ignored { get; set; }
 }
 
 ```

--- a/src/CsvHelper/Configuration/Attributes/AllowCommentsAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/AllowCommentsAttribute.cs
@@ -7,21 +7,21 @@ using System;
 namespace CsvHelper.Configuration.Attributes
 {
 	/// <summary>
-	/// A value indicating if comments are allowed.
+	/// A value indicating whether comments are allowed.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 	public class AllowCommentsAttribute : Attribute, IClassMapper
 	{
 		/// <summary>
-		/// Gets a value indicating if comments are allowed.
+		/// Gets a value indicating whether comments are allowed.
 		/// </summary>
 		public bool AllowComments { get; private set; }
 
 		/// <summary>
-		/// A value indicating if comments are allowed.
+		/// A value indicating whether comments are allowed.
 		/// </summary>
-		/// <param name="allowComments">The value indicating id comments are allowed.</param>
-		public AllowCommentsAttribute(bool allowComments)
+		/// <param name="allowComments">The value indicating whether comments are allowed.</param>
+		public AllowCommentsAttribute(bool allowComments = true)
 		{
 			AllowComments = allowComments;
 		}

--- a/src/CsvHelper/Configuration/Attributes/CacheFieldsAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/CacheFieldsAttribute.cs
@@ -8,7 +8,6 @@ namespace CsvHelper.Configuration.Attributes
 {
 	/// <summary>
 	/// Cache fields that are created when parsing.
-	/// Default is false.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 	public class CacheFieldsAttribute : Attribute, IClassMapper
@@ -22,7 +21,7 @@ namespace CsvHelper.Configuration.Attributes
 		/// Cache fields that are created when parsing.
 		/// </summary>
 		/// <param name="cacheFields"></param>
-		public CacheFieldsAttribute(bool cacheFields)
+		public CacheFieldsAttribute(bool cacheFields = true)
 		{
 			CacheFields = cacheFields;
 		}

--- a/src/CsvHelper/Configuration/Attributes/CountBytesAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/CountBytesAttribute.cs
@@ -9,7 +9,7 @@ namespace CsvHelper.Configuration.Attributes
 {
 	/// <summary>
 	/// A value indicating whether the number of bytes should
-	/// be counted while parsing. Default is false. This will slow down parsing
+	/// be counted while parsing. This will slow down parsing
 	/// because it needs to get the byte count of every char for the given encoding.
 	/// The <see cref="Encoding"/> needs to be set correctly for this to be accurate.
 	/// </summary>
@@ -18,7 +18,7 @@ namespace CsvHelper.Configuration.Attributes
 	{
 		/// <summary>
 		/// A value indicating whether the number of bytes should
-		/// be counted while parsing. Default is false. This will slow down parsing
+		/// be counted while parsing. This will slow down parsing
 		/// because it needs to get the byte count of every char for the given encoding.
 		/// The <see cref="Encoding"/> needs to be set correctly for this to be accurate.
 		/// </summary>
@@ -26,12 +26,12 @@ namespace CsvHelper.Configuration.Attributes
 
 		/// <summary>
 		/// A value indicating whether the number of bytes should
-		/// be counted while parsing. Default is false. This will slow down parsing
+		/// be counted while parsing. This will slow down parsing
 		/// because it needs to get the byte count of every char for the given encoding.
 		/// The <see cref="Encoding"/> needs to be set correctly for this to be accurate.
 		/// </summary>
 		/// <param name="countBytes"></param>
-		public CountBytesAttribute(bool countBytes)
+		public CountBytesAttribute(bool countBytes = true)
 		{
 			CountBytes = countBytes;
 		}

--- a/src/CsvHelper/Configuration/Attributes/CultureInfoAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/CultureInfoAttribute.cs
@@ -8,9 +8,8 @@ using System.Globalization;
 namespace CsvHelper.Configuration.Attributes
 {
 	/// <summary>
-	/// The <see cref="CultureInfo"/> used when type converting.
-	/// This will override the global <see cref="CsvConfiguration.CultureInfo"/>
-	/// setting. Or set the same if the attribute is specified on class level.
+	/// The <see cref="System.Globalization.CultureInfo"/> used when type converting the member.
+	/// This will be used instead of the <see cref="CsvConfiguration.CultureInfo"/> setting.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
 	public class CultureInfoAttribute : Attribute, IMemberMapper, IParameterMapper
@@ -20,15 +19,32 @@ namespace CsvHelper.Configuration.Attributes
 		/// </summary>
 		public CultureInfo CultureInfo { get; private set; }
 
-		/// <summary>
-		/// The <see cref="CultureInfo"/> used when type converting.
-		/// This will override the global <see cref="CsvConfiguration.CultureInfo"/>
-		/// setting. Or set the same if the attribute is specified on class level.
-		/// </summary>
-		/// <param name="culture">The culture.</param>
-		public CultureInfoAttribute(string culture)
+		/// <summary><inheritdoc cref="CultureInfoAttribute"/></summary>
+		/// <param name="name">
+		/// The name of a culture (case insensitive), or the literal values <c>"InvariantCulture"</c>,
+		/// <c>"CurrentCulture"</c>, <c>"CurrentUICulture"</c>, <c>"InstalledUICulture"</c> to use the
+		/// corresponding static properties on <see cref="System.Globalization.CultureInfo"/>.
+		/// </param>
+		public CultureInfoAttribute(string name)
 		{
-			CultureInfo = CultureInfo.GetCultureInfo(culture);
+			switch(name)
+			{
+				case nameof(CultureInfo.InvariantCulture):
+					CultureInfo = CultureInfo.InvariantCulture;
+					break;
+				case nameof(CultureInfo.CurrentCulture):
+					CultureInfo = CultureInfo.CurrentCulture;
+					break;
+				case nameof(CultureInfo.CurrentUICulture):
+					CultureInfo = CultureInfo.CurrentUICulture;
+					break;
+				case nameof(CultureInfo.InstalledUICulture):
+					CultureInfo = CultureInfo.InstalledUICulture;
+					break;
+				default:
+					CultureInfo = CultureInfo.GetCultureInfo(name);
+					break;
+			}
 		}
 
 		/// <inheritdoc />

--- a/src/CsvHelper/Configuration/Attributes/CultureInfoAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/CultureInfoAttribute.cs
@@ -8,10 +8,12 @@ using System.Globalization;
 namespace CsvHelper.Configuration.Attributes
 {
 	/// <summary>
-	/// The <see cref="System.Globalization.CultureInfo"/> used when type converting the member.
-	/// This will be used instead of the <see cref="CsvConfiguration.CultureInfo"/> setting.
+	/// When applied to a member, specifies the <see cref="System.Globalization.CultureInfo"/>
+	/// used when type converting the member. When applied to a type, the value of
+	/// <see cref="CsvConfiguration.CultureInfo"/> in the <see cref="CsvConfiguration"/>
+	/// returned by <see cref="CsvConfiguration.FromType{T}()"/>
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 	public class CultureInfoAttribute : Attribute, IMemberMapper, IParameterMapper
 	{
 		/// <summary>

--- a/src/CsvHelper/Configuration/Attributes/DetectColumnCountChangesAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/DetectColumnCountChangesAttribute.cs
@@ -8,7 +8,7 @@ namespace CsvHelper.Configuration.Attributes
 {
 	/// <summary>
 	/// A value indicating whether changes in the column
-	/// count should be detected. If true, a <see cref="BadDataException"/>
+	/// count should be detected. If <see langword="true"/>, a <see cref="BadDataException"/>
 	/// will be thrown if a different column count is detected.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
@@ -16,17 +16,17 @@ namespace CsvHelper.Configuration.Attributes
 	{
 		/// <summary>
 		/// A value indicating whether changes in the column
-		/// count should be detected. If true, a <see cref="BadDataException"/>
+		/// count should be detected. If <see langword="true"/>, a <see cref="BadDataException"/>
 		/// will be thrown if a different column count is detected.
 		/// </summary>
 		public bool DetectColumnCountChanges { get; private set; }
 
 		/// <summary>
 		/// A value indicating whether changes in the column
-		/// count should be detected. If true, a <see cref="BadDataException"/>
+		/// count should be detected. If <see langword="true"/>, a <see cref="BadDataException"/>
 		/// will be thrown if a different column count is detected.
 		/// </summary>
-		public DetectColumnCountChangesAttribute(bool detectColumnCountChanges)
+		public DetectColumnCountChangesAttribute(bool detectColumnCountChanges = true)
 		{
 			DetectColumnCountChanges = detectColumnCountChanges;
 		}

--- a/src/CsvHelper/Configuration/Attributes/DetectDelimiterAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/DetectDelimiterAttribute.cs
@@ -8,7 +8,6 @@ namespace CsvHelper.Configuration.Attributes
 {
 	/// <summary>
 	/// Detect the delimiter instead of using the delimiter from configuration.
-	/// Default is <c>false</c>.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 	public class DetectDelimiterAttribute : Attribute, IClassMapper
@@ -21,7 +20,7 @@ namespace CsvHelper.Configuration.Attributes
 		/// <summary>
 		/// Detect the delimiter instead of using the delimiter from configuration.
 		/// </summary>
-		public DetectDelimiterAttribute(bool detectDelimiter)
+		public DetectDelimiterAttribute(bool detectDelimiter = true)
 		{
 			DetectDelimiter = detectDelimiter;
 		}

--- a/src/CsvHelper/Configuration/Attributes/EncodingAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/EncodingAttribute.cs
@@ -18,14 +18,23 @@ namespace CsvHelper.Configuration.Attributes
         /// </summary>
         public Encoding Encoding { get; private set; }
 
-        /// <summary>
-        /// The encoding used when counting bytes.
-        /// </summary>
-        /// <param name="encoding">The encoding.</param>
-        public EncodingAttribute(string encoding)
+		/// <summary>
+		/// The encoding used when counting bytes.
+		/// </summary>
+		/// <param name="name"><inheritdoc cref="Encoding.GetEncoding(string)"/></param>
+		public EncodingAttribute(string name)
         {
-            Encoding = Encoding.GetEncoding(encoding);
-        }
+            Encoding = Encoding.GetEncoding(name);
+		}
+
+		/// <summary>
+		/// The encoding used when counting bytes.
+		/// </summary>
+		/// <param name="codepage"><inheritdoc cref="Encoding.GetEncoding(int)"/></param>
+		public EncodingAttribute(int codepage)
+		{
+			Encoding = Encoding.GetEncoding(codepage);
+		}
 
 		/// <inheritdoc />
 		public void ApplyTo(CsvConfiguration configuration)

--- a/src/CsvHelper/Configuration/Attributes/EscapeAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/EscapeAttribute.cs
@@ -9,7 +9,7 @@ namespace CsvHelper.Configuration.Attributes
     /// <summary>
     /// The escape character used to escape a quote inside a field.
     /// </summary>
-    [AttributeUsage( AttributeTargets.Class, AllowMultiple = false, Inherited = true )]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class EscapeAttribute : Attribute, IClassMapper
     {
         /// <summary>
@@ -21,7 +21,7 @@ namespace CsvHelper.Configuration.Attributes
         /// The escape character used to escape a quote inside a field.
         /// </summary>
         /// <param name="escape">The escape character.</param>
-        public EscapeAttribute( char escape )
+        public EscapeAttribute(char escape)
         {
             Escape = escape;
         }

--- a/src/CsvHelper/Configuration/Attributes/ExceptionMessagesContainRawDataAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/ExceptionMessagesContainRawDataAttribute.cs
@@ -7,25 +7,23 @@ using System;
 namespace CsvHelper.Configuration.Attributes
 {
 	/// <summary>
-	/// A value indicating if exception messages contain raw CSV data.
-	/// <c>true</c> if exception contain raw CSV data, otherwise <c>false</c>.
-	/// Default is <c>true</c>.
+	/// A value indicating whether exception messages contain raw CSV data.
+	/// <see langword="true"/> if exceptions contain raw CSV data, otherwise <see langword="false"/>.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 	public class ExceptionMessagesContainRawDataAttribute : Attribute, IClassMapper
 	{
 		/// <summary>
-		/// A value indicating if exception messages contain raw CSV data.
-		/// <c>true</c> if exception contain raw CSV data, otherwise <c>false</c>.
+		/// A value indicating whether exception messages contain raw CSV data.
+		/// <see langword="true"/> if exceptions contain raw CSV data, otherwise <see langword="false"/>.
 		/// </summary>
 		public bool ExceptionMessagesContainRawData { get; private set; }
 
 		/// <summary>
-		/// A value indicating if exception messages contain raw CSV data.
-		/// <c>true</c> if exception contain raw CSV data, otherwise <c>false</c>.
+		/// A value indicating whether exception messages contain raw CSV data.
+		/// <see langword="true"/> if exceptions contain raw CSV data, otherwise <see langword="false"/>.
 		/// </summary>
-		/// <param name="exceptionMessagesContainRawData"></param>
-		public ExceptionMessagesContainRawDataAttribute(bool exceptionMessagesContainRawData)
+		public ExceptionMessagesContainRawDataAttribute(bool exceptionMessagesContainRawData = true)
 		{
 			ExceptionMessagesContainRawData = exceptionMessagesContainRawData;
 		}

--- a/src/CsvHelper/Configuration/Attributes/HasHeaderRecordAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/HasHeaderRecordAttribute.cs
@@ -7,21 +7,21 @@ using System;
 namespace CsvHelper.Configuration.Attributes
 {
     /// <summary>
-    /// A value indicating if the CSV file has a header record.
+    /// A value indicating whether the CSV file has a header record.
     /// </summary>
-    [AttributeUsage( AttributeTargets.Class, AllowMultiple = false, Inherited = true )]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class HasHeaderRecordAttribute : Attribute, IClassMapper
     {
         /// <summary>
-        /// Gets a value indicating if the CSV file has a header record.
+        /// Gets a value indicating whether the CSV file has a header record.
         /// </summary>
         public bool HasHeaderRecord { get; private set; }
 
         /// <summary>
-        /// A value indicating if the CSV file has a header record.
+        /// A value indicating whether the CSV file has a header record.
         /// </summary>
-        /// <param name="hasHeaderRecord">A value indicating if the CSV file has a header record.</param>
-        public HasHeaderRecordAttribute( bool hasHeaderRecord )
+        /// <param name="hasHeaderRecord">A value indicating whether the CSV file has a header record.</param>
+        public HasHeaderRecordAttribute(bool hasHeaderRecord = true)
         {
             HasHeaderRecord = hasHeaderRecord;
         }

--- a/src/CsvHelper/Configuration/Attributes/HeaderPrefixAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/HeaderPrefixAttribute.cs
@@ -18,7 +18,7 @@ namespace CsvHelper.Configuration.Attributes
 		public string? Prefix { get; private set; }
 
 		/// <summary>
-		/// Gets a value indicating if the prefix should inherit parent prefixes.
+		/// Gets a value indicating whether the prefix should inherit parent prefixes.
 		/// </summary>
 		public bool Inherit { get; private set; }
 

--- a/src/CsvHelper/Configuration/Attributes/IgnoreBlankLinesAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/IgnoreBlankLinesAttribute.cs
@@ -7,21 +7,20 @@ using System;
 namespace CsvHelper.Configuration.Attributes
 {
     /// <summary>
-    /// A value indicating if blank lines should be ignored when reading.
+    /// A value indicating whether blank lines should be ignored when reading.
     /// </summary>
-    [AttributeUsage( AttributeTargets.Class, AllowMultiple = false, Inherited = true )]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class IgnoreBlankLinesAttribute : Attribute, IClassMapper
     {
         /// <summary>
-        /// Gets a value indicating if blank lines should be ignored when reading.
+        /// Gets a value indicating whether blank lines should be ignored when reading.
         /// </summary>
         public bool IgnoreBlankLines { get; private set; }
 
         /// <summary>
-        /// A value indicating if blank lines should be ignored when reading.
+        /// A value indicating whether blank lines should be ignored when reading.
         /// </summary>
-        /// <param name="ignoreBlankLines">The Ignore Blank Lines Flag.</param>
-        public IgnoreBlankLinesAttribute( bool ignoreBlankLines )
+        public IgnoreBlankLinesAttribute(bool ignoreBlankLines = true)
         {
             IgnoreBlankLines = ignoreBlankLines;
         }

--- a/src/CsvHelper/Configuration/Attributes/IgnoreReferencesAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/IgnoreReferencesAttribute.cs
@@ -8,26 +8,25 @@ namespace CsvHelper.Configuration.Attributes
 {
 	/// <summary>
 	/// Gets a value indicating whether references
-	/// should be ignored when auto mapping. <c>true</c> to ignore
-	/// references, otherwise <c>false</c>. Default is false.
+	/// should be ignored when auto mapping. <see langword="true"/> to ignore
+	/// references, otherwise <see langword="false"/>.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 	public class IgnoreReferencesAttribute : Attribute, IClassMapper
 	{
 		/// <summary>
 		/// Gets a value indicating whether references
-		/// should be ignored when auto mapping. <c>true</c> to ignore
-		/// references, otherwise <c>false</c>. Default is false.
+		/// should be ignored when auto mapping. <see langword="true"/> to ignore
+		/// references, otherwise <see langword="false"/>.
 		/// </summary>
 		public bool IgnoreReferences { get; private set; }
 
 		/// <summary>
 		/// Gets a value indicating whether references
-		/// should be ignored when auto mapping. <c>true</c> to ignore
-		/// references, otherwise <c>false</c>. Default is false.
+		/// should be ignored when auto mapping. <see langword="true"/> to ignore
+		/// references, otherwise <see langword="false"/>.
 		/// </summary>
-		/// <param name="ignoreReferences">Ignore references value.</param>
-		public IgnoreReferencesAttribute(bool ignoreReferences)
+		public IgnoreReferencesAttribute(bool ignoreReferences = true)
 		{
 			IgnoreReferences = ignoreReferences;
 		}

--- a/src/CsvHelper/Configuration/Attributes/IncludePrivateMembersAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/IncludePrivateMembersAttribute.cs
@@ -7,21 +7,20 @@ using System;
 namespace CsvHelper.Configuration.Attributes
 {
     /// <summary>
-    /// A value indicating if private member should be read from and written to.
+    /// A value indicating whether private members should be read from and written to.
     /// </summary>
-    [AttributeUsage( AttributeTargets.Class, AllowMultiple = false, Inherited = true )]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class IncludePrivateMembersAttribute : Attribute, IClassMapper
     {
         /// <summary>
-        /// Gets a value indicating if private member should be read from and written to.
+        /// Gets a value indicating whether private members should be read from and written to.
         /// </summary>
         public bool IncludePrivateMembers { get; private set; }
 
         /// <summary>
-        /// A value indicating if private member should be read from and written to.
+        /// A value indicating whether private members should be read from and written to.
         /// </summary>
-        /// <param name="includePrivateMembers">The Include Private Members Flag.</param>
-        public IncludePrivateMembersAttribute( bool includePrivateMembers )
+        public IncludePrivateMembersAttribute(bool includePrivateMembers = true)
         {
             IncludePrivateMembers = includePrivateMembers;
         }

--- a/src/CsvHelper/Configuration/Attributes/IndexAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/IndexAttribute.cs
@@ -12,7 +12,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// will be written in the order of the field
 	/// indexes.
 	/// </summary>
-	[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false, Inherited = true )]
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
 	public class IndexAttribute : Attribute, IMemberMapper, IParameterMapper
 	{
 		/// <summary>
@@ -33,7 +33,7 @@ namespace CsvHelper.Configuration.Attributes
 		/// </summary>
 		/// <param name="index">The index.</param>
 		/// <param name="indexEnd">The index end.</param>
-		public IndexAttribute( int index, int indexEnd = -1 )
+		public IndexAttribute(int index, int indexEnd = -1)
 		{
 			Index = index;
 			IndexEnd = indexEnd;

--- a/src/CsvHelper/Configuration/Attributes/InjectionCharactersAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/InjectionCharactersAttribute.cs
@@ -11,6 +11,7 @@ namespace CsvHelper.Configuration.Attributes
 	/// <summary>
 	/// Gets the characters that are used for injection attacks.
 	/// </summary>
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 	public class InjectionCharactersAttribute : Attribute, IClassMapper
 	{
 		/// <summary>

--- a/src/CsvHelper/Configuration/Attributes/LineBreakInQuotedFieldIsBadDataAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/LineBreakInQuotedFieldIsBadDataAttribute.cs
@@ -7,25 +7,23 @@ using System;
 namespace CsvHelper.Configuration.Attributes
 {
 	/// <summary>
-	/// A value indicating if a line break found in a quote field should
-	/// be considered bad data. <c>true</c> to consider a line break bad data, otherwise <c>false</c>.
-	/// Defaults to false.
+	/// A value indicating whether a line break found in a quote field should
+	/// be considered bad data. <see langword="true"/> to consider a line break bad data, otherwise <see langword="false"/>.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 	public class LineBreakInQuotedFieldIsBadDataAttribute : Attribute, IClassMapper
 	{
 		/// <summary>
-		/// A value indicating if a line break found in a quote field should
-		/// be considered bad data. <c>true</c> to consider a line break bad data, otherwise <c>false</c>.
+		/// A value indicating whether a line break found in a quote field should
+		/// be considered bad data. <see langword="true"/> to consider a line break bad data, otherwise <see langword="false"/>.
 		/// </summary>
 		public bool LineBreakInQuotedFieldIsBadData { get; private set; }
 
 		/// <summary>
-		/// A value indicating if a line break found in a quote field should
-		/// be considered bad data. <c>true</c> to consider a line break bad data, otherwise <c>false</c>.
+		/// A value indicating whether a line break found in a quote field should
+		/// be considered bad data. <see langword="true"/> to consider a line break bad data, otherwise <see langword="false"/>.
 		/// </summary>
-		/// <param name="lineBreakInQuotedFieldIsBadData"></param>
-		public LineBreakInQuotedFieldIsBadDataAttribute(bool lineBreakInQuotedFieldIsBadData)
+		public LineBreakInQuotedFieldIsBadDataAttribute(bool lineBreakInQuotedFieldIsBadData = true)
 		{
 			LineBreakInQuotedFieldIsBadData = lineBreakInQuotedFieldIsBadData;
 		}

--- a/src/CsvHelper/Configuration/Attributes/QuoteAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/QuoteAttribute.cs
@@ -9,7 +9,7 @@ namespace CsvHelper.Configuration.Attributes
     /// <summary>
     /// The character used to quote fields.
     /// </summary>
-    [AttributeUsage( AttributeTargets.Class, AllowMultiple = false, Inherited = true )]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class QuoteAttribute : Attribute, IClassMapper
     {
         /// <summary>
@@ -21,7 +21,7 @@ namespace CsvHelper.Configuration.Attributes
         /// The character used to quote fields.
         /// </summary>
         /// <param name="quote">The quote character.</param>
-        public QuoteAttribute( char quote )
+        public QuoteAttribute(char quote)
         {
             Quote = quote;
         }

--- a/src/CsvHelper/Configuration/Attributes/TrimOptionsAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/TrimOptionsAttribute.cs
@@ -9,7 +9,7 @@ namespace CsvHelper.Configuration.Attributes
     /// <summary>
     /// The fields trimming options.
     /// </summary>
-    [AttributeUsage( AttributeTargets.Class, AllowMultiple = false, Inherited = true )]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class TrimOptionsAttribute : Attribute, IClassMapper
     {
         /// <summary>
@@ -21,7 +21,7 @@ namespace CsvHelper.Configuration.Attributes
         /// The fields trimming options.
         /// </summary>
         /// <param name="trimOptions">The TrimOptions.</param>
-        public TrimOptionsAttribute( TrimOptions trimOptions )
+        public TrimOptionsAttribute(TrimOptions trimOptions)
         {
             TrimOptions = trimOptions;
         }

--- a/src/CsvHelper/Configuration/Attributes/UseNewObjectForNullReferenceMembersAttribute.cs
+++ b/src/CsvHelper/Configuration/Attributes/UseNewObjectForNullReferenceMembersAttribute.cs
@@ -7,33 +7,32 @@ using System;
 namespace CsvHelper.Configuration.Attributes
 {
 	/// <summary>
-	/// Gets a value indicating that during writing if a new 
-	/// object should be created when a reference member is null.
-	/// True to create a new object and use it's defaults for the
-	/// fields, or false to leave the fields empty for all the
-	/// reference member's member.
+	/// Gets a value indicating that during writing whether a new 
+	/// object should be created when a reference member is <see langword="null"/>.
+	/// <see langword="true"/> to create a new object and use its defaults for the
+	/// fields, or <see langword="false"/> to leave the fields empty for all the
+	/// reference member's members.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 	public class UseNewObjectForNullReferenceMembersAttribute : Attribute, IClassMapper
 	{
 		/// <summary>
-		/// Gets a value indicating that during writing if a new 
-		/// object should be created when a reference member is null.
-		/// True to create a new object and use it's defaults for the
-		/// fields, or false to leave the fields empty for all the
-		/// reference member's member.
+		/// Gets a value indicating that during writing whether a new 
+		/// object should be created when a reference member is <see langword="null"/>.
+		/// <see langword="true"/> to create a new object and use its defaults for the
+		/// fields, or <see langword="false"/> to leave the fields empty for all the
+		/// reference member's members.
 		/// </summary>
 		public bool UseNewObjectForNullReferenceMembers { get; private set; }
 
 		/// <summary>
-		/// Gets a value indicating that during writing if a new 
-		/// object should be created when a reference member is null.
-		/// True to create a new object and use it's defaults for the
-		/// fields, or false to leave the fields empty for all the
-		/// reference member's member.
+		/// Gets a value indicating that during writing whether a new 
+		/// object should be created when a reference member is <see langword="null"/>.
+		/// <see langword="true"/> to create a new object and use its defaults for the
+		/// fields, or <see langword="false"/> to leave the fields empty for all the
+		/// reference member's members.
 		/// </summary>
-		/// <param name="useNewObjectForNullReferenceMembers">The value.</param>
-		public UseNewObjectForNullReferenceMembersAttribute(bool useNewObjectForNullReferenceMembers)
+		public UseNewObjectForNullReferenceMembersAttribute(bool useNewObjectForNullReferenceMembers = true)
 		{
 			UseNewObjectForNullReferenceMembers = useNewObjectForNullReferenceMembers;
 		}

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -11,7 +11,6 @@ using System.Reflection;
 using System.Text;
 using CsvHelper.Configuration.Attributes;
 using CsvHelper.Delegates;
-using CsvHelper.TypeConversion;
 
 namespace CsvHelper.Configuration
 {
@@ -165,21 +164,14 @@ namespace CsvHelper.Configuration
 		/// <summary>
 		/// Initializes a new instance of the <see cref="CsvConfiguration"/> class
 		/// using the given <see cref="System.Globalization.CultureInfo"/>. Since <see cref="Delimiter"/>
-		/// uses <see cref="CultureInfo"/> for it's default, the given <see cref="System.Globalization.CultureInfo"/>
+		/// uses <see cref="CultureInfo"/> for its default, the given <see cref="System.Globalization.CultureInfo"/>
 		/// will be used instead.
 		/// </summary>
 		/// <param name="cultureInfo">The culture information.</param>
-		/// <param name="attributesType">The type that contains the configuration attributes.
-		/// This will call <see cref="ApplyAttributes(Type)"/> automatically.</param>
-		public CsvConfiguration(CultureInfo cultureInfo, Type? attributesType = null)
+		public CsvConfiguration(CultureInfo cultureInfo)
 		{
 			CultureInfo = cultureInfo;
 			Delimiter = cultureInfo.TextInfo.ListSeparator;
-
-			if (attributesType != null)
-			{
-				ApplyAttributes(attributesType);
-			}
 		}
 
 		/// <summary>
@@ -235,6 +227,88 @@ namespace CsvHelper.Configuration
 			}
 
 			return this;
+		}
+
+		/// <summary>
+		/// Creates a <see cref="CsvConfiguration"/> instance configured using CsvHelper attributes applied
+		/// to <typeparamref name="T"/> at the type-level. This method requires <typeparamref name="T"/> to
+		/// be annotated with <see cref="CultureInfoAttribute"/> (or to sub-class a type which is).
+		/// </summary>
+		/// <typeparam name="T">
+		/// The type whose attributes should be used to configure the <see cref="CsvConfiguration"/> instance.
+		/// This is normally the type you are intending to map for reading and writing.
+		/// </typeparam>
+		/// <returns>A new <see cref="CsvConfiguration"/> instance configured with attributes applied to <typeparamref name="T"/>.</returns>
+		/// <remarks>
+		/// CsvHelper attributes applied to members and parameters do not influence the return value of this method.
+		/// Such attributes do not define values which are used in <see cref="CsvConfiguration"/> and instead influence
+		/// the maps which are built and used during reading and writing. See <see cref="MemberMap"/> and <see cref="ParameterMap"/>.
+		/// </remarks>
+		/// <exception cref="ConfigurationException">If <typeparamref name="T"/> is not annotated with <see cref="CultureInfoAttribute"/>.</exception>
+		/// <exception cref="ArgumentNullException">If the argument to the <see cref="CultureInfoAttribute"/> is <see langword="null"/>.</exception>
+		/// <exception cref="CultureNotFoundException">If the argument to the <see cref="CultureInfoAttribute"/> does not specify a supported culture.</exception>
+		public static CsvConfiguration FromType<T>()
+		{
+			return FromType(typeof(T));
+		}
+
+		/// <summary>
+		/// Creates a <see cref="CsvConfiguration"/> instance configured using <paramref name="cultureInfo"/>
+		/// and CsvHelper attributes applied to <typeparamref name="T"/> at the type-level.
+		/// This method ignores any <see cref="CultureInfoAttribute"/> applied to <typeparamref name="T"/>.
+		/// </summary>
+		/// <typeparam name="T"><inheritdoc cref="FromType{T}()"/></typeparam>
+		/// <param name="cultureInfo">The <see cref="CultureInfo"/> to configure the returned <see cref="CsvConfiguration"/> with.</param>
+		/// <returns>A new <see cref="CsvConfiguration"/> instance configured with <paramref name="cultureInfo"/> and attributes applied to <typeparamref name="T"/>.</returns>
+		/// <remarks><inheritdoc cref="FromType{T}()"/></remarks>
+		public static CsvConfiguration FromType<T>(CultureInfo cultureInfo)
+		{
+			return FromType(typeof(T), cultureInfo);
+		}
+
+		/// <summary>
+		/// Creates a <see cref="CsvConfiguration"/> instance configured using CsvHelper attributes applied
+		/// to <paramref name="type"/> at the type-level. This method requires <paramref name="type"/> to
+		/// be annotated with <see cref="CultureInfoAttribute"/> (or to sub-class a type which is).
+		/// </summary>
+		/// <param name="type"><inheritdoc cref="FromType{T}()" path="/typeparam"/></param>
+		/// <returns>A new <see cref="CsvConfiguration"/> instance configured with attributes applied to <paramref name="type"/>.</returns>
+		/// <remarks>
+		/// CsvHelper attributes applied to members and parameters do not influence the return value of this method.
+		/// Such attributes do not define values which are used in <see cref="CsvConfiguration"/> and instead influence
+		/// the maps which are built and used during reading and writing. See <see cref="MemberMap"/> and <see cref="ParameterMap"/>.
+		/// </remarks>
+		/// <exception cref="ConfigurationException">If <paramref name="type"/> is not annotated with <see cref="CultureInfoAttribute"/>.</exception>
+		/// <exception cref="ArgumentNullException">If the argument to the <see cref="CultureInfoAttribute"/> is <see langword="null"/>.</exception>
+		/// <exception cref="CultureNotFoundException">If the argument to the <see cref="CultureInfoAttribute"/> does not specify a supported culture.</exception>
+		public static CsvConfiguration FromType(Type type)
+		{
+			var cultureInfoAttribute = (CultureInfoAttribute?)Attribute.GetCustomAttribute(type, typeof(CultureInfoAttribute));
+
+			if (cultureInfoAttribute is null)
+			{
+				throw new ConfigurationException($"{type} is not configured with {nameof(CultureInfoAttribute)} at the type level");
+			}
+
+			var config = new CsvConfiguration(cultureInfoAttribute.CultureInfo);
+			config.ApplyAttributes(type);
+			return config;
+		}
+
+		/// <summary>
+		/// Creates a <see cref="CsvConfiguration"/> instance configured using <paramref name="cultureInfo"/>
+		/// and CsvHelper attributes applied to <paramref name="type"/> at the type-level.
+		/// This method ignores any <see cref="CultureInfoAttribute"/> applied to <paramref name="type"/>.
+		/// </summary>
+		/// <param name="type"><inheritdoc cref="FromType{T}()" path="/typeparam"/></param>
+		/// <param name="cultureInfo"><inheritdoc cref="FromType{T}(CultureInfo)"/></param>
+		/// <returns>A new <see cref="CsvConfiguration"/> instance configured with <paramref name="cultureInfo"/> and attributes applied to <paramref name="type"/></returns>
+		/// <remarks><inheritdoc cref="FromType{T}()"/></remarks>
+		public static CsvConfiguration FromType(Type type, CultureInfo cultureInfo)
+		{
+			var config = new CsvConfiguration(cultureInfo);
+			config.ApplyAttributes(type);
+			return config;
 		}
 	}
 }

--- a/tests/CsvHelper.Tests/Mappings/Attribute/AllowCommentsTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/AllowCommentsTests.cs
@@ -14,12 +14,20 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void AllowCommentsTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(AllowCommentsTestClass));
-			Assert.True(config.AllowComments);
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(AllowCommentsTrueTestClass)).AllowComments);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(AllowCommentsFalseTestClass)).AllowComments);
 		}
 
-		[AllowComments(true)]
-		private class AllowCommentsTestClass
+		[AllowComments]
+		private class AllowCommentsTrueTestClass
+		{
+			public int Id { get; set; }
+
+			public string Name { get; set; }
+		}
+
+		[AllowComments(false)]
+		private class AllowCommentsFalseTestClass
 		{
 			public int Id { get; set; }
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/AllowCommentsTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/AllowCommentsTests.cs
@@ -14,8 +14,8 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void AllowCommentsTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(AllowCommentsTrueTestClass)).AllowComments);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(AllowCommentsFalseTestClass)).AllowComments);
+			Assert.True(CsvConfiguration.FromType<AllowCommentsTrueTestClass>(CultureInfo.InvariantCulture).AllowComments);
+			Assert.False(CsvConfiguration.FromType<AllowCommentsFalseTestClass>(CultureInfo.InvariantCulture).AllowComments);
 		}
 
 		[AllowComments]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/BufferSizeTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/BufferSizeTests.cs
@@ -15,7 +15,7 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
+			var config = CsvConfiguration.FromType<Foo>(CultureInfo.InvariantCulture);
 			Assert.Equal(2, config.BufferSize);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/CacheFieldsTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/CacheFieldsTests.cs
@@ -10,8 +10,8 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).CacheFields);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).CacheFields);
+			Assert.True(CsvConfiguration.FromType<FooTrue>(CultureInfo.InvariantCulture).CacheFields);
+			Assert.False(CsvConfiguration.FromType<FooFalse>(CultureInfo.InvariantCulture).CacheFields);
 		}
 
 		[CacheFields]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/CacheFieldsTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/CacheFieldsTests.cs
@@ -10,11 +10,14 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
-			Assert.True(config.CacheFields);
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).CacheFields);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).CacheFields);
 		}
 
-		[CacheFields(true)]
-		private class Foo { }
+		[CacheFields]
+		private class FooTrue { }
+
+		[CacheFields(false)]
+		private class FooFalse { }
 	}
 }

--- a/tests/CsvHelper.Tests/Mappings/Attribute/CommentTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/CommentTests.cs
@@ -16,7 +16,7 @@ namespace CsvHelper.Tests.AttributeMapping
         [Fact]
         public void CommentTest()
         {
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(CommentTestClass));
+			var config = CsvConfiguration.FromType<CommentTestClass>(CultureInfo.InvariantCulture);
             Assert.Equal('x', config.Comment);
         }
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/CountBytesTest.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/CountBytesTest.cs
@@ -10,11 +10,14 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
-			Assert.True(config.CountBytes);
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).CountBytes);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).CountBytes);
 		}
 
-		[CountBytes(true)]
-		private class Foo { }
+		[CountBytes]
+		private class FooTrue { }
+
+		[CountBytes(false)]
+		private class FooFalse { }
 	}
 }

--- a/tests/CsvHelper.Tests/Mappings/Attribute/CountBytesTest.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/CountBytesTest.cs
@@ -10,8 +10,8 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).CountBytes);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).CountBytes);
+			Assert.True(CsvConfiguration.FromType<FooTrue>(CultureInfo.InvariantCulture).CountBytes);
+			Assert.False(CsvConfiguration.FromType<FooFalse>(CultureInfo.InvariantCulture).CountBytes);
 		}
 
 		[CountBytes]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/DelimiterTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/DelimiterTests.cs
@@ -16,7 +16,7 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void DelimiterReaderTest()
 		{
-			var configuration = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(DelimiterTestClass));
+			var configuration = CsvConfiguration.FromType<DelimiterTestClass>(CultureInfo.InvariantCulture);
 
 			Assert.Equal("§", configuration.Delimiter);
 		}

--- a/tests/CsvHelper.Tests/Mappings/Attribute/DetectColumnCountChangesTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/DetectColumnCountChangesTests.cs
@@ -10,11 +10,14 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
-			Assert.True(config.DetectColumnCountChanges);
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).DetectColumnCountChanges);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).DetectColumnCountChanges);
 		}
 
-		[DetectColumnCountChanges(true)]
-		private class Foo { }
+		[DetectColumnCountChanges]
+		private class FooTrue { }
+
+		[DetectColumnCountChanges(false)]
+		private class FooFalse { }
 	}
 }

--- a/tests/CsvHelper.Tests/Mappings/Attribute/DetectColumnCountChangesTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/DetectColumnCountChangesTests.cs
@@ -10,8 +10,8 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).DetectColumnCountChanges);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).DetectColumnCountChanges);
+			Assert.True(CsvConfiguration.FromType<FooTrue>(CultureInfo.InvariantCulture).DetectColumnCountChanges);
+			Assert.False(CsvConfiguration.FromType<FooFalse>(CultureInfo.InvariantCulture).DetectColumnCountChanges);
 		}
 
 		[DetectColumnCountChanges]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/DetectDelimiterTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/DetectDelimiterTests.cs
@@ -10,11 +10,14 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
-			Assert.True(config.DetectDelimiter);
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).DetectDelimiter);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).DetectDelimiter);
 		}
 
-		[DetectDelimiter(true)]
-		private class Foo { }
+		[DetectDelimiter]
+		private class FooTrue { }
+
+		[DetectDelimiter(false)]
+		private class FooFalse { }
 	}
 }

--- a/tests/CsvHelper.Tests/Mappings/Attribute/DetectDelimiterTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/DetectDelimiterTests.cs
@@ -10,8 +10,8 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).DetectDelimiter);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).DetectDelimiter);
+			Assert.True(CsvConfiguration.FromType<FooTrue>(CultureInfo.InvariantCulture).DetectDelimiter);
+			Assert.False(CsvConfiguration.FromType<FooFalse>(CultureInfo.InvariantCulture).DetectDelimiter);
 		}
 
 		[DetectDelimiter]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/DetectDelimiterValuesTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/DetectDelimiterValuesTests.cs
@@ -15,7 +15,7 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
+			var config = CsvConfiguration.FromType<Foo>(CultureInfo.InvariantCulture);
 			Assert.Equal(new[] { "a", "b" }, config.DetectDelimiterValues);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/EncodingTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/EncodingTests.cs
@@ -15,8 +15,8 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void EncodingTest()
 		{
-			Assert.Equal(Encoding.ASCII, new CsvConfiguration(CultureInfo.InvariantCulture, typeof(EncodingNameTestClass)).Encoding);
-			Assert.Equal(Encoding.ASCII, new CsvConfiguration(CultureInfo.InvariantCulture, typeof(EncodingCodepageTestClass)).Encoding);
+			Assert.Equal(Encoding.ASCII, CsvConfiguration.FromType<EncodingNameTestClass>(CultureInfo.InvariantCulture).Encoding);
+			Assert.Equal(Encoding.ASCII, CsvConfiguration.FromType<EncodingCodepageTestClass>(CultureInfo.InvariantCulture).Encoding);
 		}
 
 		[Encoding("ASCII")]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/EncodingTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/EncodingTests.cs
@@ -5,8 +5,6 @@
 using CsvHelper.Configuration;
 using CsvHelper.Configuration.Attributes;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -17,13 +15,20 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void EncodingTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(EncodingTestClass));
-
-			Assert.Equal(Encoding.ASCII, config.Encoding);
+			Assert.Equal(Encoding.ASCII, new CsvConfiguration(CultureInfo.InvariantCulture, typeof(EncodingNameTestClass)).Encoding);
+			Assert.Equal(Encoding.ASCII, new CsvConfiguration(CultureInfo.InvariantCulture, typeof(EncodingCodepageTestClass)).Encoding);
 		}
 
 		[Encoding("ASCII")]
-		private class EncodingTestClass
+		private class EncodingNameTestClass
+		{
+			public int Id { get; set; }
+
+			public string Name { get; set; }
+		}
+
+		[Encoding(20127)]
+		private class EncodingCodepageTestClass
 		{
 			public int Id { get; set; }
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/EscapeTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/EscapeTests.cs
@@ -16,7 +16,7 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void EscapeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(EscapeTestClass));
+			var config = CsvConfiguration.FromType<EscapeTestClass>(CultureInfo.InvariantCulture);
 
 			Assert.Equal('x', config.Escape);
 		}

--- a/tests/CsvHelper.Tests/Mappings/Attribute/ExceptionMessagesContainRawDataTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/ExceptionMessagesContainRawDataTests.cs
@@ -1,11 +1,6 @@
 ﻿using CsvHelper.Configuration;
 using CsvHelper.Configuration.Attributes;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace CsvHelper.Tests.Mappings.Attribute
@@ -15,11 +10,14 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
-			Assert.False(config.ExceptionMessagesContainRawData);
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).ExceptionMessagesContainRawData);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).ExceptionMessagesContainRawData);
 		}
 
+		[ExceptionMessagesContainRawData]
+		private class FooTrue { }
+
 		[ExceptionMessagesContainRawData(false)]
-		private class Foo { }
+		private class FooFalse { }
 	}
 }

--- a/tests/CsvHelper.Tests/Mappings/Attribute/ExceptionMessagesContainRawDataTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/ExceptionMessagesContainRawDataTests.cs
@@ -10,8 +10,8 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).ExceptionMessagesContainRawData);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).ExceptionMessagesContainRawData);
+			Assert.True(CsvConfiguration.FromType<FooTrue>(CultureInfo.InvariantCulture).ExceptionMessagesContainRawData);
+			Assert.False(CsvConfiguration.FromType<FooFalse>(CultureInfo.InvariantCulture).ExceptionMessagesContainRawData);
 		}
 
 		[ExceptionMessagesContainRawData]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/HasHeaderRecordTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/HasHeaderRecordTests.cs
@@ -14,8 +14,8 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void HasHeaderRecordTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(HasHeaderRecordTrueTestClass)).HasHeaderRecord);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(HasHeaderRecordFalseTestClass)).HasHeaderRecord);
+			Assert.True(CsvConfiguration.FromType<HasHeaderRecordTrueTestClass>(CultureInfo.InvariantCulture).HasHeaderRecord);
+			Assert.False(CsvConfiguration.FromType<HasHeaderRecordFalseTestClass>(CultureInfo.InvariantCulture).HasHeaderRecord);
 		}
 
 		[HasHeaderRecord]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/HasHeaderRecordTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/HasHeaderRecordTests.cs
@@ -14,13 +14,20 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void HasHeaderRecordTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(HasHeaderRecordTestClass));
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(HasHeaderRecordTrueTestClass)).HasHeaderRecord);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(HasHeaderRecordFalseTestClass)).HasHeaderRecord);
+		}
 
-			Assert.False(config.HasHeaderRecord);
+		[HasHeaderRecord]
+		private class HasHeaderRecordTrueTestClass
+		{
+			public int Id { get; set; }
+
+			public string Name { get; set; }
 		}
 
 		[HasHeaderRecord(false)]
-		private class HasHeaderRecordTestClass
+		private class HasHeaderRecordFalseTestClass
 		{
 			public int Id { get; set; }
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/IgnoreBlankLinesTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/IgnoreBlankLinesTests.cs
@@ -2,10 +2,9 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // http://csvhelper.com
+using CsvHelper.Configuration;
 using CsvHelper.Configuration.Attributes;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using Xunit;
 
 namespace CsvHelper.Tests.AttributeMapping
@@ -15,18 +14,20 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void IgnoreBlankLinesTest()
 		{
-			using (var reader = new StringReader("Id,Name\r\n1,one\r\n"))
-			using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
-			{
-				var records = csv.GetRecords<IgnoreBlankLinesTestClass>().ToList();
-				var actual = csv.Configuration.IgnoreBlankLines;
-
-				Assert.True(actual);
-			}
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(IgnoreBlankLinesTrueTestClass)).IgnoreBlankLines);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(IgnoreBlankLinesFalseTestClass)).IgnoreBlankLines);
 		}
 
-		[IgnoreBlankLines(true)]
-		private class IgnoreBlankLinesTestClass
+		[IgnoreBlankLines]
+		private class IgnoreBlankLinesTrueTestClass
+		{
+			public int Id { get; set; }
+
+			public string Name { get; set; }
+		}
+
+		[IgnoreBlankLines(false)]
+		private class IgnoreBlankLinesFalseTestClass
 		{
 			public int Id { get; set; }
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/IgnoreBlankLinesTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/IgnoreBlankLinesTests.cs
@@ -14,8 +14,8 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void IgnoreBlankLinesTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(IgnoreBlankLinesTrueTestClass)).IgnoreBlankLines);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(IgnoreBlankLinesFalseTestClass)).IgnoreBlankLines);
+			Assert.True(CsvConfiguration.FromType<IgnoreBlankLinesTrueTestClass>(CultureInfo.InvariantCulture).IgnoreBlankLines);
+			Assert.False(CsvConfiguration.FromType<IgnoreBlankLinesFalseTestClass>(CultureInfo.InvariantCulture).IgnoreBlankLines);
 		}
 
 		[IgnoreBlankLines]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/IgnoreReferencesTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/IgnoreReferencesTests.cs
@@ -10,8 +10,8 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).IgnoreReferences);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).IgnoreReferences);
+			Assert.True(CsvConfiguration.FromType<FooTrue>(CultureInfo.InvariantCulture).IgnoreReferences);
+			Assert.False(CsvConfiguration.FromType<FooFalse>(CultureInfo.InvariantCulture).IgnoreReferences);
 		}
 
 		[IgnoreReferences]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/IgnoreReferencesTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/IgnoreReferencesTests.cs
@@ -1,11 +1,6 @@
 ﻿using CsvHelper.Configuration;
 using CsvHelper.Configuration.Attributes;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace CsvHelper.Tests.Mappings.Attribute
@@ -15,11 +10,14 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
-			Assert.True(config.IgnoreReferences);
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).IgnoreReferences);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).IgnoreReferences);
 		}
 
-		[IgnoreReferences(true)]
-		private class Foo { }
+		[IgnoreReferences]
+		private class FooTrue { }
+
+		[IgnoreReferences(false)]
+		private class FooFalse { }
 	}
 }

--- a/tests/CsvHelper.Tests/Mappings/Attribute/IncludePrivateMembersTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/IncludePrivateMembersTests.cs
@@ -14,8 +14,8 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void IncludePrivateMembersTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(IncludePrivateMembersTrueTestClass)).IncludePrivateMembers);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(IncludePrivateMembersFalseTestClass)).IncludePrivateMembers);
+			Assert.True(CsvConfiguration.FromType<IncludePrivateMembersTrueTestClass>(CultureInfo.InvariantCulture).IncludePrivateMembers);
+			Assert.False(CsvConfiguration.FromType<IncludePrivateMembersFalseTestClass>(CultureInfo.InvariantCulture).IncludePrivateMembers);
 		}
 
 		[IncludePrivateMembers]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/IncludePrivateMembersTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/IncludePrivateMembersTests.cs
@@ -12,14 +12,22 @@ namespace CsvHelper.Tests.AttributeMapping
 	public class IncludePrivateMembersTests
 	{
 		[Fact]
-		public void TrimOptionsTest()
+		public void IncludePrivateMembersTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(IncludePrivateMembersTestClass));
-			Assert.True(config.IncludePrivateMembers);
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(IncludePrivateMembersTrueTestClass)).IncludePrivateMembers);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(IncludePrivateMembersFalseTestClass)).IncludePrivateMembers);
 		}
 
-		[IncludePrivateMembers(true)]
-		private class IncludePrivateMembersTestClass
+		[IncludePrivateMembers]
+		private class IncludePrivateMembersTrueTestClass
+		{
+			public int Id { get; set; }
+
+			public string Name { get; set; }
+		}
+
+		[IncludePrivateMembers(false)]
+		private class IncludePrivateMembersFalseTestClass
 		{
 			public int Id { get; set; }
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/InjectionCharactersTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/InjectionCharactersTests.cs
@@ -15,7 +15,7 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
+			var config = CsvConfiguration.FromType<Foo>(CultureInfo.InvariantCulture);
 			Assert.Equal(new[] { 'a', 'b' }, config.InjectionCharacters);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/InjectionEscapeCharacterTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/InjectionEscapeCharacterTests.cs
@@ -15,7 +15,7 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
+			var config = CsvConfiguration.FromType<Foo>(CultureInfo.InvariantCulture);
 			Assert.Equal('a', config.InjectionEscapeCharacter);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/InjectionOptionsTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/InjectionOptionsTests.cs
@@ -15,7 +15,7 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
+			var config = CsvConfiguration.FromType<Foo>(CultureInfo.InvariantCulture);
 			Assert.Equal(InjectionOptions.Escape, config.InjectionOptions);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/LineBreakInQuotedFieldIsBadDataTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/LineBreakInQuotedFieldIsBadDataTests.cs
@@ -1,11 +1,6 @@
 ﻿using CsvHelper.Configuration;
 using CsvHelper.Configuration.Attributes;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace CsvHelper.Tests.Mappings.Attribute
@@ -15,11 +10,14 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
-			Assert.True(config.LineBreakInQuotedFieldIsBadData);
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).LineBreakInQuotedFieldIsBadData);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).LineBreakInQuotedFieldIsBadData);
 		}
 
-		[LineBreakInQuotedFieldIsBadData(true)]
-		private class Foo { }
+		[LineBreakInQuotedFieldIsBadData]
+		private class FooTrue { }
+
+		[LineBreakInQuotedFieldIsBadData(false)]
+		private class FooFalse { }
 	}
 }

--- a/tests/CsvHelper.Tests/Mappings/Attribute/LineBreakInQuotedFieldIsBadDataTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/LineBreakInQuotedFieldIsBadDataTests.cs
@@ -10,8 +10,8 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).LineBreakInQuotedFieldIsBadData);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).LineBreakInQuotedFieldIsBadData);
+			Assert.True(CsvConfiguration.FromType<FooTrue>(CultureInfo.InvariantCulture).LineBreakInQuotedFieldIsBadData);
+			Assert.False(CsvConfiguration.FromType<FooFalse>(CultureInfo.InvariantCulture).LineBreakInQuotedFieldIsBadData);
 		}
 
 		[LineBreakInQuotedFieldIsBadData]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/MaxFieldSizeTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/MaxFieldSizeTests.cs
@@ -10,7 +10,7 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
+			var config = CsvConfiguration.FromType<Foo>(CultureInfo.InvariantCulture);
 			Assert.Equal(2, config.MaxFieldSize);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/MemberTypesTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/MemberTypesTests.cs
@@ -10,7 +10,7 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
+			var config = CsvConfiguration.FromType<Foo>(CultureInfo.InvariantCulture);
 			Assert.Equal(MemberTypes.Fields, config.MemberTypes);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/ModeTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/ModeTests.cs
@@ -10,7 +10,7 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
+			var config = CsvConfiguration.FromType<Foo>(CultureInfo.InvariantCulture);
 			Assert.Equal(CsvMode.Escape, config.Mode);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/NewLineTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/NewLineTests.cs
@@ -10,7 +10,7 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
+			var config = CsvConfiguration.FromType<Foo>(CultureInfo.InvariantCulture);
 			Assert.Equal("a", config.NewLine);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/ProcessFieldBufferSizeTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/ProcessFieldBufferSizeTests.cs
@@ -10,7 +10,7 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
+			var config = CsvConfiguration.FromType<Foo>(CultureInfo.InvariantCulture);
 			Assert.Equal(2, config.ProcessFieldBufferSize);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/QuoteTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/QuoteTests.cs
@@ -14,7 +14,7 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void QuoteTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(QuoteTestClass));
+			var config = CsvConfiguration.FromType<QuoteTestClass>(CultureInfo.InvariantCulture);
 			Assert.Equal('x', config.Quote);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/TrimOptionsTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/TrimOptionsTests.cs
@@ -16,7 +16,7 @@ namespace CsvHelper.Tests.AttributeMapping
 		[Fact]
 		public void TrimOptionsTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(TrimOptionsTestClass));
+			var config = CsvConfiguration.FromType<TrimOptionsTestClass>(CultureInfo.InvariantCulture);
 			Assert.Equal(TrimOptions.InsideQuotes, config.TrimOptions);
 		}
 

--- a/tests/CsvHelper.Tests/Mappings/Attribute/UseNewObjectForNullReferenceMembersTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/UseNewObjectForNullReferenceMembersTests.cs
@@ -10,8 +10,8 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).UseNewObjectForNullReferenceMembers);
-			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).UseNewObjectForNullReferenceMembers);
+			Assert.True(CsvConfiguration.FromType<FooTrue>(CultureInfo.InvariantCulture).UseNewObjectForNullReferenceMembers);
+			Assert.False(CsvConfiguration.FromType<FooFalse>(CultureInfo.InvariantCulture).UseNewObjectForNullReferenceMembers);
 		}
 
 		[UseNewObjectForNullReferenceMembers]

--- a/tests/CsvHelper.Tests/Mappings/Attribute/UseNewObjectForNullReferenceMembersTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/UseNewObjectForNullReferenceMembersTests.cs
@@ -10,11 +10,14 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
-			Assert.False(config.UseNewObjectForNullReferenceMembers);
+			Assert.True(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooTrue)).UseNewObjectForNullReferenceMembers);
+			Assert.False(new CsvConfiguration(CultureInfo.InvariantCulture, typeof(FooFalse)).UseNewObjectForNullReferenceMembers);
 		}
 
+		[UseNewObjectForNullReferenceMembers]
+		private class FooTrue { }
+
 		[UseNewObjectForNullReferenceMembers(false)]
-		private class Foo { }
+		private class FooFalse { }
 	}
 }

--- a/tests/CsvHelper.Tests/Mappings/Attribute/WhiteSpaceCharsTests.cs
+++ b/tests/CsvHelper.Tests/Mappings/Attribute/WhiteSpaceCharsTests.cs
@@ -10,7 +10,7 @@ namespace CsvHelper.Tests.Mappings.Attribute
 		[Fact]
 		public void ConstructorAttributeTest()
 		{
-			var config = new CsvConfiguration(CultureInfo.InvariantCulture, typeof(Foo));
+			var config = CsvConfiguration.FromType<Foo>(CultureInfo.InvariantCulture);
 			Assert.Equal(new[] { 'a', 'b' }, config.WhiteSpaceChars);
 		}
 


### PR DESCRIPTION
Probably better viewed per commit. Had planned separate PRs but it is easier this way given the conflicts. The commits are separate at least:

1. Set default `true` for boolean-valued attributes. Allows e.g. `[CountBytes]` instead of `[CountBytes(true)]`
2. Add additional `EncodingAttribute(int codepage)` constructor
3. Allow using static `CultureInfo` properties via `CultureInfoAttribute` e.g. `[CultureInfo("InvariantCulture")]`
4. (The main event) Allow `CultureInfoAttribute` on classes
   - This proposes a breaking change to remove the optional `Type?` parameter in the constructor of `CsvConfiguration` and instead add a couple of static helpers to initialise a `CsvConfiguration` from an annotated type. This takes the mapping work out of the constructor and makes the `CultureInfo` behaviour explicit as to whether it is expected on the type or not. Users who do not want to use the static helpers can still call `ApplyAttributes` after the constructor.

Example (adapted from an updated example in this PR):

```csharp
void Main()
{
	string s = @"Identifier||Amount2|IsBool|Constant
1|1,234|1,234|yes|a
2|1.234|1.234|no|b
";

	CsvConfiguration config = CsvConfiguration.FromType<Foo>(); // <----------
	using (var reader = new StringReader(s))
	using (var csv = new CsvReader(reader, config))
	{
		List<Foo> records = csv.GetRecords<Foo>().ToList();

		// These print "True"

		Console.WriteLine(records[0].Amount == 1.234m); // Using "de-DE"
		Console.WriteLine(records[0].Amount2 == 1234); // Using InvariantCulture

		Console.WriteLine(records[1].Amount == 1234);
		Console.WriteLine(records[1].Amount2 == 1.234m);

	}
}

[Delimiter("|")]
[CultureInfo("de-DE")] // <----------
public class Foo
{
	[Name("Identifier")]
	public int Id { get; set; }

	[Index(1)]
	public decimal Amount { get; set; }
	
	[CultureInfo("InvariantCulture")]
	public decimal Amount2 { get; set; }

	[BooleanTrueValues("yes")]
	[BooleanFalseValues("no")]
	public bool IsBool { get; set; }

	[Constant("bar")]
	public string Constant { get; set; }

	[Optional]
	public string Optional { get; set; }

	[Ignore]
	public string Ignored { get; set; }
}
```

fixes #2131 
fixes #2107 
fixes #2076 