### PR TITLE
Add new `WriteRecords` benchmark and performance fix.

### DIFF
--- a/performance/CsvHelper.Benchmarks/BenchmarkMain.cs
+++ b/performance/CsvHelper.Benchmarks/BenchmarkMain.cs
@@ -6,6 +6,6 @@ internal class BenchmarkMain
 {
 	static void Main(string[] args)
 	{
-		_ = BenchmarkRunner.Run<BenchmarkEnumerateRecords>();
+		_ = BenchmarkSwitcher.FromAssembly(System.Reflection.Assembly.GetExecutingAssembly()).Run(args);
 	}
 }

--- a/performance/CsvHelper.Benchmarks/BenchmarkWriteCsv.cs
+++ b/performance/CsvHelper.Benchmarks/BenchmarkWriteCsv.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+
+namespace CsvHelper.Benchmarks;
+
+public class BenchmarkWriteCsv
+{
+	private const int entryCount = 10000;
+	private readonly List<Simple> records = new(entryCount);
+	
+	public class Simple
+	{
+		public int Id1 { get; set; }
+		public int Id2 { get; set; }
+		public string Name1 { get; set; }
+		public string Name2 { get; set; }
+	}
+
+	[GlobalSetup]
+	public void GlobalSetup()
+	{
+		var random = new Random(42);
+		var chars = new char[10];
+		string getRandomString()
+		{
+			for (int i = 0; i < 10; ++i)
+				chars[i] = (char)random.Next('a', 'z' + 1);
+			return new string(chars);
+		}
+
+		for (int i = 0; i < entryCount; ++i)
+		{
+			records.Add(new Simple
+			{
+				Id1 = random.Next(),
+				Id2 = random.Next(),
+				Name1 = getRandomString(),
+				Name2 = getRandomString(),
+			});
+		}
+	}
+
+	[Benchmark]
+	public void WriteRecords()
+	{
+		using var stream = new MemoryStream();        
+		using var streamWriter = new StreamWriter(stream);
+		using var writer = new CsvHelper.CsvWriter(streamWriter, CultureInfo.InvariantCulture);
+		writer.WriteRecords(records);
+		streamWriter.Flush();
+	}
+}

--- a/performance/CsvHelper.Benchmarks/CsvHelper.Benchmarks.csproj
+++ b/performance/CsvHelper.Benchmarks/CsvHelper.Benchmarks.csproj
@@ -6,7 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36421.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CsvHelper/Expressions/ObjectRecordWriter.cs
+++ b/src/CsvHelper/Expressions/ObjectRecordWriter.cs
@@ -46,7 +46,7 @@ public class ObjectRecordWriter : RecordWriter
 			throw new WriterException(Writer.Context, $"No properties are mapped for type '{type.FullName}'.");
 		}
 
-		var delegates = new List<Action<T>>();
+		var expressions = new List<Expression>(members.Count);
 
 		foreach (var memberMap in members)
 		{
@@ -59,7 +59,7 @@ public class ObjectRecordWriter : RecordWriter
 				var args = Expression.New(constructor, recordParameterConverted);
 				Expression exp = Expression.Invoke(memberMap.Data.WritingConvertExpression, args);
 				exp = Expression.Call(Expression.Constant(Writer), nameof(Writer.WriteField), null, exp);
-				delegates.Add(Expression.Lambda<Action<T>>(exp, recordParameter).Compile());
+				expressions.Add(exp);
 				continue;
 			}
 
@@ -110,12 +110,16 @@ public class ObjectRecordWriter : RecordWriter
 			}
 
 			var writeFieldMethodCall = Expression.Call(Expression.Constant(Writer), nameof(Writer.WriteConvertedField), null, fieldExpression, Expression.Constant(memberMap.Data.Type));
-
-			delegates.Add(Expression.Lambda<Action<T>>(writeFieldMethodCall, recordParameter).Compile());
+			expressions.Add(writeFieldMethodCall);
 		}
 
-		var action = CombineDelegates(delegates) ?? new Action<T>((T parameter) => { });
+		if (expressions.Count == 0)
+		{
+			return new Action<T>((T parameter) => { });
+		}
 
-		return action;
+		// Combine all field writes into a single block
+		var block = Expression.Block(expressions);
+		return Expression.Lambda<Action<T>>(block, recordParameter).Compile();
 	}
 }


### PR DESCRIPTION
# Updates
The new benchmark measures the performance of WriteRecords given an `IEnumerable<T>` records. The performance fix is to adjust `ObjectRecordWriter` to take all expressions and put them into a single block expression that writes all fields at once, instead of combining multiple expressions into a single multi-cast delegate. This results in fewer delegate invocations since it is called per record instead of per field, and only a single delegate compile. The current benchmark runs ~15% faster with the new code.

Now that delegates are not combined `RecordWriter.CombineDelegates` could be removed, though I opted not to since it is on a public class and I didn't want to break compatibility. I also noted this was added since Silverlight doesn't have `Delegate.Combine` and I'm not sure if Silverlight has `Expression.Block` though given it is out of support as of Oct 2021 I figured this was ok.

# Before
<img width="746" height="218" alt="OldBehavior" src="https://github.com/user-attachments/assets/77ec8c9e-e140-458d-97c4-2e7a3ce7ce77" />
<img width="985" height="194" alt="OldTopFuncs" src="https://github.com/user-attachments/assets/08b43641-5269-4803-b796-60a048505840" />

# After
_Note the CPU trace shows more samples in the after but this is due to BenchmarkDotNet having a variable number of iterations per run. The actual performance per iteration is faster_
<img width="744" height="219" alt="NewBehavior" src="https://github.com/user-attachments/assets/fc7862aa-30c6-403f-8116-ffa9dd6e0bb4" />
<img width="760" height="204" alt="NewTopFuncs" src="https://github.com/user-attachments/assets/c901a064-075a-44a5-a3bc-6b7257057423" />
