### PR TITLE
DisposeAsync async enumerators in CsvWriter

### DIFF
--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -626,10 +626,7 @@ public class CsvWriter : IWriter
 		}
 		finally
 		{
-			if (enumerator is IDisposable en)
-			{
-				en.Dispose();
-			}
+			await enumerator.DisposeAsync().ConfigureAwait(false);
 		}
 	}
 


### PR DESCRIPTION
fixes https://github.com/JoshClose/CsvHelper/issues/2264

As an alternative we could use `await using var enumerator...` but this would increase the difference between the overloads.