### PR TITLE
Optimize invalid fields parsing when no callback defined [#2345]

### DIFF
--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -944,8 +944,13 @@ public class CsvParser : IParser, IDisposable
 	{
 		// If field is already known to be bad, different rules can be applied.
 
-		var args = new BadDataFoundArgs(new string(buffer, start, length), RawRecord, Context);
-		badDataFound?.Invoke(args);
+		if (badDataFound is not null)
+		{
+			// Note on performance: accessing RawRecord allocates a new string with the entire row.
+			// It can be costly overall when lots of fields are invalid.
+			var args = new BadDataFoundArgs(new string(buffer, start, length), RawRecord, Context);
+			badDataFound.Invoke(args);
+		}
 
 		var newStart = start;
 		var newLength = length;


### PR DESCRIPTION
See the description of the issue in #2345.

This proposal avoids allocating a new string with the current row on each invalid field if the user didn't define the "bad data" callback. 
As an example, this reduced the time to parse a 3.5M file with 20k lines from 16 secs to 61 ms (see an example of how to reproduce in the issue).

I didn't add tests because the callback is already tested.

To go further and improve even if the callback is defined, I guess the `RawRecord` could be filled when a line is considered ended (and if the callback is defined) to avoid a new allocation on each field.