### PR TITLE
Fix 2153 TypeConverterFactory not used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ obj/
 artifacts/
 .tmp/
 cache/
-
+.idea/
 *.user
 *.psess
 *.log

--- a/src/CsvHelper/TypeConversion/NotSupportedTypeConverter.cs
+++ b/src/CsvHelper/TypeConversion/NotSupportedTypeConverter.cs
@@ -17,7 +17,7 @@ namespace CsvHelper.TypeConversion
 	/// converter will need to be created to have a field convert to and
 	/// from <see cref="Type"/>.
 	/// </summary>
-	public class TypeConverter : DefaultTypeConverter
+	public class NotSupportedTypeConverter<T> : TypeConverterGeneric<T>
 	{
 		/// <summary>
 		/// Throws an exception.
@@ -26,9 +26,9 @@ namespace CsvHelper.TypeConversion
 		/// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
 		/// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
 		/// <returns>The object created from the string.</returns>
-		public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+		public override T ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
 		{
-			var message = "Converting System.Type is not supported. " +
+			var message = $"Converting " + typeof(T).FullName + " is not supported. " +
 						  "If you want to do this, create your own ITypeConverter and register " +
 						  "it in the TypeConverterFactory by calling AddConverter.";
 			throw new TypeConverterException(this, memberMapData, text ?? string.Empty, row.Context, message);
@@ -41,9 +41,9 @@ namespace CsvHelper.TypeConversion
 		/// <param name="row">The <see cref="IWriterRow"/> for the current record.</param>
 		/// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being written.</param>
 		/// <returns>The string representation of the object.</returns>
-		public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+		public override string ConvertToString(T value, IWriterRow row, MemberMapData memberMapData)
 		{
-			var message = "Converting System.Type is not supported. " +
+			var message = "Converting " + typeof(T).FullName + " is not supported. " +
 						  "If you want to do this, create your own ITypeConverter and register " +
 						  "it in the TypeConverterFactory by calling AddConverter.";
 			throw new TypeConverterException(this, memberMapData, value, row.Context, message);

--- a/src/CsvHelper/TypeConversion/NotSupportedTypeConverter.cs
+++ b/src/CsvHelper/TypeConversion/NotSupportedTypeConverter.cs
@@ -17,7 +17,7 @@ namespace CsvHelper.TypeConversion
 	/// converter will need to be created to have a field convert to and
 	/// from <see cref="Type"/>.
 	/// </summary>
-	public class NotSupportedTypeConverter<T> : TypeConverterGeneric<T>
+	public class NotSupportedTypeConverter<T> : TypeConverter<T>
 	{
 		/// <summary>
 		/// Throws an exception.

--- a/src/CsvHelper/TypeConversion/TypeConverter.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverter.cs
@@ -5,7 +5,7 @@ namespace CsvHelper.TypeConversion
 	/// <summary>
 	/// Converts values to and from strings.
 	/// </summary>
-	public abstract class TypeConverterGeneric<T> : ITypeConverter
+	public abstract class TypeConverter<T> : ITypeConverter
 	{
 		/// <summary>
 		/// Converts the string to a (T) value.

--- a/src/CsvHelper/TypeConversion/TypeConverterCache.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterCache.cs
@@ -19,6 +19,7 @@ namespace CsvHelper.TypeConversion
 	public class TypeConverterCache
 	{
 		private readonly Dictionary<Type, ITypeConverter> typeConverters = new Dictionary<Type, ITypeConverter>();
+		private readonly List<ITypeConverterFactory> defaultTypeConverterFactories = new List<ITypeConverterFactory>();
 		private readonly List<ITypeConverterFactory> typeConverterFactories = new List<ITypeConverterFactory>();
 		private readonly Dictionary<Type, ITypeConverterFactory> typeConverterFactoryCache = new Dictionary<Type, ITypeConverterFactory>();
 
@@ -167,7 +168,7 @@ namespace CsvHelper.TypeConversion
 
 			if (!typeConverterFactoryCache.TryGetValue(type, out var factory))
 			{
-				factory = typeConverterFactories.FirstOrDefault(f => f.CanCreate(type));
+				factory = typeConverterFactories.Concat(defaultTypeConverterFactories).FirstOrDefault(f => f.CanCreate(type));
 				if (factory != null)
 				{
 					typeConverterFactoryCache[type] = factory;
@@ -243,9 +244,9 @@ namespace CsvHelper.TypeConversion
 			AddConverter(typeof(TimeOnly), new TimeOnlyConverter());
 #endif
 
-			AddConverterFactory(new EnumConverterFactory());
-			AddConverterFactory(new NullableConverterFactory());
-			AddConverterFactory(new CollectionConverterFactory());
+			defaultTypeConverterFactories.Add(new EnumConverterFactory());
+			defaultTypeConverterFactories.Add(new NullableConverterFactory());
+			defaultTypeConverterFactories.Add(new CollectionConverterFactory());
 		}
 	}
 }

--- a/src/CsvHelper/TypeConversion/TypeConverterCache.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterCache.cs
@@ -234,7 +234,7 @@ namespace CsvHelper.TypeConversion
 			AddConverter(typeof(sbyte), new SByteConverter());
 			AddConverter(typeof(string), new StringConverter());
 			AddConverter(typeof(TimeSpan), new TimeSpanConverter());
-			AddConverter(typeof(Type), new TypeConverter());
+			AddConverter(new NotSupportedTypeConverter<Type>());
 			AddConverter(typeof(ushort), new UInt16Converter());
 			AddConverter(typeof(uint), new UInt32Converter());
 			AddConverter(typeof(ulong), new UInt64Converter());

--- a/src/CsvHelper/TypeConversion/TypeConverterCache.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterCache.cs
@@ -77,11 +77,11 @@ namespace CsvHelper.TypeConversion
 		}
 
 		/// <summary>
-		/// Adds the <see cref="TypeConverterGeneric"/> for the given <see cref="System.Type"/>.
+		/// Adds the <see cref="TypeConverter{T}"/> for the given <see cref="System.Type"/>.
 		/// </summary>
 		/// <typeparam name="T">The type the converter converts.</typeparam>
 		/// <param name="typeConverter">The type converter that converts the type.</param>
-		public void AddConverter<T>(TypeConverterGeneric<T> typeConverter) =>
+		public void AddConverter<T>(TypeConverter<T> typeConverter) =>
 			AddConverter<T>(typeConverter as ITypeConverter);
 
 

--- a/src/CsvHelper/TypeConversion/TypeConverterCache.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterCache.cs
@@ -76,6 +76,15 @@ namespace CsvHelper.TypeConversion
 		}
 
 		/// <summary>
+		/// Adds the <see cref="TypeConverterGeneric"/> for the given <see cref="System.Type"/>.
+		/// </summary>
+		/// <typeparam name="T">The type the converter converts.</typeparam>
+		/// <param name="typeConverter">The type converter that converts the type.</param>
+		public void AddConverter<T>(TypeConverterGeneric<T> typeConverter) =>
+			AddConverter<T>(typeConverter as ITypeConverter);
+
+
+		/// <summary>
 		/// Adds the <see cref="ITypeConverter"/> for the given <see cref="System.Type"/>.
 		/// </summary>
 		/// <typeparam name="T">The type the converter converts.</typeparam>

--- a/src/CsvHelper/TypeConversion/TypeConverterGeneric.cs
+++ b/src/CsvHelper/TypeConversion/TypeConverterGeneric.cs
@@ -1,0 +1,36 @@
+using CsvHelper.Configuration;
+
+namespace CsvHelper.TypeConversion
+{
+	/// <summary>
+	/// Converts values to and from strings.
+	/// </summary>
+	public abstract class TypeConverterGeneric<T> : ITypeConverter
+	{
+		/// <summary>
+		/// Converts the string to a (T) value.
+		/// </summary>
+		/// <param name="text">The string to convert to an object.</param>
+		/// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+		/// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+		/// <returns>The value created from the string.</returns>
+		public abstract T ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData);
+
+		/// <summary>
+		/// Converts the value to a string.
+		/// </summary>
+		/// <param name="value">The value to convert to a string.</param>
+		/// <param name="row">The <see cref="IWriterRow"/> for the current record.</param>
+		/// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being written.</param>
+		/// <returns>The string representation of the value.</returns>
+		public abstract string ConvertToString(T value, IWriterRow row, MemberMapData memberMapData);
+
+		object ITypeConverter.ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData) =>
+			ConvertFromString(text, row, memberMapData);
+
+		string ITypeConverter.ConvertToString(object value, IWriterRow row, MemberMapData memberMapData) =>
+			value is T v
+				? ConvertToString(v, row, memberMapData)
+				: throw new System.InvalidCastException();
+	}
+}

--- a/tests/CsvHelper.Tests/TypeConversion/TypeConverterFactoryTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/TypeConverterFactoryTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+using Xunit;
+
+namespace CsvHelper.Tests.TypeConversion
+{
+	public class TypeConverterFactoryTests
+	{
+		public readonly record struct Option<T> : IEnumerable<T>
+		{
+			public bool IsPresent { get; }
+			private readonly T _value;
+
+			internal Option(T value)
+			{
+				IsPresent = true;
+				_value = value;
+			}
+
+			public IEnumerator<T> GetEnumerator()
+			{
+				if (IsPresent) yield return _value;
+			}
+
+			IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+		}
+
+		private class MyOptionTypeFactory : ITypeConverterFactory
+		{
+			public bool CanCreate(Type type) =>
+				type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Option<>);
+
+			public bool Create(Type type, TypeConverterCache cache, out ITypeConverter typeConverter)
+			{
+				var wrappedType = type.GetGenericArguments().Single();
+				typeConverter =
+					Activator.CreateInstance(typeof(OptionConverter<>).MakeGenericType(wrappedType)) as
+						ITypeConverter ?? throw new NullReferenceException();
+				return true;
+			}
+
+			internal class OptionConverter<T> : TypeConverterGeneric<Option<T>>
+			{
+				public override string ConvertToString(Option<T> value, IWriterRow row,
+					MemberMapData memberMapData)
+				{
+					var wrappedTypeConverter = row.Context.TypeConverterCache.GetConverter<T>();
+					return value.IsPresent
+						? wrappedTypeConverter.ConvertToString(value.Single(), row, memberMapData)
+						: "";
+				}
+
+				public override Option<T> ConvertFromString(string text, IReaderRow row,
+					MemberMapData memberMapData)
+				{
+					var wrappedTypeConverter = row.Context.TypeConverterCache.GetConverter<T>();
+
+					return text == ""
+						? new Option<T>()
+						: new Option<T>((T)wrappedTypeConverter.ConvertFromString(text, row, memberMapData));
+				}
+			}
+		}
+
+		private record RecordWithGenerics(Option<int> MaybeNumber);
+
+		[Fact]
+		void ReadTypeConverterGenericInt()
+		{
+			var input = """
+			            MaybeNumber
+			            23
+
+			            """;
+
+			using var cr = new CsvReader(new StringReader(input), CultureInfo.InvariantCulture);
+			cr.Context.TypeConverterCache.AddConverter(new MyOptionTypeFactory.OptionConverter<int>());
+			var firstRow = cr.GetRecords<RecordWithGenerics>().First();
+			Assert.Equal(new Option<int>(23), firstRow.MaybeNumber);
+		}
+
+		[Fact]
+		void WriteTypeConverterGenericInt()
+		{
+			var expected = """
+			               MaybeNumber
+			               42
+
+			               """;
+
+			var stringWriter = new StringWriter();
+			using var cw = new CsvWriter(stringWriter, CultureInfo.InvariantCulture);
+			cw.Context.TypeConverterCache.AddConverter(new MyOptionTypeFactory.OptionConverter<int>());
+			cw.WriteRecords(new[]
+			{
+				new RecordWithGenerics(new Option<int>(42))
+			});
+			Assert.Equal(expected, stringWriter.ToString());
+		}
+	}
+}

