### PR TITLE
remove-invalid-loop

### DIFF
--- a/src/CsvHelper/Configuration/ConfigurationFunctions.cs
+++ b/src/CsvHelper/Configuration/ConfigurationFunctions.cs
@@ -35,10 +35,7 @@ namespace CsvHelper.Configuration
 
 			if (args.Context.Reader.HeaderRecord != null)
 			{
-				foreach (var header in args.Context.Reader.HeaderRecord)
-				{
-					errorMessage.AppendLine($"Headers: '{string.Join("', '", args.Context.Reader.HeaderRecord)}'");
-				}
+				errorMessage.AppendLine($"Headers: '{string.Join("', '", args.Context.Reader.HeaderRecord)}'");
 			}
 
 			var messagePostfix =
@@ -146,7 +143,7 @@ namespace CsvHelper.Configuration
 		}
 
 		/// <summary>
-		/// Returns the type's constructor with the most parameters. 
+		/// Returns the type's constructor with the most parameters.
 		/// If two constructors have the same number of parameters, then
 		/// there is no guarantee which one will be returned. If you have
 		/// that situation, you should probably implement this function yourself.


### PR DESCRIPTION
fix for https://github.com/JoshClose/CsvHelper/issues/2202

there is an invalid loop which causes the header to be printed for header.length