### PR TITLE
Fix UseDefaultOnConversionFailure behavior for nullable types

### DIFF
--- a/tests/CsvHelper.Tests/Mocks/ReaderRowMock.cs
+++ b/tests/CsvHelper.Tests/Mocks/ReaderRowMock.cs
@@ -27,19 +27,28 @@ namespace CsvHelper.Tests.Mocks
 
 		public string[] HeaderRecord => throw new NotImplementedException();
 
-		public IParser Parser => throw new NotImplementedException();
+		public IParser Parser { get; }
 
-		public CsvContext Context => throw new NotImplementedException();
+		public CsvContext Context { get; }
 
 		public IReaderConfiguration Configuration { get; private set; }
 
 		public ReaderRowMock()
+			: this(new CsvConfiguration(CultureInfo.InvariantCulture))
 		{
-			Configuration = new CsvConfiguration(CultureInfo.InvariantCulture);
+		}
+
+		public ReaderRowMock(IParser parser)
+		{
+			Parser = parser;
+			Context = Parser.Context;
+			Configuration = Context.Configuration;
 		}
 
 		public ReaderRowMock(CsvConfiguration configuration)
 		{
+			Parser = new ParserMock(configuration);
+			Context = Parser.Context;
 			Configuration = configuration;
 		}
 

--- a/tests/CsvHelper.Tests/TypeConversion/NullableConverterTests.cs
+++ b/tests/CsvHelper.Tests/TypeConversion/NullableConverterTests.cs
@@ -1,0 +1,131 @@
+﻿// Copyright 2009-2024 Josh Close
+// This file is a part of CsvHelper and is dual licensed under MS-PL and Apache 2.0.
+// See LICENSE.txt for details or visit http://www.opensource.org/licenses/ms-pl.html for MS-PL and http://opensource.org/licenses/Apache-2.0 for Apache 2.0.
+// https://github.com/JoshClose/CsvHelper
+using System.Globalization;
+using System.Reflection;
+using CsvHelper.Configuration;
+using CsvHelper.Tests.Mocks;
+using CsvHelper.TypeConversion;
+using Xunit;
+
+namespace CsvHelper.Tests.TypeConversion
+{
+	public class NullableConverterTests
+	{
+		private const string InvalidIntString = "abc";
+
+		private readonly MemberInfo _nullableIntMemberInfo = typeof(NullableConverterTests)
+			.GetProperty(nameof(NullableInt), BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+		// this property is used to create a MemberMapData instance for a nullable int member
+		private int? NullableInt { get; set; }
+
+		[Fact]
+		public void ConvertNullableTypeFromStringThrowsWithUseDefaultOnConversionFailureFalse()
+		{
+			// setup
+			var converter = new NullableConverter(typeof(int?), new TypeConverterCache());
+			var propertyMapData = new MemberMapData(_nullableIntMemberInfo)
+			{
+				TypeConverter = converter,
+				TypeConverterOptions = {
+					CultureInfo = CultureInfo.InvariantCulture,
+				},
+				Default = null,
+				IsDefaultSet = true,
+				UseDefaultOnConversionFailure = false,
+			};
+			var csvConfiguration = new CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				ExceptionMessagesContainRawData = false,
+			};
+			var row = new ReaderRowMock(new ParserMock(csvConfiguration));
+
+			// act
+			var exception = Record.Exception(() => converter.ConvertFromString(InvalidIntString, row, propertyMapData));
+
+			// assert
+			Assert.IsType<TypeConverterException>(exception);
+		}
+
+		[Fact]
+		public void ConvertNullableTypeFromStringWithConfiguredNullValueDoesNotThrow()
+		{
+			// setup
+			var converter = new NullableConverter(typeof(int?), new TypeConverterCache());
+			var configuredNullValue = InvalidIntString;
+			var propertyMapData = new MemberMapData(_nullableIntMemberInfo)
+			{
+				TypeConverter = converter,
+				TypeConverterOptions = {
+					// configure InvalidIntString as an expected null value for this member.
+					NullValues = { configuredNullValue },
+					CultureInfo = CultureInfo.InvariantCulture,
+				},
+				Default = null,
+				IsDefaultSet = true,
+				UseDefaultOnConversionFailure = false,
+			};
+
+			// act
+			object? result = null;
+			var exception = Record.Exception(() => result = converter.ConvertFromString(configuredNullValue, null!, propertyMapData));
+
+			// assert
+			Assert.Null(exception);
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public void ConvertNullableTypeFromStringWithUseDefaultOnConversionFailureTrueDoesNotThrow()
+		{
+			// setup
+			var converter = new NullableConverter(typeof(int?), new TypeConverterCache());
+			var propertyMapData = new MemberMapData(_nullableIntMemberInfo)
+			{
+				TypeConverter = converter,
+				TypeConverterOptions = {
+					CultureInfo = CultureInfo.InvariantCulture,
+				},
+				Default = null,
+				IsDefaultSet = true,
+				UseDefaultOnConversionFailure = true,
+			};
+
+			// act
+			var exception = Record.Exception(() => converter.ConvertFromString(InvalidIntString, null!, propertyMapData));
+
+			// assert
+			Assert.Null(exception);
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData(-1)]
+		[InlineData(99)]
+		public void ConvertNullableTypeFromStringWithUseDefaultOnConversionFailureTrueReturnsDefaultValue(object? defaultValue)
+		{
+			// setup
+			var converter = new NullableConverter(typeof(int?), new TypeConverterCache());
+			var propertyMapData = new MemberMapData(_nullableIntMemberInfo)
+			{
+				TypeConverter = converter,
+				TypeConverterOptions = {
+					CultureInfo = CultureInfo.InvariantCulture,
+				},
+				Default = defaultValue,
+				IsDefaultSet = true,
+				UseDefaultOnConversionFailure = true,
+			};
+
+			// act
+			object? result = null;
+			var exception = Record.Exception(() => result = converter.ConvertFromString(InvalidIntString, null!, propertyMapData));
+
+			// assert
+			Assert.Null(exception);
+			Assert.StrictEqual(defaultValue, result);
+		}
+	}
+}


### PR DESCRIPTION
Setting `null` as the default value for a member with a nullable type with `UseDefaultOnConversionFailure` set to `true` will not use that default value when a conversion failure occurs, but throws a `TypeConverterException` instead. This is unintuitive behavior and seems like a bug.

This code fixes the type comparison when the default value is set to `null` so that the code behaves like one would expect.

[discussion](https://github.com/JoshClose/CsvHelper/issues/2156#issuecomment-2245023237)
Closes #2156