### PR TITLE
Use `IsDefined` to check the presence of attributes

### DIFF
--- a/src/CsvHelper/Configuration/ClassMap.cs
+++ b/src/CsvHelper/Configuration/ClassMap.cs
@@ -346,7 +346,7 @@ public abstract class ClassMap
 					continue;
 				}
 
-				if (!field.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Any())
+				if (!Attribute.IsDefined(field, typeof(CompilerGeneratedAttribute), false))
 				{
 					fields.Add(ReflectionHelper.GetDeclaringField(type, field, flags));
 				}
@@ -357,7 +357,7 @@ public abstract class ClassMap
 
 		foreach (var member in members)
 		{
-			if (member.GetCustomAttribute<IgnoreAttribute>() != null)
+			if (Attribute.IsDefined(member, typeof(IgnoreAttribute)))
 			{
 				// Ignore this member including its tree if it's a reference.
 				continue;
@@ -459,7 +459,7 @@ public abstract class ClassMap
 		{
 			var parameterMap = new ParameterMap(parameter);
 
-			if (parameter.GetCustomAttributes<IgnoreAttribute>(true).Any() || parameter.GetCustomAttributes<ConstantAttribute>(true).Any())
+			if (Attribute.IsDefined(parameter, typeof(IgnoreAttribute), true) || Attribute.IsDefined(parameter, typeof(ConstantAttribute), true))
 			{
 				// If there is an IgnoreAttribute or ConstantAttribute, we still need to add a map because a constructor requires
 				// all parameters to be present. A default value will be used later on.

--- a/src/CsvHelper/Configuration/CsvConfiguration.cs
+++ b/src/CsvHelper/Configuration/CsvConfiguration.cs
@@ -297,8 +297,8 @@ public record CsvConfiguration : IReaderConfiguration, IWriterConfiguration
 	/// <exception cref="CultureNotFoundException">If the argument to the <see cref="CultureInfoAttribute"/> does not specify a supported culture.</exception>
 	public static CsvConfiguration FromAttributes(Type type)
 	{
-		var cultureInfoAttribute = (CultureInfoAttribute?)Attribute.GetCustomAttribute(type, typeof(CultureInfoAttribute));
-		if (cultureInfoAttribute == null)
+		var hasCultureInfoAttribute = Attribute.IsDefined(type, typeof(CultureInfoAttribute));
+		if (!hasCultureInfoAttribute)
 		{
 			throw new ConfigurationException($"A {nameof(CultureInfoAttribute)} is required on type '{type.Name}' to use this method.");
 		}

--- a/src/CsvHelper/ReflectionHelper.cs
+++ b/src/CsvHelper/ReflectionHelper.cs
@@ -61,7 +61,7 @@ internal static class ReflectionHelper
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static List<PropertyInfo> GetUniqueProperties(Type type, BindingFlags flags, bool overwrite = false)
 	{
-		var ignoreBase = type.GetCustomAttribute(typeof(IgnoreBaseAttribute)) != null;
+		var ignoreBase = Attribute.IsDefined(type, typeof(IgnoreBaseAttribute));
 
 		var properties = new Dictionary<string, PropertyInfo>();
 
@@ -99,7 +99,7 @@ internal static class ReflectionHelper
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static List<FieldInfo> GetUniqueFields(Type type, BindingFlags flags, bool overwrite = false)
 	{
-		var ignoreBase = type.GetCustomAttribute(typeof(IgnoreBaseAttribute)) != null;
+		var ignoreBase = Attribute.IsDefined(type, typeof(IgnoreBaseAttribute));
 
 		var fields = new Dictionary<string, FieldInfo>();
 


### PR DESCRIPTION
Instead of retrieving an attribute _only_ to see if it exists we can use `Attribute.IsDefined` for this.

Here's a micro benchmark to show that `GetCustomAttributes`+`Any` allocates 104 bytes while `IsDefined` is allocation free.

| Method              | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
|-------------------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
| GetCustomAttributes | 243.6 ns | 0.94 ns | 0.83 ns |  1.00 | 0.0124 |     104 B |        1.00 |
| IsDefined           | 139.6 ns | 0.55 ns | 0.51 ns |  0.57 |      - |         - |        0.00 |

<details>
<summary>benchmark code</summary>

```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Reflection;
using System.Runtime.CompilerServices;

BenchmarkRunner.Run<AttributeBenchmarks>();

[MemoryDiagnoser]
public class AttributeBenchmarks
{
    private FieldInfo _fieldInfo;

    [GlobalSetup]
    public void Setup()
    {
        _fieldInfo = typeof(MyClas).GetField("_myField", BindingFlags.Public | BindingFlags.Instance);
    }

    [Benchmark(Baseline = true)]
    public bool GetCustomAttributes() => _fieldInfo.GetCustomAttributes<CompilerGeneratedAttribute>(false).Any();

    [Benchmark]
    public bool IsDefined() => _fieldInfo.IsDefined(typeof(CompilerGeneratedAttribute), false);
}

class MyClas
{
    [CompilerGenerated]
    public int _myField;
}
```

</details>