### PR TITLE
Add benchmarking project and remove empty array allocations

### DIFF
--- a/CsvHelper.sln
+++ b/CsvHelper.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsvHelper.Tests", "tests\Cs
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsvHelper.Website", "src\CsvHelper.Website\CsvHelper.Website.csproj", "{3E59CA52-D248-4CBB-BB06-270FA942C4B8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsvHelper.Benchmarks", "src\CsvHelper.Benchmarks\CsvHelper.Benchmarks.csproj", "{8BAE18D9-A722-40FF-A195-3AB5E74481E0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,26 @@ Global
 		{3E59CA52-D248-4CBB-BB06-270FA942C4B8}.Release|x64.Build.0 = Release|Any CPU
 		{3E59CA52-D248-4CBB-BB06-270FA942C4B8}.Release|x86.ActiveCfg = Release|Any CPU
 		{3E59CA52-D248-4CBB-BB06-270FA942C4B8}.Release|x86.Build.0 = Release|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Debug|ARM.Build.0 = Debug|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Debug|x64.Build.0 = Debug|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Debug|x86.Build.0 = Debug|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Release|ARM.ActiveCfg = Release|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Release|ARM.Build.0 = Release|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Release|x64.ActiveCfg = Release|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Release|x64.Build.0 = Release|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Release|x86.ActiveCfg = Release|Any CPU
+		{8BAE18D9-A722-40FF-A195-3AB5E74481E0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CsvHelper.Benchmarks/BenchmarkEnumerateRecords.cs
+++ b/src/CsvHelper.Benchmarks/BenchmarkEnumerateRecords.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+
+using BenchmarkDotNet.Attributes;
+
+namespace CsvHelper.Benchmarks;
+
+[MemoryDiagnoser]
+public class BenchmarkEnumerateRecords
+{
+	private const int entryCount = 10000;
+	private readonly MemoryStream stream = new();
+
+	public class Simple
+	{
+		public int Id { get; set; }
+		public string Name { get; set; }
+	}
+
+	[GlobalSetup]
+	public void GlobalSetup()
+	{
+		using var streamWriter = new StreamWriter(this.stream, null, -1, true);
+		using var writer = new CsvWriter(streamWriter, CultureInfo.InvariantCulture, true);
+		var random = new Random(42); // Pick a known seed to keep things consistent
+
+		var chars = new char[10];
+		string getRandomString()
+		{
+			for (int i = 0; i < 10; ++i)
+				chars[i] = (char)random.Next('a', 'z' + 1);
+			return new string(chars);
+		}
+
+		writer.WriteHeader(typeof(Simple));
+		writer.NextRecord();
+		for (int i = 0; i < BenchmarkEnumerateRecords.entryCount; ++i)
+		{
+			writer.WriteRecord(new Simple()
+			{
+				Id = random.Next(),
+				Name = getRandomString()
+			});
+			writer.NextRecord();
+		}
+	}
+
+	[GlobalCleanup]
+	public void GlobalCleanup()
+	{
+		this.stream.Dispose();
+	}
+
+	[Benchmark]
+	public void EnumerateRecords()
+	{
+		this.stream.Position = 0;
+		using var streamReader = new StreamReader(this.stream, null, true, -1, true);
+		using var csv = new CsvReader(streamReader, CultureInfo.InvariantCulture, true);
+		foreach (var record in csv.GetRecords<Simple>())
+		{
+			_ = record;
+		}
+	}
+}

--- a/src/CsvHelper.Benchmarks/BenchmarkMain.cs
+++ b/src/CsvHelper.Benchmarks/BenchmarkMain.cs
@@ -1,0 +1,11 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace CsvHelper.Benchmarks;
+
+internal class BenchmarkMain
+{
+	static void Main(string[] args)
+	{
+		_ = BenchmarkRunner.Run<BenchmarkEnumerateRecords>();
+	}
+}

--- a/src/CsvHelper.Benchmarks/CsvHelper.Benchmarks.csproj
+++ b/src/CsvHelper.Benchmarks/CsvHelper.Benchmarks.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CsvHelper\CsvHelper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CsvHelper/ObjectCreator.cs
+++ b/src/CsvHelper/ObjectCreator.cs
@@ -53,6 +53,11 @@ public class ObjectCreator
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static Type[] GetArgTypes(object?[] args)
 	{
+		if (args.Length == 0)
+		{
+			return Array.Empty<Type>();
+		}
+
 		var argTypes = new Type[args.Length];
 		for (var i = 0; i < args.Length; i++)
 		{


### PR DESCRIPTION
- This PR adds a CsvHelper.Benchmarks project to hold onto benchmarks for CsvHelper. This also adds a BenchmarkEnumerateRecords benchmark that benchmarks iterating through a CSV using csv.GetRecords()

- This PR updates ObjectCreator.GetArgTypes to not allocate an empty Type[] when the passed in object array is empty. This helps reduce allocations by ~14% in the new BenchmarkEnumerateRecords benchmark.

## Before
| Method           | Mean     | Error     | StdDev    | Gen0     | Gen1    | Allocated |
|----------------- |---------:|----------:|----------:|---------:|--------:|----------:|
| EnumerateRecords | 2.951 ms | 0.0576 ms | 0.0640 ms | 203.1250 | 15.6250 |   1.69 MB |

![image](https://github.com/user-attachments/assets/34e52e76-f87d-4278-a002-d40019972707)

## After
| Method           | Mean     | Error     | StdDev    | Gen0     | Gen1    | Allocated |
|----------------- |---------:|----------:|----------:|---------:|--------:|----------:|
| EnumerateRecords | 2.303 ms | 0.0171 ms | 0.0152 ms | 171.8750 | 15.6250 |   1.46 MB |

![image](https://github.com/user-attachments/assets/07d4c86e-3c31-4813-b94b-2048ea925617)

