### PR TITLE
Change order of checks in default ShouldQuote implementation

### DIFF
--- a/src/CsvHelper/Configuration/ConfigurationFunctions.cs
+++ b/src/CsvHelper/Configuration/ConfigurationFunctions.cs
@@ -105,8 +105,8 @@ namespace CsvHelper.Configuration
 
 			var shouldQuote = !string.IsNullOrEmpty(args.Field) &&
 			(
-				args.Field[0] == ' ' // Starts with a space
-				|| args.Field[^1] == ' ' // Ends with a space
+				args.Field.StartsWith(' ') // Starts with a space
+				|| args.Field.EndsWith(' ') // Ends with a space
 				|| args.Field.Contains(config.Quote) // Contains quote
 				|| !config.IsNewLineSet && args.Field.IndexOfAny(lineEndingChars) > -1 // Contains line ending characters
 				|| config.IsNewLineSet && args.Field.Contains(config.NewLine) // Contains newline

--- a/src/CsvHelper/Configuration/ConfigurationFunctions.cs
+++ b/src/CsvHelper/Configuration/ConfigurationFunctions.cs
@@ -106,7 +106,7 @@ namespace CsvHelper.Configuration
 			var shouldQuote = !string.IsNullOrEmpty(args.Field) &&
 			(
 				args.Field[0] == ' ' // Starts with a space
-				|| args.Field[args.Field.Length - 1] == ' ' // Ends with a space
+				|| args.Field[^1] == ' ' // Ends with a space
 				|| args.Field.Contains(config.Quote) // Contains quote
 				|| !config.IsNewLineSet && args.Field.IndexOfAny(lineEndingChars) > -1 // Contains line ending characters
 				|| config.IsNewLineSet && args.Field.Contains(config.NewLine) // Contains newline

--- a/src/CsvHelper/Configuration/ConfigurationFunctions.cs
+++ b/src/CsvHelper/Configuration/ConfigurationFunctions.cs
@@ -105,12 +105,12 @@ namespace CsvHelper.Configuration
 
 			var shouldQuote = !string.IsNullOrEmpty(args.Field) &&
 			(
-				args.Field.Contains(config.Quote) // Contains quote
-				|| args.Field[0] == ' ' // Starts with a space
+				args.Field[0] == ' ' // Starts with a space
 				|| args.Field[args.Field.Length - 1] == ' ' // Ends with a space
-				|| (config.Delimiter.Length > 0 && args.Field.Contains(config.Delimiter)) // Contains delimiter
+				|| args.Field.Contains(config.Quote) // Contains quote
 				|| !config.IsNewLineSet && args.Field.IndexOfAny(lineEndingChars) > -1 // Contains line ending characters
 				|| config.IsNewLineSet && args.Field.Contains(config.NewLine) // Contains newline
+				|| (config.Delimiter.Length > 0 && args.Field.Contains(config.Delimiter)) // Contains delimiter
 			);
 
 			return shouldQuote;


### PR DESCRIPTION
This PR moves the space checks before the quote check & moves new line checks before the delimiter check. While it will definitely depend on the input data, this change sorting the comparisons from fastest to potentially the slowest one should help with the performance.