### PR TITLE
Just another unit test for number reading (mixed culture format)

### DIFF
--- a/tests/CsvHelper.Tests/Reading/NumberReadingTests.cs
+++ b/tests/CsvHelper.Tests/Reading/NumberReadingTests.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using CsvHelper.Configuration;
+using Xunit;
+
+namespace CsvHelper.Tests.Reading
+{
+	public class NumberReadingTests
+	{
+		[Fact]
+		public void ReadDecimalDoubleCultureDeInvariantMix()
+		{
+			var input = new StringReader("""
+			                             MyMoney;YourMoney;MoreMoney;BigMoney
+			                             1.2;3.4;5.6;7.8
+			                             """);
+
+			using var cr = new CsvReader(input, new CsvConfiguration(CultureInfo.InvariantCulture) { Delimiter = ";" });
+			var records = cr.GetRecords(new
+			{
+				MyMoney = default(decimal),
+				YourMoney = default(double),
+				MoreMoney = default(decimal?),
+				BigMoney = default(double?),
+			}).ToArray();
+
+			Assert.Equal(1.2m, records.Single().MyMoney);
+			Assert.Equal(3.4, records.Single().YourMoney);
+			Assert.Equal(5.6m, records.Single().MoreMoney);
+			Assert.Equal(7.8, records.Single().BigMoney);
+		}
+	}
+}


### PR DESCRIPTION
I just had to locate a bug regarding decimal number parsing (decimal separator issue).
CsvHelper is working fine, but I wrote a simple test to rule out the possibility for a library issue. 
Bug was on my side (wrong culture given in user code).

Maybe you like to add this test safeguarding this use case -- maybe not.