--- a/tests/CsvHelper.Tests/TypeConversion/TypeConverterFactoryTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/TypeConverterFactoryTests.cs
@@ -103,5 +103,39 @@ namespace CsvHelper.Tests.TypeConversion
 			});
 			Assert.Equal(expected, stringWriter.ToString());
 		}
+
+		[Fact]
+		void ReadTypeConverterFactory()
+		{
+			var input = """
+			            MaybeNumber
+			            23
+
+			            """;
+
+			using var cr = new CsvReader(new StringReader(input), CultureInfo.InvariantCulture);
+			cr.Context.TypeConverterCache.AddConverterFactory(new MyOptionTypeFactory());
+			var firstRow = cr.GetRecords<RecordWithGenerics>().First();
+			Assert.Equal(new Option<int>(23), firstRow.MaybeNumber);
+		}
+
+		[Fact]
+		void WriteTypeConverterFactory()
+		{
+			var expected = """
+			               MaybeNumber
+			               42
+
+			               """;
+
+			var stringWriter = new StringWriter();
+			using var cw = new CsvWriter(stringWriter, CultureInfo.InvariantCulture);
+			cw.Context.TypeConverterCache.AddConverterFactory(new MyOptionTypeFactory());
+			cw.WriteRecords(new[]
+			{
+				new RecordWithGenerics(new Option<int>(42))
+			});
+			Assert.Equal(expected, stringWriter.ToString());
+		}
 	}
 }

