### PR TITLE
 Fix WriteDynamicHeader parameter to be non-nullable

### DIFF
--- a/src/CsvHelper/CsvWriter.cs
+++ b/src/CsvHelper/CsvWriter.cs
@@ -296,7 +296,7 @@ public class CsvWriter : IWriter
 	/// </summary>
 	/// <param name="record">The header record to write.</param>
 	/// <exception cref="ArgumentNullException">Thrown when no record is passed.</exception>
-	public virtual void WriteDynamicHeader(IDynamicMetaObjectProvider? record)
+	public virtual void WriteDynamicHeader(IDynamicMetaObjectProvider record)
 	{
 		if (record == null)
 		{
@@ -941,3 +941,4 @@ public class CsvWriter : IWriter
 		return false;
 	}
 }
+


### PR DESCRIPTION
## Summary
  - Fixed WriteDynamicHeader method signature to accept non-nullable IDynamicMetaObjectProvider parameter
  - Resolves issue #2355 where DynamicObject parameter handling was inconsistent

  ## Test plan
  - Run existing DynamicTests to verify WriteDynamicHeader works correctly with both ExpandoObject and DynamicObject
   types
  - Verify WriteDynamicIDynamicMetaObjectProviderHasDifferentPropertyOrderingTest passes

Fixes #2355 