### PR TITLE
add max buffer sizes and if should process bad field flag

### DIFF
--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -28,6 +28,8 @@ namespace CsvHelper.Configuration
 		/// <inheritdoc/>
 		public virtual BadDataFound BadDataFound { get; set; } = ConfigurationFunctions.BadDataFound;
 
+		public virtual bool ProcessBadDataFields { get; set; } = true;
+
 		/// <inheritdoc/>
 		public virtual int BufferSize { get; set; } = 0x1000;
 
@@ -36,6 +38,9 @@ namespace CsvHelper.Configuration
 
 		/// <inheritdoc/>
 		public virtual char Comment { get; set; } = '#';
+
+		/// <inheritdoc/>
+		public virtual int? MaxProcessFieldBufferSize { get; set; }
 
 		/// <inheritdoc/>
 		public virtual bool CountBytes { get; set; }
@@ -134,6 +139,9 @@ namespace CsvHelper.Configuration
 
 		/// <inheritdoc/>
 		public virtual int ProcessFieldBufferSize { get; set; } = 1024;
+
+		/// <inheritdoc/>
+		public virtual int? MaxBufferSize { get; set; }
 
 		/// <inheritdoc/>
 		public virtual char Quote { get; set; } = '"';

--- a/src/CsvHelper/Configuration/IParserConfiguration.cs
+++ b/src/CsvHelper/Configuration/IParserConfiguration.cs
@@ -62,6 +62,20 @@ namespace CsvHelper.Configuration
 		int ProcessFieldBufferSize { get; }
 
 		/// <summary>
+		/// Gets the maximum allowed size of the buffer which must not be increased above that value.
+		/// No limit if not defined.
+		/// </summary>
+		int? MaxBufferSize { get; }
+
+		/// <summary>
+		/// Gets the maximum allowed size of the process field buffer which must not be increased above that value.
+		/// If field is longer value is truncated what leads to data loss.
+		/// No limit if not defined.
+		/// WARNING: setting too low value can lead to field truncation if length bigger than this value
+		/// </summary>
+		int? MaxProcessFieldBufferSize { get; }
+
+		/// <summary>
 		/// Gets a value indicating whether the number of bytes should
 		/// be counted while parsing. Default is false. This will slow down parsing
 		/// because it needs to get the byte count of every char for the given encoding.
@@ -81,6 +95,11 @@ namespace CsvHelper.Configuration
 		/// instead of throwing an exception.
 		/// </summary>
 		BadDataFound BadDataFound { get; }
