### PR TITLE
Reduce amount of target frameworks

### DIFF
--- a/src/CsvHelper.Website/CsvHelper.Website.csproj
+++ b/src/CsvHelper.Website/CsvHelper.Website.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -8,8 +8,7 @@
 
 		<!-- Build -->
 		<AssemblyName>CsvHelper</AssemblyName>
-		<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net48;net47;net462</TargetFrameworks>
-		<!--<TargetFrameworks>net60</TargetFrameworks>-->
+		<TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>CsvHelper</RootNamespace>
 		<DefaultLanguage>en-US</DefaultLanguage>
@@ -49,52 +48,13 @@
 		<None Include="Icon.png" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
-	<!-- .NET 4.6.2 -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="System.Memory" Version="4.5.0" />
-	</ItemGroup>
-
-	<!-- .NET 4.7 -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="System.Memory" Version="4.5.0" />
-	</ItemGroup>
-
-	<!-- .NET 4.8 -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="System.Memory" Version="4.5.0" />
-	</ItemGroup>
-
 	<!-- .NET Standard 2.0 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="System.Memory" Version="4.5.0" />
-	</ItemGroup>
-
-	<!-- .NET Standard 2.1 -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="[1.0.0]">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup>
-		<Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/tests/CsvHelper.Tests/CsvHelper.Tests.csproj
+++ b/tests/CsvHelper.Tests/CsvHelper.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net48;net47;net462</TargetFrameworks>
-		<!--<TargetFrameworks>net8.0</TargetFrameworks>-->
+		<TargetFrameworks>net8.0;net48;net47;net462</TargetFrameworks>
 		<LangVersion>preview</LangVersion>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>CsvHelper.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Changes:
- Reduce amount of target frameworks: .NET 8 + .NET Standard 2.0

Motivation:
- .NET 6 EOL November 12, 2024 (https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/)
- .NET 7 EOL May 14, 2024 (https://devblogs.microsoft.com/dotnet/dotnet-7-end-of-support/)
- .NET Standard 2.0 could be installable in .NET Framework 4.6.2+, no need to have separate tfm for older frameworks
