### PR TITLE
CsvWriter performance optimization

### DIFF
--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -331,7 +331,7 @@ namespace CsvHelper
 		{
 			try
 			{
-				recordManager.Value.Write(record);
+				recordManager.Value.GetWriterAction<T>(GetTypeInfoForRecord(record))(record);
 			}
 			catch (TargetInvocationException ex)
 			{
@@ -362,6 +362,9 @@ namespace CsvHelper
 					NextRecord();
 				}
 
+				Action<object> writerAction = null;
+				RecordTypeInfo writerActionType = default;
+
 				foreach (var record in records)
 				{
 					if (record == null)
@@ -371,7 +374,13 @@ namespace CsvHelper
 						continue;
 					}
 
-					WriteRecord(record);
+					if (writerAction == null || writerActionType.RecordType != record.GetType())
+					{
+						writerActionType = GetTypeInfoForRecord(record);
+						writerAction = recordManager.Value.GetWriterAction<object>(writerActionType);
+					}
+
+					writerAction(record);
 					NextRecord();
 				}
 			}
@@ -393,9 +402,18 @@ namespace CsvHelper
 					NextRecord();
 				}
 
+				Action<T> writerAction = null;
+				RecordTypeInfo writerActionType = default;
+
 				foreach (var record in records)
 				{
-					WriteRecord(record);
+					if (writerAction == null || (record != null && writerActionType.RecordType != record.GetType()))
+					{
+						writerActionType = GetTypeInfoForRecord(record);
+						writerAction = recordManager.Value.GetWriterAction<T>(writerActionType);
+					}
+
+					writerAction(record);
 					NextRecord();
 				}
 			}
@@ -420,11 +438,20 @@ namespace CsvHelper
 					await NextRecordAsync().ConfigureAwait(false);
 				}
 
+				Action<object> writerAction = null;
+				RecordTypeInfo writerActionType = default;
+
 				foreach (var record in records)
 				{
 					cancellationToken.ThrowIfCancellationRequested();
 
-					WriteRecord(record);
+					if (writerAction == null || (record != null && writerActionType.RecordType != record.GetType()))
+					{
+						writerActionType = GetTypeInfoForRecord(record);
+						writerAction = recordManager.Value.GetWriterAction<object>(writerActionType);
+					}
+
+					writerAction(record);
 					await NextRecordAsync().ConfigureAwait(false);
 				}
 			}
@@ -449,11 +476,20 @@ namespace CsvHelper
 					await NextRecordAsync().ConfigureAwait(false);
 				}
 
+				Action<T> writerAction = null;
+				RecordTypeInfo writerActionType = default;
+
 				foreach (var record in records)
 				{
 					cancellationToken.ThrowIfCancellationRequested();
 
-					WriteRecord(record);
+					if (writerAction == null || (record != null && writerActionType.RecordType != record.GetType()))
+					{
+						writerActionType = GetTypeInfoForRecord(record);
+						writerAction = recordManager.Value.GetWriterAction<T>(writerActionType);
+					}
+
+					writerAction(record);
 					await NextRecordAsync().ConfigureAwait(false);
 				}
 			}
@@ -478,11 +514,20 @@ namespace CsvHelper
 					await NextRecordAsync().ConfigureAwait(false);
 				}
 
+				Action<T> writerAction = null;
+				RecordTypeInfo writerActionType = default;
+
 				await foreach (var record in records.ConfigureAwait(false))
 				{
 					cancellationToken.ThrowIfCancellationRequested();
 
-					WriteRecord(record);
+					if (writerAction == null || (record != null && writerActionType.RecordType != record.GetType()))
+					{
+						writerActionType = GetTypeInfoForRecord(record);
+						writerAction = recordManager.Value.GetWriterAction<T>(writerActionType);
+					}
+
+					writerAction(record);
 					await NextRecordAsync().ConfigureAwait(false);
 				}
 			}
@@ -576,15 +621,15 @@ namespace CsvHelper
 		/// <typeparam name="T">The type of the record.</typeparam>
 		/// <param name="record">The record to determine the type of.</param>
 		/// <returns>The System.Type for the record.</returns>
-		public virtual Type GetTypeForRecord<T>(T record)
+		public virtual RecordTypeInfo GetTypeInfoForRecord<T>(T record)
 		{
 			var type = typeof(T);
 			if (type == typeof(object))
 			{
-				type = record.GetType();
+				return new RecordTypeInfo(record.GetType(), true);
 			}
 
-			return type;
+			return new RecordTypeInfo(type, false);
 		}
 
 		/// <summary>

--- a/src/CsvHelper/Expressions/DynamicRecordWriter.cs
+++ b/src/CsvHelper/Expressions/DynamicRecordWriter.cs
@@ -30,8 +30,8 @@ namespace CsvHelper.Expressions
 		/// that will write the given record using the current writer row.
 		/// </summary>
 		/// <typeparam name="T">The record type.</typeparam>
