### PR TITLE
Fixes for issues with multichar newline

### DIFF
--- a/tests/CsvHelper.Tests/CsvParserRawRecordTests.cs
+++ b/tests/CsvHelper.Tests/CsvParserRawRecordTests.cs
@@ -139,5 +139,75 @@ namespace CsvHelper.Tests
 				Assert.Equal(string.Empty, parser.RawRecord.ToString());
 			}
 		}
+
+		[Fact]
+		public void HandleMultipleCharacter()
+		{
+			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				NewLine = "|##|\r\n",
+				Delimiter = "|*|"
+			};
+			
+			using (var stream = new MemoryStream())
+			using (var writer = new StreamWriter(stream))
+			using (var reader = new StreamReader(stream))
+				
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.Write("1|*|2|##|\r\n");
+				writer.Write("3|*|4|##|\r\n");
+				writer.Write("|*5|*|6|##|\r\n");
+				writer.Write("7|##||*|6||##|\r\n");
+				writer.Flush();
+				stream.Position = 0;
+
+				parser.Read();
+				Assert.Equal("1|*|2|##|\r\n", parser.RawRecord);
+
+				parser.Read();
+				Assert.Equal("3|*|4|##|\r\n", parser.RawRecord);
+
+				parser.Read();
+				Assert.Equal("|*5|*|6|##|\r\n", parser.RawRecord);
+				
+				parser.Read();
+				Assert.Equal("7|##||*|6||##|\r\n", parser.RawRecord);
+				
+				parser.Read();
+				Assert.Equal(string.Empty, parser.RawRecord.ToString());
+			}
+		}
+		
+		[Fact]
+		public void HandleMultipleCharacterSmallBuffer()
+		{
+			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				NewLine = "|##|\r\n",
+				Delimiter = "|*|",
+				BufferSize = 1,
+			};
+			
+			using (var stream = new MemoryStream())
+			using (var writer = new StreamWriter(stream))
+			using (var reader = new StreamReader(stream))
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.Write("1|*|2|##|\r\n");
+				writer.Write("3|*|4|##|\r\n");
+				writer.Flush();
+				stream.Position = 0;
+
+				parser.Read();
+				Assert.Equal("1|*|2|##|\r\n", parser.RawRecord.ToString());
+
+				parser.Read();
+				Assert.Equal("3|*|4|##|\r\n", parser.RawRecord.ToString());
+
+				parser.Read();
+				Assert.Equal(string.Empty, parser.RawRecord.ToString());
+			}
+		}
 	}
 }

--- a/tests/CsvHelper.Tests/Parsing/BufferSplittingNewLineEndingTests.cs
+++ b/tests/CsvHelper.Tests/Parsing/BufferSplittingNewLineEndingTests.cs
@@ -98,5 +98,28 @@ namespace CsvHelper.Tests.Parsing
 				Assert.Equal("5,\"600\"\r\n", parser.RawRecord);
 			}
 		}
+		
+		[Fact]
+		public void BufferSplitsLongNewLineTest()
+		{
+			var s = new StringBuilder();
+			s.Append("1,200000|123456789012345678901234567890|\r\n");
+			s.Append("3,4000|123456789012345678901234567890|\r\n");
+			var config = new CsvHelper.Configuration.CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				BufferSize = 16,
+				NewLine = "|123456789012345678901234567890|\r\n",
+			};
+			using (var reader = new StringReader(s.ToString()))
+			using (var parser = new CsvParser(reader, config))
+			{
+				parser.Read();
+				Assert.Equal(2, parser.Count);
+				Assert.Equal("1,200000|123456789012345678901234567890|\r\n", parser.RawRecord);
+				parser.Read();
+				Assert.Equal(2, parser.Count);
+				Assert.Equal("3,4000|123456789012345678901234567890|\r\n", parser.RawRecord);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Contains fixes for the issues described in #2216, have verified this solves all our problems in our own testing.

Added support for filling the buffer with enough room to peek the next x characters to confirm it is the new line or delimiter instead of relying on just checking the first character. This fill behavior and peeking ahead will only be used if either the newline or delimiter is over two characters long. 