### PR TITLE
Remove lock in hotpath

### DIFF
--- a/src/CsvHelper/ObjectCreator.cs
+++ b/src/CsvHelper/ObjectCreator.cs
@@ -3,6 +3,7 @@
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -18,7 +19,7 @@ namespace CsvHelper
 	/// </summary>
 	public class ObjectCreator
     {
-		private readonly Dictionary<int, Func<object[], object>> cache = new Dictionary<int, Func<object[], object>>();
+		private readonly ConcurrentDictionary<int, Func<object[], object>> cache = new ConcurrentDictionary<int, Func<object[], object>>();
 
 		/// <summary>
 		/// Creates an instance of type T using the given arguments.
@@ -47,10 +48,7 @@ namespace CsvHelper
 		{
 			var argTypes = GetArgTypes(args);
 			var key = GetConstructorCacheKey(type, argTypes);
-			if (!cache.TryGetValue(key, out var func))
-			{
-				cache[key] = func = CreateInstanceFunc(type, argTypes);
-			}
+			var func = cache.GetOrAdd(key, _ => CreateInstanceFunc(type, argTypes));
 
 			return func;
 		}

--- a/src/CsvHelper/ObjectResolver.cs
+++ b/src/CsvHelper/ObjectResolver.cs
@@ -58,14 +58,7 @@ namespace CsvHelper
 		static ObjectResolver()
 		{
 			var objectCreator = new ObjectCreator();
-			var locker = new object();
-			current = new ObjectResolver(type => true, (type, args) =>
-			{
-				lock (locker)
-				{
-					return objectCreator.CreateInstance(type, args);
-				}
-			});
+			current = new ObjectResolver(type => true, objectCreator.CreateInstance);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Using a `lock` in the hotpath of resolving every field of every record is fine for single-threaded operations, but when using a `CsvReader` across multiple threads, this creates a highly contentious serialization block. 

This PR updates the hotpath to use a `ConcurrentDictionary<,>` instead. Given the expected use of being very read-heavy, a `ConcurrentDictionary<,>` will have high throughput across all threads, with minimal locking only on the initial encounter with each type. 