### PR TITLE
Fix CultureInfo mistake in Parsing.BadDataTests

### DIFF
--- a/tests/CsvHelper.Tests/Parsing/BadDataTests.cs
+++ b/tests/CsvHelper.Tests/Parsing/BadDataTests.cs
@@ -139,7 +139,7 @@ namespace CsvHelper.Tests.Parsing
 			var badstring = new StringReader("Fish,\"DDDD");
 
 			string[] record = new string[0];
-			var cfg = new CsvConfiguration(CultureInfo.CurrentCulture)
+			var cfg = new CsvConfiguration(CultureInfo.InvariantCulture)
 			{
 				BadDataFound = args => record = args.Context.Parser.Record
 			};


### PR DESCRIPTION
I noticed a tiny issue in a test-case for BadDataTesting.

The list delimiter is assumed to be a `,`, but the configuration is using `CultureInfo.CurrentCulture`. 

This leads to the test failing on my machine, when the local is set to German.

Similar tests in the file use `CultureInfo.InvariantCulture` which fixes this issue.