### PR TITLE
fix: dispose enumerator in CsvWriter.WriteRecordsAsync

### DIFF
--- a/src/CsvHelper.Website/input/change-log/index.md
+++ b/src/CsvHelper.Website/input/change-log/index.md
@@ -1,5 +1,11 @@
 ﻿# Change Log
 
+### 33.0.2
+
+#### Bug Fixes
+
+- Dispose of IAsyncDisposable enumerators in CsvWriter
+
 ### 33.0.1
 
 #### Bug Fixes

--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -506,9 +506,13 @@ public class CsvWriter : IWriter
 		}
 		finally
 		{
-			if (enumerator is IDisposable en)
+			if (enumerator is IAsyncDisposable asyncDisposable)
 			{
-				en.Dispose();
+				await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+			}
+			else if (enumerator is IDisposable disposable)
+			{
+				disposable.Dispose();
 			}
 		}
 	}
@@ -566,10 +570,15 @@ public class CsvWriter : IWriter
 		}
 		finally
 		{
-			if (enumerator is IDisposable en)
+			if (enumerator is IAsyncDisposable asyncDisposable)
 			{
-				en.Dispose();
+				await asyncDisposable.DisposeAsync().ConfigureAwait(false);
 			}
+			else if (enumerator is IDisposable disposable)
+			{
+				disposable.Dispose();
+			}
+
 		}
 	}
 
@@ -626,9 +635,13 @@ public class CsvWriter : IWriter
 		}
 		finally
 		{
-			if (enumerator is IDisposable en)
+			if (enumerator is IAsyncDisposable asyncDisposable)
 			{
-				en.Dispose();
+				await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+			}
+			else if (enumerator is IDisposable disposable)
+			{
+				disposable.Dispose();
 			}
 		}
 	}


### PR DESCRIPTION
We should check enumerator with `IAsyncDisposable` too.

p.s. A bit better version of https://github.com/JoshClose/CsvHelper/pull/2265

Closes: https://github.com/JoshClose/CsvHelper/issues/2264