--- a/tests/CsvHelper.Tests/TypeConversion/TypeConverterFactoryTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/TypeConverterFactoryTests.cs
@@ -45,7 +45,7 @@ namespace CsvHelper.Tests.TypeConversion
 				return true;
 			}
 
-			internal class OptionConverter<T> : TypeConverterGeneric<Option<T>>
+			internal class OptionConverter<T> : TypeConverter<Option<T>>
 			{
 				public override string ConvertToString(Option<T> value, IWriterRow row,
 					MemberMapData memberMapData)


### PR DESCRIPTION
See https://github.com/JoshClose/CsvHelper/issues/2153

Notes: I added a new abstract TypeConverterGeneric<T> class to make it easier to create generic type converters.
This is not necessary to fix the issue, but makes it a easier to write generic type converter factories (as can be seen in test).

Please have a look at System.Text.Json.Serialization.JsonConverter<T> (and JsonConverterFactory) which has this and is a quite useful API. I recommend to rename `TypeConverterGeneric<T>` to `TypeConverter<T>` to make it consistent (see again `JsonConverter`) but this name is already taken without `<T>` for something different. I will add another commit to solve this but of course this is a (minor) breaking change as current `TypeConverter` is public (but probably not used by anyone). Please feel free to edit/cherry pick.

Let me know if there is anything I can do getting this merged.