+
+		/// <summary>
+		/// If set bad data fields are not processed and empty array allocated for them
+		/// </summary>
+		bool ProcessBadDataFields { get; }
 
 		/// <summary>
 		/// Gets or sets the maximum size of a field.

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -22,8 +22,7 @@ namespace CsvHelper
 	/// </summary>
 	public class CsvParser : IParser, IDisposable
 	{
-		private readonly IParserConfiguration configuration;
-		private readonly FieldCache fieldCache = new FieldCache();
+		private readonly FieldCache fieldCache = new();
 		private readonly TextReader reader;
 		private readonly char quote;
 		private readonly char escape;
@@ -45,8 +44,10 @@ namespace CsvHelper
 		private readonly string[] delimiterValues;
 		private readonly bool detectDelimiter;
 		private readonly double maxFieldSize;
+		private readonly int? maxProcessFieldBufferSize;
+		private readonly int? maxBufferSize;
+		private readonly bool processBadDataFields;
 
-		private string delimiter;
 		private char delimiterFirstChar;
 		private char[] buffer;
 		private int bufferSize;
@@ -54,15 +55,10 @@ namespace CsvHelper
 		private int bufferPosition;
 		private int rowStartPosition;
 		private int fieldStartPosition;
-		private int row;
-		private int rawRow;
-		private long charCount;
-		private long byteCount;
 		private bool inQuotes;
 		private bool inEscape;
 		private Field[] fields;
 		private string[] processedFields;
-		private int fieldsPosition;
 		private bool disposed;
 		private int quoteCount;
 		private char[] processFieldBuffer;
@@ -76,31 +72,31 @@ namespace CsvHelper
 		private bool isRecordProcessed;
 		private string[]? record;
 
-		/// <inheritdoc/>
-		public long CharCount => charCount;
+		/// <inheritdoc />
+		public long CharCount { get; private set; }
 
-		/// <inheritdoc/>
-		public long ByteCount => byteCount;
+		/// <inheritdoc />
+		public long ByteCount { get; private set; }
 
-		/// <inheritdoc/>
-		public int Row => row;
+		/// <inheritdoc />
+		public int Row { get; private set; }
 
-		/// <inheritdoc/>
+		/// <inheritdoc />
 		public string[]? Record
 		{
 			get
 			{
-				if (isRecordProcessed == true)
+				if (isRecordProcessed)
 				{
 					return this.record;
 				}
 
-				if (fieldsPosition == 0)
+				if (Count == 0)
 				{
 					return null;
 				}
 
-				var record = new string[fieldsPosition];
+				var record = new string[Count];
 
 				for (var i = 0; i < record.Length; i++)
 				{
@@ -114,25 +110,25 @@ namespace CsvHelper
 			}
 		}
 
-		/// <inheritdoc/>
-		public string RawRecord => new string(buffer, rowStartPosition, bufferPosition - rowStartPosition);
+		/// <inheritdoc />
+		public string RawRecord => new(buffer, rowStartPosition, bufferPosition - rowStartPosition);
 
-		/// <inheritdoc/>
-		public int Count => fieldsPosition;
+		/// <inheritdoc />
+		public int Count { get; private set; }
 
-		/// <inheritdoc/>
-		public int RawRow => rawRow;
+		/// <inheritdoc />
+		public int RawRow { get; private set; }
 
-		/// <inheritdoc/>
-		public string Delimiter => delimiter;
+		/// <inheritdoc />
+		public string Delimiter { get; private set; }
 
-		/// <inheritdoc/>
-		public CsvContext Context { get; private set; }
+		/// <inheritdoc />
+		public CsvContext Context { get; }
 
-		/// <inheritdoc/>
-		public IParserConfiguration Configuration => configuration;
+		/// <inheritdoc />
+		public IParserConfiguration Configuration { get; }
 
-		/// <inheritdoc/>
+		/// <inheritdoc />
 		public string this[int index]
 		{
 			get
@@ -140,9 +136,9 @@ namespace CsvHelper
 				if (isProcessingField)
 				{
 					var message =
-						$"You can't access {nameof(IParser)}[int] or {nameof(IParser)}.{nameof(IParser.Record)} inside of the {nameof(BadDataFound)} callback. " +
-						$"Use {nameof(BadDataFoundArgs)}.{nameof(BadDataFoundArgs.Field)} and {nameof(BadDataFoundArgs)}.{nameof(BadDataFoundArgs.RawRecord)} instead."
-					;
+							$"You can't access {nameof(IParser)}[int] or {nameof(IParser)}.{nameof(IParser.Record)} inside of the {nameof(BadDataFound)} callback. " +
+							$"Use {nameof(BadDataFoundArgs)}.{nameof(BadDataFoundArgs.Field)} and {nameof(BadDataFoundArgs)}.{nameof(BadDataFoundArgs.RawRecord)} instead."
+						;
 
 					throw new ParserException(Context, message);
 				}
@@ -158,15 +154,21 @@ namespace CsvHelper
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="CsvParser"/> class.
+		///     Initializes a new instance of the <see cref="CsvParser" /> class.
 		/// </summary>
 		/// <param name="reader">The reader.</param>
 		/// <param name="culture">The culture.</param>
 		/// <param name="leaveOpen">if set to <c>true</c> [leave open].</param>
-		public CsvParser(TextReader reader, CultureInfo culture, bool leaveOpen = false) : this(reader, new CsvConfiguration(culture), leaveOpen) { }
+		public CsvParser(TextReader reader, CultureInfo culture, bool leaveOpen = false) : this(
+			reader,
+			new CsvConfiguration(culture),
+			leaveOpen
+		)
+		{
+		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="CsvParser"/> class.
+		///     Initializes a new instance of the <see cref="CsvParser" /> class.
 		/// </summary>
 		/// <param name="reader">The reader.</param>
 		/// <param name="configuration">The configuration.</param>
@@ -174,7 +176,7 @@ namespace CsvHelper
 		public CsvParser(TextReader reader, IParserConfiguration configuration, bool leaveOpen = false)
 		{
 			this.reader = reader ?? throw new ArgumentNullException(nameof(reader));
-			this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+			Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
 			configuration.Validate();
 
@@ -186,7 +188,7 @@ namespace CsvHelper
 			cacheFields = configuration.CacheFields;
 			comment = configuration.Comment;
 			countBytes = configuration.CountBytes;
-			delimiter = configuration.Delimiter;
+			Delimiter = configuration.Delimiter;
 			delimiterFirstChar = configuration.Delimiter[0];
 			delimiterValues = configuration.DetectDelimiterValues;
 			detectDelimiter = configuration.DetectDelimiter;
@@ -197,6 +199,9 @@ namespace CsvHelper
 			this.leaveOpen = leaveOpen;
 			lineBreakInQuotedFieldIsBadData = configuration.LineBreakInQuotedFieldIsBadData;
 			maxFieldSize = configuration.MaxFieldSize;
+			maxProcessFieldBufferSize = configuration.MaxProcessFieldBufferSize;
+			maxBufferSize = configuration.MaxBufferSize;
+			processBadDataFields = configuration.ProcessBadDataFields;
 			newLine = configuration.NewLine;
 			newLineFirstChar = configuration.NewLine[0];
 			mode = configuration.Mode;
@@ -211,16 +216,16 @@ namespace CsvHelper
 			processedFields = new string[128];
 		}
 
-		/// <inheritdoc/>
+		/// <inheritdoc />
 		public bool Read()
 		{
 			isRecordProcessed = false;
 			rowStartPosition = bufferPosition;
 			fieldStartPosition = rowStartPosition;
-			fieldsPosition = 0;
+			Count = 0;
 			quoteCount = 0;
-			row++;
-			rawRow++;
+			Row++;
+			RawRow++;
 			var c = '\0';
 			var cPrev = c;
 
@@ -233,7 +238,7 @@ namespace CsvHelper
 						return ReadEndOfFile();
 					}
 
-					if (row == 1 && detectDelimiter)
+					if (Row == 1 && detectDelimiter)
 					{
 						DetectDelimiter();
 					}
@@ -246,16 +251,68 @@ namespace CsvHelper
 			}
 		}
 
-		/// <inheritdoc/>
+		private bool FillBuffer()
+		{
+			if (IsBufferSizeNotExceeded() && rowStartPosition == 0 && CharCount > 0 && charsRead == bufferSize)
+			{
+				// The record is longer than the memory buffer. Increase the buffer.
+				bufferSize *= 2;
+
+				SetBufferToMaxValueIfExceeded();
+
+				var tempBuffer = new char[bufferSize];
+				buffer.CopyTo(tempBuffer, 0);
+				buffer = tempBuffer;
+			}
+
+			var charsLeft = Math.Max(charsRead - rowStartPosition, 0);
+
+			Array.Copy(buffer, rowStartPosition, buffer, 0, charsLeft);
+
+			fieldStartPosition -= rowStartPosition;
+			rowStartPosition = 0;
+			bufferPosition = charsLeft;
+
+			charsRead = reader.Read(buffer, charsLeft, buffer.Length - charsLeft);
+
+			if (charsRead == 0)
+			{
+				return false;
+			}
+
+			charsRead += charsLeft;
+
+			return true;
+		}
+
+		private bool IsBufferSizeNotExceeded()
+		{
+			if (!maxBufferSize.HasValue)
+			{
+				return true;
+			}
+
+			return bufferSize < maxBufferSize;
+		}
+
+		private void SetBufferToMaxValueIfExceeded()
+		{
+			if (maxBufferSize.HasValue && bufferSize > maxBufferSize)
+			{
+				bufferSize = maxBufferSize.Value;
+			}
+		}
+
+		/// <inheritdoc />
 		public async Task<bool> ReadAsync()
 		{
 			isRecordProcessed = false;
 			rowStartPosition = bufferPosition;
 			fieldStartPosition = rowStartPosition;
-			fieldsPosition = 0;
+			Count = 0;
 			quoteCount = 0;
-			row++;
-			rawRow++;
+			Row++;
+			RawRow++;
 			var c = '\0';
 			var cPrev = c;
 
@@ -268,7 +325,7 @@ namespace CsvHelper
 						return ReadEndOfFile();
 					}
 
-					if (row == 1 && detectDelimiter)
+					if (Row == 1 && detectDelimiter)
 					{
 						DetectDelimiter();
 					}
@@ -281,15 +338,50 @@ namespace CsvHelper
 			}
 		}
 
