### PR TITLE
Remove uses of System.ValueTuple

### DIFF
--- a/src/CsvHelper/Configuration/ClassMap`1.cs
+++ b/src/CsvHelper/Configuration/ClassMap`1.cs
@@ -27,7 +27,7 @@ public abstract class ClassMap<TClass> : ClassMap
 	/// <returns>The member mapping.</returns>
 	public virtual MemberMap<TClass, TMember> Map<TMember>(Expression<Func<TClass, TMember?>> expression, bool useExistingMap = true)
 	{
-		var (classMap, member) = GetMemberMap(expression);
+		var classMap = GetMemberMap(expression, out var member);
 		var memberMap = classMap.Map(typeof(TClass), member, useExistingMap); ;
 
 		return (MemberMap<TClass, TMember>)memberMap;
@@ -42,7 +42,7 @@ public abstract class ClassMap<TClass> : ClassMap
 	/// <returns>The member mapping.</returns>
 	public virtual MemberMap Map<T>(Expression<Func<T, object?>> expression, bool useExistingMap = true)
 	{
-		var (classMap, member) = GetMemberMap(expression);
+		var classMap = GetMemberMap(expression, out var member);
 		var memberMap = classMap.Map(typeof(TClass), member, useExistingMap);
 
 		return memberMap;
@@ -64,7 +64,7 @@ public abstract class ClassMap<TClass> : ClassMap
 		return References(typeof(TClassMap), member, constructorArgs);
 	}
 
-	private (ClassMap, MemberInfo) GetMemberMap<TModel, TProperty>(Expression<Func<TModel, TProperty?>> expression)
+	private ClassMap GetMemberMap<TModel, TProperty>(Expression<Func<TModel, TProperty?>> expression, out MemberInfo member)
 	{
 		var stack = ReflectionHelper.GetMembers(expression);
 		if (stack.Count == 0)
@@ -73,7 +73,6 @@ public abstract class ClassMap<TClass> : ClassMap
 		}
 
 		ClassMap currentClassMap = this;
-		MemberInfo member;
 
 		if (stack.Count > 1)
 		{
@@ -105,6 +104,6 @@ public abstract class ClassMap<TClass> : ClassMap
 		// Add the member map to the last reference map.
 		member = stack.Pop();
 
-		return (currentClassMap, member);
+		return currentClassMap;
 	}
 }


### PR DESCRIPTION
System.ValueTuple is not included in net462. For reasons that I can't explain, I am seeing local test errors in #2142 in VS (but not on the command line) relating to missing System.Runtime.CompilerServices.Unsafe assembly. That assembly seems to be a runtime dependency (?) of System.Memory 4.5.0 which this library references.

Bumping System.Memory to 4.5.5 appears to fix those issues, but the net462 build fails due to missing System.ValueTuple on net462. I guess System.Memory 4.5.0 brings that in implicitly (it is not listed as a dependency). Instead of adding an explicit reference to the System.ValueTuple package on net462, we can just remove the few internal uses.

tl;dr this unblocks bumping the System.Memory version which fixes some strange local test issues