### PR TITLE
fix (typo?): error CS1061 function in class not found

### DIFF
--- a/docs/examples/configuration/class-maps/mapping-by-name/index.html
+++ b/docs/examples/configuration/class-maps/mapping-by-name/index.html
@@ -412,10 +412,13 @@
 <h6 id="example">Example</h6>
 <pre><code class="language-cs">void Main()
 {
+	using CsvHelper;
+	using CsvHelper.Configuration;
+	
 	using (var reader = new StreamReader(&quot;path\\to\\file.csv&quot;))
 	using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
 	{
-		csv.Context.RegisterClassMap&lt;FooMap&gt;();
+		csv.Configuration.RegisterClassMap&lt;FooMap&gt;();
 		var records = csv.GetRecords&lt;Foo&gt;();
 	}
 }


### PR DESCRIPTION
There is no function RegisterClassMap in the class Context so I searched for and find that it must be called "Configuration".

The full error message in Unity: 
error CS1061: 'ReadingContext' does not contain a definition for 'RegisterClassMap' and no accessible extension method 'RegisterClassMap' accepting a first argument of type 'ReadingContext' could be found.