+		private async Task<bool> FillBufferAsync()
+		{
+			if (IsBufferSizeNotExceeded() && rowStartPosition == 0 && CharCount > 0 && charsRead == bufferSize)
+			{
+				// The record is longer than the memory buffer. Increase the buffer.
+				bufferSize *= 2;
+
+				SetBufferToMaxValueIfExceeded();
+
+				var tempBuffer = new char[bufferSize];
+				buffer.CopyTo(tempBuffer, 0);
+				buffer = tempBuffer;
+			}
+
+			var charsLeft = Math.Max(charsRead - rowStartPosition, 0);
+
+			Array.Copy(buffer, rowStartPosition, buffer, 0, charsLeft);
+
+			fieldStartPosition -= rowStartPosition;
+			rowStartPosition = 0;
+			bufferPosition = charsLeft;
+
+			charsRead = await reader.ReadAsync(buffer, charsLeft, buffer.Length - charsLeft).ConfigureAwait(false);
+
+			if (charsRead == 0)
+			{
+				return false;
+			}
+
+			charsRead += charsLeft;
+
+			return true;
+		}
+
 		private void DetectDelimiter()
 		{
 			var text = new string(buffer, 0, charsRead);
-			var newDelimiter = configuration.GetDelimiter(new GetDelimiterArgs(text, configuration));
+			var newDelimiter = Configuration.GetDelimiter(new GetDelimiterArgs(text, Configuration));
+
 			if (newDelimiter != null)
 			{
-				delimiter = newDelimiter;
+				Delimiter = newDelimiter;
 				delimiterFirstChar = newDelimiter[0];
-				configuration.Validate();
+				Configuration.Validate();
 			}
 		}
 
