### PR TITLE
Use NET6_0_OR_GREATER to detect support for DateOnly and TimeOnly

### DIFF
--- a/src/CsvHelper/TypeConversion/DateOnlyConverter.cs
+++ b/src/CsvHelper/TypeConversion/DateOnlyConverter.cs
@@ -2,7 +2,7 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
-#if NET6_0
+#if NET6_0_OR_GREATER
 using CsvHelper.Configuration;
 using System;
 using System.Globalization;

--- a/src/CsvHelper/TypeConversion/TimeOnlyConverter.cs
+++ b/src/CsvHelper/TypeConversion/TimeOnlyConverter.cs
@@ -2,7 +2,7 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
-#if NET6_0
+#if NET6_0_OR_GREATER
 using CsvHelper.Configuration;
 using System;
 using System.Globalization;

--- a/src/CsvHelper/TypeConversion/TypeConverterCache.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterCache.cs
@@ -229,7 +229,7 @@ namespace CsvHelper.TypeConversion
 			AddConverter(typeof(uint), new UInt32Converter());
 			AddConverter(typeof(ulong), new UInt64Converter());
 			AddConverter(typeof(Uri), new UriConverter());
-#if NET6_0
+#if NET6_0_OR_GREATER
 			AddConverter(typeof(DateOnly), new DateOnlyConverter());
 			AddConverter(typeof(TimeOnly), new TimeOnlyConverter());
 #endif

--- a/tests/CsvHelper.Tests/TypeConversion/DateOnlyConverterTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/DateOnlyConverterTests.cs
@@ -2,7 +2,7 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
-#if NET6_0
+#if NET6_0_OR_GREATER
 using CsvHelper.Configuration;
 using CsvHelper.Tests.Mocks;
 using CsvHelper.TypeConversion;

--- a/tests/CsvHelper.Tests/TypeConversion/TimeOnlyConverterTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/TimeOnlyConverterTests.cs
@@ -2,7 +2,7 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
-#if NET6_0
+#if NET6_0_OR_GREATER
 using CsvHelper.Configuration;
 using CsvHelper.Tests.Mocks;
 using CsvHelper.TypeConversion;


### PR DESCRIPTION
If support is ever added for .NET 7 or later, this will ensure support for these classes is still compiled in. These preprocessor symbols are [documented here](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives).