### PR TITLE
🔨 GuidConverter should be consistent

### DIFF
--- a/src/CsvHelper/TypeConversion/GuidConverter.cs
+++ b/src/CsvHelper/TypeConversion/GuidConverter.cs
@@ -21,12 +21,12 @@ namespace CsvHelper.TypeConversion
 		/// <returns>The object created from the string.</returns>
 		public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
 		{
-			if (text == null)
+			if (Guid.TryParse(text, out var g))
 			{
-				return base.ConvertFromString(text, row, memberMapData);
+				return g;
 			}
 
-			return new Guid(text);
+			return base.ConvertFromString(text, row, memberMapData);
 		}
 	}
 }

--- a/tests/CsvHelper.Tests/TypeConversion/GuidConverterTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/GuidConverterTests.cs
@@ -1,0 +1,66 @@
+// Copyright 2009-2024 Josh Close
+// This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
+// See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
+// https://github.com/JoshClose/CsvHelper
+using System;
+using System.Globalization;
+using CsvHelper.Configuration;
+using CsvHelper.Tests.Mocks;
+using CsvHelper.TypeConversion;
+using Xunit;
+
+namespace CsvHelper.Tests.TypeConversion
+{
+
+	public class GuidConverterTests
+	{
+		[Fact]
+		public void ConvertToStringTest()
+		{
+			var converter = new GuidConverter();
+			var propertyMapData = new MemberMapData(null)
+			{
+				TypeConverter = converter,
+				TypeConverterOptions = { CultureInfo = CultureInfo.CurrentCulture }
+			};
+
+			var value = Guid.NewGuid();
+
+			// Valid conversions.
+			Assert.Equal(value.ToString(), converter.ConvertToString(value, null, propertyMapData));
+
+			// Invalid conversions.
+			Assert.Equal("1", converter.ConvertToString(1, null, propertyMapData));
+			Assert.Equal("", converter.ConvertToString(null, null, propertyMapData));
+		}
+
+		[Fact]
+		public void ConvertFromStringTest()
+		{
+			var converter = new GuidConverter();
+			var propertyMapData = new MemberMapData(null)
+			{
+				TypeConverterOptions = { CultureInfo = CultureInfo.CurrentCulture }
+			};
+
+			var row = new CsvReader(new ParserMock());
+
+			var value = Guid.NewGuid();
+
+			// Valid conversions.
+			Assert.Equal(value.ToString(), converter.ConvertFromString(value.ToString(), null, propertyMapData).ToString());
+			Assert.Equal(value.ToString(), converter.ConvertFromString(value.ToString("N"), null, propertyMapData).ToString());
+			Assert.Equal(value.ToString(), converter.ConvertFromString(value.ToString("D"), null, propertyMapData).ToString());
+			Assert.Equal(value.ToString(), converter.ConvertFromString(value.ToString("B"), null, propertyMapData).ToString());
+			Assert.Equal(value.ToString(), converter.ConvertFromString(value.ToString("P"), null, propertyMapData).ToString());
+			Assert.Equal(value.ToString(), converter.ConvertFromString(value.ToString("X"), null, propertyMapData).ToString());
+
+			// Invalid conversions.
+			Assert.Throws<TypeConverterException>(() => converter.ConvertFromString(null, row, propertyMapData));
+			Assert.Throws<TypeConverterException>(() => converter.ConvertFromString("", row, propertyMapData));
+			Assert.Throws<TypeConverterException>(() => converter.ConvertFromString(" ", row, propertyMapData));
+			Assert.Throws<TypeConverterException>(() => converter.ConvertFromString("Not A Guid", row, propertyMapData));
+			Assert.Throws<TypeConverterException>(() => converter.ConvertFromString("GGGGAAAA-0000-0000-0000-000000000000", row, propertyMapData));
+		}
+	}
+}


### PR DESCRIPTION
GuidConverter should be consistent with other value converters.

When an Integer cannot be parsed from a source Csv, using the `Int32Converter`, a `TypeConverterException` is thrown;

When Guid's cannot be parsed from a source Csv, using the `GuidConverter`, a `FormatException` is thrown.

This is to provide a consistent behaviour with other base converters.