@@ -301,33 +393,42 @@ namespace CsvHelper
 				{
 					// Continue the state before doing anything else.
 					ReadLineResult result;
+
 					switch (state)
 					{
 						case ParserState.Spaces:
 							result = ReadSpaces(ref c);
+
 							break;
 						case ParserState.BlankLine:
 							result = ReadBlankLine(ref c);
+
 							break;
 						case ParserState.Delimiter:
 							result = ReadDelimiter(ref c);
+
 							break;
 						case ParserState.LineEnding:
 							result = ReadLineEnding(ref c);
+
 							break;
 						case ParserState.NewLine:
 							result = ReadNewLine(ref c);
+
 							break;
 						default:
 							throw new InvalidOperationException($"Parser state '{state}' is not valid.");
 					}
 
 					var shouldReturn =
-						// Buffer needs to be filled.
-						result == ReadLineResult.Incomplete ||
-						// Done reading row.
-						result == ReadLineResult.Complete && (state == ParserState.LineEnding || state == ParserState.NewLine)
-					;
+
+							// Buffer needs to be filled.
+							result == ReadLineResult.Incomplete ||
+
+							// Done reading row.
+							(result == ReadLineResult.Complete &&
+							 (state == ParserState.LineEnding || state == ParserState.NewLine))
+						;
 
 					if (result == ReadLineResult.Complete)
 					{
@@ -343,11 +444,11 @@ namespace CsvHelper
 				cPrev = c;
 				c = buffer[bufferPosition];
 				bufferPosition++;
-				charCount++;
+				CharCount++;
 
 				if (countBytes)
 				{
-					byteCount += encoding.GetByteCount(new char[] { c });
+					ByteCount += encoding.GetByteCount(new[] { c });
 				}
 
 				if (maxFieldSize > 0 && bufferPosition - fieldStartPosition - 1 > maxFieldSize)
@@ -356,34 +457,41 @@ namespace CsvHelper
 				}
 
 				var isFirstCharOfRow = rowStartPosition == bufferPosition - 1;
-				if (isFirstCharOfRow && (allowComments && c == comment || ignoreBlankLines && ((c == '\r' || c == '\n') && !isNewLineSet || c == newLineFirstChar && isNewLineSet)))
+
+				if (isFirstCharOfRow &&
+				    ((allowComments && c == comment) ||
+				     (ignoreBlankLines &&
+				      (((c == '\r' || c == '\n') && !isNewLineSet) || (c == newLineFirstChar && isNewLineSet)))))
 				{
 					state = ParserState.BlankLine;
 					var result = ReadBlankLine(ref c);
+
 					if (result == ReadLineResult.Complete)
 					{
 						state = ParserState.None;
 
 						continue;
 					}
-					else
-					{
-						return ReadLineResult.Incomplete;
-					}
+
+					return ReadLineResult.Incomplete;
 				}
 
 				if (mode == CsvMode.RFC4180)
 				{
 					var isFirstCharOfField = fieldStartPosition == bufferPosition - 1;
+
 					if (isFirstCharOfField)
 					{
-						if ((trimOptions & TrimOptions.Trim) == TrimOptions.Trim && ArrayHelper.Contains(whiteSpaceChars, c))
+						if ((trimOptions & TrimOptions.Trim) == TrimOptions.Trim &&
+						    ArrayHelper.Contains(whiteSpaceChars, c))
 						{
 							// Skip through whitespace. This is so we can process the field later.
 							var result = ReadSpaces(ref c);
+
 							if (result == ReadLineResult.Incomplete)
 							{
 								fieldStartPosition = bufferPosition;
+
 								return result;
 							}
 						}
@@ -412,9 +520,9 @@ namespace CsvHelper
 
 						if (inQuotes)
 						{
-							if (c == '\r' || c == '\n' && cPrev != '\r')
+							if (c == '\r' || (c == '\n' && cPrev != '\r'))
 							{
-								rawRow++;
+								RawRow++;
 							}
 
 							// We don't care about anything else if we're in quotes.
@@ -452,6 +560,7 @@ namespace CsvHelper
 				{
 					state = ParserState.Delimiter;
 					var result = ReadDelimiter(ref c);
+
 					if (result == ReadLineResult.Incomplete)
 					{
 						return result;
@@ -466,6 +575,7 @@ namespace CsvHelper
 				{
 					state = ParserState.LineEnding;
 					var result = ReadLineEnding(ref c);
+
 					if (result == ReadLineResult.Complete)
 					{
 						state = ParserState.None;
@@ -478,6 +588,7 @@ namespace CsvHelper
 				{
 					state = ParserState.NewLine;
 					var result = ReadNewLine(ref c);
+
 					if (result == ReadLineResult.Complete)
 					{
 						state = ParserState.None;
@@ -501,10 +612,11 @@ namespace CsvHelper
 
 				c = buffer[bufferPosition];
 				bufferPosition++;
-				charCount++;
+				CharCount++;
+
 				if (countBytes)
 				{
-					byteCount += encoding.GetByteCount(new char[] { c });
+					ByteCount += encoding.GetByteCount(new[] { c });
 				}
 			}
 
@@ -518,12 +630,13 @@ namespace CsvHelper
 				if (c == '\r' || c == '\n')
 				{
 					var result = ReadLineEnding(ref c);
+
 					if (result == ReadLineResult.Complete)
 					{
 						rowStartPosition = bufferPosition;
 						fieldStartPosition = rowStartPosition;
-						row++;
-						rawRow++;
+						Row++;
+						RawRow++;
 					}
 
 					return result;
@@ -531,10 +644,11 @@ namespace CsvHelper
 
 				c = buffer[bufferPosition];
 				bufferPosition++;
-				charCount++;
+				CharCount++;
+
 				if (countBytes)
 				{
-					byteCount += encoding.GetByteCount(new char[] { c });
+					ByteCount += encoding.GetByteCount(new[] { c });
 				}
 			}
 
@@ -543,7 +657,7 @@ namespace CsvHelper
 
 		private ReadLineResult ReadDelimiter(ref char c)
 		{
-			for (var i = delimiterPosition; i < delimiter.Length; i++)
+			for (var i = delimiterPosition; i < Delimiter.Length; i++)
 			{
 				if (bufferPosition >= charsRead)
 				{
@@ -553,7 +667,8 @@ namespace CsvHelper
 				delimiterPosition++;
 
 				c = buffer[bufferPosition];
-				if (c != delimiter[i])
+
+				if (c != Delimiter[i])
 				{
 					c = buffer[bufferPosition - 1];
 					delimiterPosition = 1;
@@ -562,10 +677,11 @@ namespace CsvHelper
 				}
 
 				bufferPosition++;
-				charCount++;
+				CharCount++;
+
 				if (countBytes)
 				{
-					byteCount += encoding.GetByteCount(new[] { c });
+					ByteCount += encoding.GetByteCount(new[] { c });
 				}
 
 				if (bufferPosition >= charsRead)
@@ -574,7 +690,7 @@ namespace CsvHelper
 				}
 			}
 
-			AddField(fieldStartPosition, bufferPosition - fieldStartPosition - delimiter.Length);
+			AddField(fieldStartPosition, bufferPosition - fieldStartPosition - Delimiter.Length);
 
 			fieldStartPosition = bufferPosition;
 			delimiterPosition = 1;
@@ -600,10 +716,11 @@ namespace CsvHelper
 				{
 					lessChars++;
 					bufferPosition++;
-					charCount++;
+					CharCount++;
+
 					if (countBytes)
 					{
-						byteCount += encoding.GetByteCount(new char[] { c });
+						ByteCount += encoding.GetByteCount(new[] { c });
 					}
 				}
 			}
@@ -630,6 +747,7 @@ namespace CsvHelper
 				newLinePosition++;
 
 				c = buffer[bufferPosition];
+
 				if (c != newLine[i])
 				{
 					c = buffer[bufferPosition - 1];
@@ -639,10 +757,11 @@ namespace CsvHelper
 				}
 
 				bufferPosition++;
-				charCount++;
+				CharCount++;
+
 				if (countBytes)
 				{
-					byteCount += encoding.GetByteCount(new[] { c });
+					ByteCount += encoding.GetByteCount(new[] { c });
 				}
 
 				if (bufferPosition >= charsRead)
@@ -672,7 +791,7 @@ namespace CsvHelper
 
 			if (state == ParserState.Delimiter)
 			{
-				AddField(fieldStartPosition, bufferPosition - fieldStartPosition - delimiter.Length);
+				AddField(fieldStartPosition, bufferPosition - fieldStartPosition - Delimiter.Length);
 
 				fieldStartPosition = bufferPosition;
 
@@ -700,94 +819,32 @@ namespace CsvHelper
 				AddField(fieldStartPosition, bufferPosition - fieldStartPosition);
 			}
 
-			return fieldsPosition > 0;
+			return Count > 0;
 		}
 
 		private void AddField(int start, int length)
 		{
-			if (fieldsPosition >= fields.Length)
+			if (Count >= fields.Length)
 			{
 				var newSize = fields.Length * 2;
 				Array.Resize(ref fields, newSize);
 				Array.Resize(ref processedFields, newSize);
 			}
 
-			ref var field = ref fields[fieldsPosition];
+			ref var field = ref fields[Count];
 			field.Start = start - rowStartPosition;
 			field.Length = length;
 			field.QuoteCount = quoteCount;
 			field.IsBad = fieldIsBadData;
 			field.IsProcessed = false;
 
-			fieldsPosition++;
+			Count++;
 			quoteCount = 0;
-		}
-
-		private bool FillBuffer()
-		{
-			// Don't forget the async method below.
-
-			if (rowStartPosition == 0 && charCount > 0 && charsRead == bufferSize)
-			{
-				// The record is longer than the memory buffer. Increase the buffer.
-				bufferSize *= 2;
-				var tempBuffer = new char[bufferSize];
-				buffer.CopyTo(tempBuffer, 0);
-				buffer = tempBuffer;
-			}
-
-			var charsLeft = Math.Max(charsRead - rowStartPosition, 0);
-
-			Array.Copy(buffer, rowStartPosition, buffer, 0, charsLeft);
-
-			fieldStartPosition -= rowStartPosition;
-			rowStartPosition = 0;
-			bufferPosition = charsLeft;
-
-			charsRead = reader.Read(buffer, charsLeft, buffer.Length - charsLeft);
-			if (charsRead == 0)
-			{
-				return false;
-			}
-
-			charsRead += charsLeft;
-
-			return true;
-		}
-
-		private async Task<bool> FillBufferAsync()
-		{
-			if (rowStartPosition == 0 && charCount > 0 && charsRead == bufferSize)
-			{
-				// The record is longer than the memory buffer. Increase the buffer.
-				bufferSize *= 2;
-				var tempBuffer = new char[bufferSize];
-				buffer.CopyTo(tempBuffer, 0);
-				buffer = tempBuffer;
-			}
-
-			var charsLeft = Math.Max(charsRead - rowStartPosition, 0);
-
-			Array.Copy(buffer, rowStartPosition, buffer, 0, charsLeft);
-
-			fieldStartPosition -= rowStartPosition;
-			rowStartPosition = 0;
-			bufferPosition = charsLeft;
-
-			charsRead = await reader.ReadAsync(buffer, charsLeft, buffer.Length - charsLeft).ConfigureAwait(false);
-			if (charsRead == 0)
-			{
-				return false;
-			}
-
-			charsRead += charsLeft;
-
-			return true;
 		}
 
 		private string GetField(int index)
 		{
-			if (index > fieldsPosition)
+			if (index > Count)
 			{
 				throw new IndexOutOfRangeException();
 			}
@@ -809,18 +866,22 @@ namespace CsvHelper
 			var quoteCount = field.QuoteCount;
 
 			ProcessedField processedField;
+
 			switch (mode)
 			{
 				case CsvMode.RFC4180:
 					processedField = field.IsBad
 						? ProcessRFC4180BadField(start, length)
 						: ProcessRFC4180Field(start, length, quoteCount);
+
 					break;
 				case CsvMode.Escape:
 					processedField = ProcessEscapeField(start, length);
+
 					break;
 				case CsvMode.NoEscape:
 					processedField = ProcessNoEscapeField(start, length);
+
 					break;
 				default:
 					throw new InvalidOperationException($"ParseMode '{mode}' is not handled.");
@@ -836,13 +897,7 @@ namespace CsvHelper
 			return value;
 		}
 
-		/// <summary>
-		/// Processes a field that complies with RFC4180.
-		/// </summary>
-		/// <param name="start">The start index of the field.</param>
-		/// <param name="length">The length of the field.</param>
-		/// <param name="quoteCount">The number of counted quotes.</param>
-		/// <returns>The processed field.</returns>
+		/// <inheritdoc />
 		protected ProcessedField ProcessRFC4180Field(int start, int length, int quoteCount)
 		{
 			var newStart = start;
@@ -861,7 +916,9 @@ namespace CsvHelper
 				return new ProcessedField(newStart, newLength, buffer);
 			}
 
-			if (buffer[newStart] != quote || buffer[newStart + newLength - 1] != quote || newLength == 1 && buffer[newStart] == quote)
+			if (buffer[newStart] != quote ||
+			    buffer[newStart + newLength - 1] != quote ||
+			    (newLength == 1 && buffer[newStart] == quote))
 			{
 				// If the field doesn't have quotes on the ends, or the field is a single quote char, it's bad data.
 				return ProcessRFC4180BadField(start, length);
@@ -894,20 +951,12 @@ namespace CsvHelper
 				return new ProcessedField(newStart, newLength, buffer);
 			}
 
-			if (newLength > processFieldBuffer.Length)
-			{
-				// Make sure the field processing buffer is large engough.
-				while (newLength > processFieldBufferSize)
-				{
-					processFieldBufferSize *= 2;
-				}
-
-				processFieldBuffer = new char[processFieldBufferSize];
-			}
+			IncreaseProcessFieldBufferLengthIfNecessaryAndAble(newLength);
 
 			// Remove escapes.
 			var inEscape = false;
 			var position = 0;
+
 			for (var i = newStart; i < newStart + newLength; i++)
 			{
 				var c = buffer[i];
@@ -923,6 +972,13 @@ namespace CsvHelper
 					continue;
 				}
 
+				if (maxProcessFieldBufferSize.HasValue && position == processFieldBufferSize)
+				{
+					//NOTE: Too long field, too short field buffer, skip it since it wouldn't be processed.
+					//Warning: field value would be truncated.
+					break;
+				}
+
 				processFieldBuffer[position] = c;
 				position++;
 			}
@@ -930,18 +986,48 @@ namespace CsvHelper
 			return new ProcessedField(0, position, processFieldBuffer);
 		}
 
-		/// <summary>
-		/// Processes a field that does not comply with RFC4180.
-		/// </summary>
-		/// <param name="start">The start index of the field.</param>
-		/// <param name="length">The length of the field.</param>
-		/// <returns>The processed field.</returns>
+		private void IncreaseProcessFieldBufferLengthIfNecessaryAndAble(int newLength)
+		{
+			if (IsProcessFieldBufferSizeNotExceeded() && newLength > processFieldBuffer.Length)
+			{
+				// Make sure the field processing buffer is large enough.
+				while (newLength > processFieldBufferSize && IsProcessFieldBufferSizeNotExceeded())
+				{
+					processFieldBufferSize *= 2;
+				}
+
+				if (maxProcessFieldBufferSize.HasValue && processFieldBufferSize > maxProcessFieldBufferSize)
+				{
+					processFieldBufferSize = maxProcessFieldBufferSize.Value;
+				}
+
+				processFieldBuffer = new char[processFieldBufferSize];
+			}
+		}
+
+		private bool IsProcessFieldBufferSizeNotExceeded()
+		{
+			if (!maxProcessFieldBufferSize.HasValue)
+			{
+				return true;
+			}
+
+			return processFieldBufferSize < maxProcessFieldBufferSize;
+		}
+
+		/// <inheritdoc />
 		protected ProcessedField ProcessRFC4180BadField(int start, int length)
 		{
 			// If field is already known to be bad, different rules can be applied.
 
 			var args = new BadDataFoundArgs(new string(buffer, start, length), RawRecord, Context);
 			badDataFound?.Invoke(args);
+
+			//NOTE: return empty processed field since this value does not matter
+			if (!processBadDataFields)
+			{
+				return new ProcessedField(0, 0, new[] { '\0' });
+			}
 
 			var newStart = start;
 			var newLength = length;
@@ -957,22 +1043,14 @@ namespace CsvHelper
 				return new ProcessedField(newStart, newLength, buffer);
 			}
 
-			if (newLength > processFieldBuffer.Length)
-			{
-				// Make sure the field processing buffer is large engough.
-				while (newLength > processFieldBufferSize)
-				{
-					processFieldBufferSize *= 2;
-				}
-
-				processFieldBuffer = new char[processFieldBufferSize];
-			}
+			IncreaseProcessFieldBufferLengthIfNecessaryAndAble(newLength);
 
 			// Remove escapes until the last quote is found.
 			var inEscape = false;
 			var position = 0;
 			var c = '\0';
 			var doneProcessing = false;
+
 			for (var i = newStart + 1; i < newStart + newLength; i++)
 			{
 				var cPrev = c;
@@ -991,7 +1069,8 @@ namespace CsvHelper
 						// Ignore the quote after an escape.
 						continue;
 					}
-					else if (cPrev == quote)
+
+					if (cPrev == quote)
 					{
 						// The escape and quote are the same character.
 						// This is the end of the field.
@@ -1007,6 +1086,13 @@ namespace CsvHelper
 					continue;
 				}
 
+				if (maxProcessFieldBufferSize.HasValue && position == processFieldBufferSize)
+				{
+					//NOTE: Too long field, too short field buffer, skip it since it wouldn't be processed.
+					//Warning: field value would be truncated.
+					break;
+				}
+
 				processFieldBuffer[position] = c;
 				position++;
 			}
@@ -1014,12 +1100,7 @@ namespace CsvHelper
 			return new ProcessedField(0, position, processFieldBuffer);
 		}
 
-		/// <summary>
-		/// Processes an escaped field.
-		/// </summary>
-		/// <param name="start">The start index of the field.</param>
-		/// <param name="length">The length of the field.</param>
-		/// <returns>The processed field.</returns>
+		/// <inheritdoc />
 		protected ProcessedField ProcessEscapeField(int start, int length)
 		{
 			var newStart = start;
@@ -1030,20 +1111,12 @@ namespace CsvHelper
 				ArrayHelper.Trim(buffer, ref newStart, ref newLength, whiteSpaceChars);
 			}
 
-			if (newLength > processFieldBuffer.Length)
-			{
-				// Make sure the field processing buffer is large engough.
-				while (newLength > processFieldBufferSize)
-				{
-					processFieldBufferSize *= 2;
-				}
-
-				processFieldBuffer = new char[processFieldBufferSize];
-			}
+			IncreaseProcessFieldBufferLengthIfNecessaryAndAble(newLength);
 
 			// Remove escapes.
 			var inEscape = false;
 			var position = 0;
+
 			for (var i = newStart; i < newStart + newLength; i++)
 			{
 				var c = buffer[i];
@@ -1055,7 +1128,15 @@ namespace CsvHelper
 				else if (c == escape)
 				{
 					inEscape = true;
+
 					continue;
+				}
+
+				if (maxProcessFieldBufferSize.HasValue && position == processFieldBufferSize)
+				{
+					//NOTE: Too long field, too short field buffer, skip it since it wouldn't be processed.
+					//Warning: field value would be truncated.
+					break;
 				}
 
 				processFieldBuffer[position] = c;
@@ -1065,13 +1146,7 @@ namespace CsvHelper
 			return new ProcessedField(0, position, processFieldBuffer);
 		}
 
-		/// <inheritdoc/>
-		/// <summary>
-		/// Processes an non-escaped field.
-		/// </summary>
-		/// <param name="start">The start index of the field.</param>
-		/// <param name="length">The length of the field.</param>
-		/// <returns>The processed field.</returns>
+		/// <inheritdoc />
 		protected ProcessedField ProcessNoEscapeField(int start, int length)
 		{
 			var newStart = start;
@@ -1085,18 +1160,15 @@ namespace CsvHelper
 			return new ProcessedField(newStart, newLength, buffer);
 		}
 
-		/// <inheritdoc/>
+		/// <inheritdoc />
 		public void Dispose()
 		{
 			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-			Dispose(disposing: true);
+			Dispose(true);
 			GC.SuppressFinalize(this);
 		}
 
-		/// <summary>
-		/// Disposes the object.
-		/// </summary>
-		/// <param name="disposing">Indicates if the object is being disposed.</param>
+		/// <inheritdoc />
 		protected virtual void Dispose(bool disposing)
 		{
 			if (disposed)
@@ -1121,29 +1193,29 @@ namespace CsvHelper
 		}
 
 		/// <summary>
-		/// Processes a raw field based on configuration.
-		/// This will remove quotes, remove escapes, and trim if configured to.
+		///     Processes a raw field based on configuration.
+		///     This will remove quotes, remove escapes, and trim if configured to.
 		/// </summary>
 		[DebuggerDisplay("Start = {Start}, Length = {Length}, Buffer.Length = {Buffer.Length}")]
 		protected readonly struct ProcessedField
 		{
 			/// <summary>
-			/// The start of the field in the buffer.
+			///     The start of the field in the buffer.
 			/// </summary>
 			public readonly int Start;
 
 			/// <summary>
-			/// The length of the field in the buffer.
+			///     The length of the field in the buffer.
 			/// </summary>
 			public readonly int Length;
 
 			/// <summary>
-			/// The buffer that contains the field.
+			///     The buffer that contains the field.
 			/// </summary>
 			public readonly char[] Buffer;
 
 			/// <summary>
-			/// Creates a new instance of ProcessedField.
+			///     Creates a new instance of ProcessedField.
 			/// </summary>
 			/// <param name="start">The start of the field in the buffer.</param>
 			/// <param name="length">The length of the field in the buffer.</param>
@@ -1177,8 +1249,8 @@ namespace CsvHelper
 		private struct Field
 		{
 			/// <summary>
-			/// Starting position of the field.
-			/// This is an offset from <see cref="rowStartPosition"/>.
+			///     Starting position of the field.
+			///     This is an offset from <see cref="rowStartPosition" />.
 			/// </summary>
 			public int Start;
 


### PR DESCRIPTION
It is possible that buffers and field buffers can grow with no limits what leads to big arrays allocations and large memory consumption, what finally leads to OutOfMemory exception. This PR introduces properties to limit max sizes of those buffers. And beside that ProcessBadDataFields flag which makes 'bad field' not processed. Since default is true, current behaviour would not be changed. Otherwise that field will be set to array of empty char because in such flag setting we are not interested in processing bad field. In some cases it can improve performance and memory consumption. 
WARNING: Limiting max processed field buffer size can lead to field value truncation (if that buffer is too small to fit in field). But it works well with ShouldSkipRecord configured to skip too long fields.