-		/// <param name="record">The record.</param>
-		protected override Action<T> CreateWriteDelegate<T>(T record)
+		/// <param name="type">The type for the record.</param>
+		protected override Action<T> CreateWriteDelegate<T>(Type type)
 		{
 			// http://stackoverflow.com/a/14011692/68499
 

--- a/src/CsvHelper/Expressions/ExpandoObjectRecordWriter.cs
+++ b/src/CsvHelper/Expressions/ExpandoObjectRecordWriter.cs
@@ -24,8 +24,8 @@ namespace CsvHelper.Expressions
 		/// that will write the given record using the current writer row.
 		/// </summary>
 		/// <typeparam name="T">The record type.</typeparam>
-		/// <param name="record">The record.</param>
-		protected override Action<T> CreateWriteDelegate<T>(T record)
+		/// <param name="type">The type for the record.</param>
+		protected override Action<T> CreateWriteDelegate<T>(Type type)
 		{
 			Action<T> action = r =>
 			{

--- a/src/CsvHelper/Expressions/ObjectRecordWriter.cs
+++ b/src/CsvHelper/Expressions/ObjectRecordWriter.cs
@@ -27,11 +27,9 @@ namespace CsvHelper.Expressions
 		/// that will write the given record using the current writer row.
 		/// </summary>
 		/// <typeparam name="T">The record type.</typeparam>
-		/// <param name="record">The record.</param>
-		protected override Action<T> CreateWriteDelegate<T>(T record)
+		/// <param name="type">The type for the record.</param>
+		protected override Action<T> CreateWriteDelegate<T>(Type type)
 		{
-			var type = Writer.GetTypeForRecord(record);
-
 			if (Writer.Context.Maps[type] == null)
 			{
 				Writer.Context.Maps.Add(Writer.Context.AutoMap(type));

--- a/src/CsvHelper/Expressions/PrimitiveRecordWriter.cs
+++ b/src/CsvHelper/Expressions/PrimitiveRecordWriter.cs
@@ -25,11 +25,9 @@ namespace CsvHelper.Expressions
 		/// that will write the given record using the current writer row.
 		/// </summary>
 		/// <typeparam name="T">The record type.</typeparam>
-		/// <param name="record">The record.</param>
-		protected override Action<T> CreateWriteDelegate<T>(T record)
+		/// <param name="type">The type for the record.</param>
+		protected override Action<T> CreateWriteDelegate<T>(Type type)
 		{
-			var type = Writer.GetTypeForRecord(record);
-
 			var recordParameter = Expression.Parameter(typeof(T), "record");
 
 			Expression fieldExpression = Expression.Convert(recordParameter, typeof(object));

--- a/src/CsvHelper/Expressions/RecordManager.cs
+++ b/src/CsvHelper/Expressions/RecordManager.cs
@@ -67,14 +67,15 @@ namespace CsvHelper.Expressions
 		}
 
 		/// <summary>
-		/// Writes the given record to the current writer row.
+		/// Gets Writer Action to write multiple rows faster
 		/// </summary>
-		/// <typeparam name="T">The type of the record.</typeparam>
-		/// <param name="record">The record.</param>
-		public void Write<T>(T record)
+		/// <param name="typeInfo"></param>
+		/// <typeparam name="T"></typeparam>
+		/// <returns></returns>
+		internal Action<T> GetWriterAction<T>(RecordTypeInfo typeInfo)
 		{
-			var recordWriter = recordWriterFactory.MakeRecordWriter(record);
-			recordWriter.Write(record);
+			var recordWriter = recordWriterFactory.MakeRecordWriter(typeInfo);
+			return recordWriter.GetWriteDelegate<T>(typeInfo);
 		}
 	}
 }

--- a/src/CsvHelper/Expressions/RecordWriterFactory.cs
+++ b/src/CsvHelper/Expressions/RecordWriterFactory.cs
@@ -2,8 +2,8 @@
 // This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
 // See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
 // https://github.com/JoshClose/CsvHelper
+
 using System.Dynamic;
-using System.Reflection;
 
 namespace CsvHelper.Expressions
 {
@@ -34,27 +34,23 @@ namespace CsvHelper.Expressions
 		/// <summary>
 		/// Creates a new record writer for the given record.
 		/// </summary>
-		/// <typeparam name="T">The type of the record.</typeparam>
-		/// <param name="record">The record.</param>
-		public virtual RecordWriter MakeRecordWriter<T>(T record)
+		/// <param name="typeInfo">The type of the record.</param>
+		public virtual RecordWriter MakeRecordWriter(RecordTypeInfo typeInfo)
 		{
-			var type = writer.GetTypeForRecord(record);
+			var type = typeInfo.RecordType;
 
-			if (record is ExpandoObject expandoObject)
-			{
-				return expandoObjectRecordWriter;
-			}
-
-			if (record is IDynamicMetaObjectProvider dynamicObject)
-			{
-				return dynamicRecordWriter;
-			}
-
-			if (type.GetTypeInfo().IsPrimitive)
+			if (type.IsPrimitive)
 			{
 				return primitiveRecordWriter;
 			}
-
+			if (typeof(ExpandoObject).IsAssignableFrom(type))
+			{
+				return expandoObjectRecordWriter;
+			}
+			if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type))
+			{
+				return dynamicRecordWriter;
+			}
 			return objectRecordWriter;
 		}
 	}

--- a/src/CsvHelper/RecordTypeInfo.cs
+++ b/src/CsvHelper/RecordTypeInfo.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace CsvHelper
+{
+	/// <summary>
+	/// Container for type info about written records
+	/// </summary>
+	public struct RecordTypeInfo
+	{
+		/// <summary>
+		/// .ctor
+		/// </summary>
+		/// <param name="recordType"></param>
+		/// <param name="isItemType"></param>
+		public RecordTypeInfo(Type recordType, bool isItemType)
+		{
+			RecordType = recordType;
+			IsItemType = isItemType;
+		}
+
+		/// <summary>
+		/// Final type of the record
+		/// </summary>
+		public Type RecordType { get; }
+
+		/// <summary>
+		/// Is this type from record item
+		/// </summary>
+		public bool IsItemType { get; }
+	}
+}


### PR DESCRIPTION
I noticed that `CsvWriter` allocated huge amount of memory during serialization, much more than the size of the data, up to 3 orders of magnitude. It doesn't have memory leaks in my scenario, however such memory traffic creates `GC` pressure and has noticeable performance impact on my application.

There are some breaking changes to the public types though. But they can be easily fixed if needed. I'd also consider to make them internal in further versions to lower the probability of someone uses them directly.

So that's what is implemented here:
- caching of writer action for collections. We can optimize for the case when most of objects in the collection have the same type.
- removed duplicate type resolving. `GetType()` is called too often.
- optimized `Type` HashCodes. No need to get `AssemblyQualifiedName` to get it's `HashCode`, we can get it directly from the `Type`. However both approaches don't guarantee no collisions.
- reduced memory allocation during writes. 

### Before
| Method         | Typed | Mean     | Error    | StdDev   | Gen0        | Allocated  |
|--------------- |------ |---------:|---------:|---------:|------------:|-----------:|
| **WriteObject**    | **False** | **561.6 ms** | **10.92 ms** | **14.58 ms** |  **88000.0000** | **1059.73 MB** |
| WriteStruct    | False | 545.8 ms | 10.69 ms | 15.67 ms |  91000.0000 | 1090.25 MB |
| WritePrimitive | False | 441.7 ms |  8.80 ms | 10.47 ms |  77000.0000 |  922.42 MB |
| WriteExpando   | False | 992.4 ms | 19.65 ms | 27.54 ms | 100000.0000 |  1204.7 MB |
| WriteDynamic   | False | 853.7 ms | 16.69 ms | 19.87 ms | 100000.0000 |  1204.7 MB |
| **WriteObject**    | **True**  | **360.8 ms** |  **7.13 ms** |  **7.33 ms** |  **31000.0000** |   **380.7 MB** |
| WriteStruct    | True  | 354.3 ms |  7.08 ms | 10.15 ms |  31000.0000 |   380.7 MB |
| WritePrimitive | True  | 249.8 ms |  4.75 ms |  4.67 ms |  23333.3333 |  281.52 MB |
| WriteExpando   | True  | 984.7 ms | 18.81 ms | 15.71 ms | 100000.0000 |  1204.7 MB |
| WriteDynamic   | True  | 858.9 ms | 16.42 ms | 16.86 ms | 100000.0000 |  1204.7 MB |

### After
| Method         | Typed | Mean      | Error    | StdDev   | Gen0       | Allocated |
|--------------- |------ |----------:|---------:|---------:|-----------:|----------:|
| **WriteObject**    | **False** | **126.46 ms** | **0.599 ms** | **0.500 ms** | **10000.0000** |  **121.3 MB** |
| WriteStruct    | False | 135.19 ms | 1.728 ms | 1.532 ms | 12500.0000 | 151.82 MB |
| WritePrimitive | False |  64.79 ms | 1.078 ms | 0.955 ms |  5000.0000 |  60.26 MB |
| WriteExpando   | False | 531.63 ms | 4.189 ms | 3.918 ms | 23000.0000 | 281.52 MB |
| WriteDynamic   | False | 399.09 ms | 6.453 ms | 5.720 ms | 22000.0000 | 266.26 MB |
| **WriteObject**    | **True**  | **129.50 ms** | **1.278 ms** | **1.067 ms** | **10000.0000** |  **121.3 MB** |
| WriteStruct    | True  | 122.63 ms | 1.732 ms | 1.620 ms | 10000.0000 |  121.3 MB |
| WritePrimitive | True  |  62.77 ms | 0.978 ms | 0.867 ms |  5000.0000 |  60.26 MB |
| WriteExpando   | True  | 589.30 ms | 6.714 ms | 6.280 ms | 23000.0000 | 281.52 MB |
| WriteDynamic   | True  | 464.30 ms | 3.689 ms | 2.880 ms | 22000.0000 | 266.26 MB |
